### PR TITLE
Expand AST and add basic well-formed checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+*.json

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,12 +18,12 @@ enum Opt {
     Compile {
         /// Input file, to read source code from. If not specified, will read
         /// from stdin.
-        #[structopt(parse(from_os_str))]
+        #[structopt(parse(from_os_str), long = "input", short = "i")]
         input: Option<PathBuf>,
 
         /// Output file, to write assembly code to. If not specified, will
         /// write to stdout.
-        #[structopt(parse(from_os_str))]
+        #[structopt(parse(from_os_str), long = "output", short = "o")]
         output: Option<PathBuf>,
     },
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/lib/src/ast.rs
+++ b/lib/src/ast.rs
@@ -1,12 +1,62 @@
+use serde::{Deserialize, Serialize};
+
 // Different stages of the AST. Each one has had certain transformations applied
 
-#[derive(Debug)]
-pub enum Ast {
-    Value(String),
+// ===== Raw (parsed, with no checks/transformations applied) =====
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RawValue {
+    Int(u32),
 }
 
-/// Placeholder type right now
-#[derive(Debug)]
-pub enum WellFormedAst {
-    Value(String),
+pub type RawIdentifier = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RawInstruction {
+    /// Sets the workspace to the given value
+    Set(RawValue),
+    /// Pushes the workspace onto the given stack
+    Push(RawIdentifier),
+    /// Pops the top value off the given stack into the workspace
+    Pop(RawIdentifier),
+    /// Creates a new stack with the given identifier
+    Create(RawIdentifier),
+    /// Destroys the stack with the given identifier
+    Destroy(RawIdentifier),
+}
+
+/// The body of a program. In the future, could also represent the body of a
+/// block or function.
+pub type RawBody = Vec<RawInstruction>;
+
+/// A program consists of a series of instructions
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RawProgram {
+    pub body: RawBody,
+}
+
+// ===== Well-formed (well-formedness checking has been applied) =====
+
+pub type WellFormedValue = RawValue;
+pub type WellFormedIdentifier = RawIdentifier;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum WellFormedInstruction {
+    /// Sets the workspace to the given value
+    Set(WellFormedValue),
+    /// Creates a new stack with the given identifier
+    Create(WellFormedIdentifier),
+    /// Destroys the stack with the given identifier
+    Destroy(WellFormedIdentifier),
+    /// Pushes the active value onto the given stack
+    Push(WellFormedIdentifier),
+    /// Pops the top value off the given stack into the active value
+    Pop(WellFormedIdentifier),
+}
+
+pub type WellFormedBody = Vec<WellFormedInstruction>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WellFormedProgram {
+    pub body: WellFormedBody,
 }

--- a/lib/src/compiler/codegen.rs
+++ b/lib/src/compiler/codegen.rs
@@ -1,12 +1,13 @@
-use crate::{ast::WellFormedAst, compiler::Compiler};
+use crate::{ast::WellFormedProgram, compiler::Compiler};
 use failure::Error;
 use std::io::Write;
 
-impl Compiler<WellFormedAst> {
+impl Compiler<WellFormedProgram> {
     /// Generates code for the target language, and writes it to the given
     /// output destination. This is the final compiler step.
     pub fn generate_code(self, output: &mut impl Write) -> Result<(), Error> {
-        output.write_all(format!("{:?}", &self.0).as_bytes())?;
+        let json = serde_json::to_string(&self.0)?;
+        output.write_all(json.as_bytes())?;
         Ok(())
     }
 }

--- a/lib/src/compiler/parse.rs
+++ b/lib/src/compiler/parse.rs
@@ -1,12 +1,17 @@
-use crate::{ast::Ast, compiler::Compiler};
+use crate::{ast::RawProgram, compiler::Compiler};
 use failure::Error;
 use std::io::Read;
 
 impl Compiler<()> {
     /// Parses source code from the given input, into an abstract syntax tree.
-    pub fn parse(self, input: &mut impl Read) -> Result<Compiler<Ast>, Error> {
+    pub fn parse(
+        self,
+        input: &mut impl Read,
+    ) -> Result<Compiler<RawProgram>, Error> {
         let mut source_buffer = String::new();
         input.read_to_string(&mut source_buffer)?;
-        Ok(Compiler(Ast::Value(source_buffer)))
+        // TODO real parsing here
+        let program = serde_json::from_str(&source_buffer)?;
+        Ok(Compiler(program))
     }
 }

--- a/lib/src/compiler/well_formed.rs
+++ b/lib/src/compiler/well_formed.rs
@@ -1,16 +1,93 @@
 use crate::{
-    ast::{Ast, WellFormedAst},
+    ast::{
+        RawBody, RawInstruction, RawProgram, WellFormedBody,
+        WellFormedInstruction, WellFormedProgram,
+    },
     compiler::Compiler,
+    env::Env,
 };
 use failure::Error;
 
-impl Compiler<Ast> {
+fn check_body_well_formed(
+    body: RawBody,
+    env: &mut Env,
+) -> Result<WellFormedBody, Error> {
+    let mut result = Vec::new();
+    for instr in body {
+        let wf_instr = match instr {
+            RawInstruction::Set(value) => WellFormedInstruction::Set(value),
+            RawInstruction::Create(ident) => {
+                // Insert the ident to the env. If insert returns false, it
+                // means the ident was already in the env, so return an error.
+                env.declare(&ident)?;
+                WellFormedInstruction::Create(ident)
+            }
+            RawInstruction::Destroy(ident) => {
+                env.verify_exists(&ident)?;
+                WellFormedInstruction::Destroy(ident)
+            }
+            RawInstruction::Push(ident) => {
+                env.verify_exists(&ident)?;
+                WellFormedInstruction::Push(ident)
+            }
+            RawInstruction::Pop(ident) => {
+                env.verify_exists(&ident)?;
+                WellFormedInstruction::Pop(ident)
+            }
+        };
+        result.push(wf_instr)
+    }
+    Ok(result)
+}
+
+impl Compiler<RawProgram> {
     /// Checks that the program is well-formed. What that actually means remains
     /// to be seen.
-    pub fn check_well_formed(self) -> Result<Compiler<WellFormedAst>, Error> {
-        let wf_ast = match self.0 {
-            Ast::Value(value) => WellFormedAst::Value(value),
-        };
-        Ok(Compiler(wf_ast))
+    pub fn check_well_formed(
+        self,
+    ) -> Result<Compiler<WellFormedProgram>, Error> {
+        Ok(Compiler(WellFormedProgram {
+            body: check_body_well_formed(self.0.body, &mut Env::new())?,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_error, ast::RawValue};
+
+    #[test]
+    fn test_no_errors() {
+        let compiler = Compiler(RawProgram {
+            body: vec![
+                RawInstruction::Create("id".into()),
+                RawInstruction::Set(RawValue::Int(5)),
+                RawInstruction::Push("id".into()),
+                RawInstruction::Pop("id".into()),
+                RawInstruction::Destroy("id".into()),
+            ],
+        });
+        let result = compiler.check_well_formed();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_ident() {
+        let compiler = Compiler(RawProgram {
+            body: vec![
+                RawInstruction::Create("id".into()),
+                RawInstruction::Create("id".into()),
+            ],
+        });
+        assert_error!(compiler.check_well_formed(), "Duplicate identifier");
+    }
+
+    #[test]
+    fn test_unknown_ident() {
+        let compiler = Compiler(RawProgram {
+            body: vec![RawInstruction::Push("id".into())],
+        });
+        assert_error!(compiler.check_well_formed(), "Unknown identifier");
     }
 }

--- a/lib/src/env.rs
+++ b/lib/src/env.rs
@@ -1,0 +1,38 @@
+use crate::error::CompilerError;
+use failure::Error;
+use std::collections::HashSet;
+
+/// An environment of identifiers
+pub struct Env {
+    idents: HashSet<String>,
+}
+
+impl Env {
+    /// Creates a new empty environment
+    pub fn new() -> Env {
+        Env {
+            idents: HashSet::new(),
+        }
+    }
+
+    /// Declares the given identifier in this environment. If the identifier did
+    /// not already exist in the environment, then it will be declared and
+    /// return `Ok`. If it is already in the env, returns `Err`.
+    pub fn declare(&mut self, ident: &str) -> Result<(), Error> {
+        if self.idents.insert(ident.into()) {
+            Ok(())
+        } else {
+            Err(CompilerError::DuplicateIdentifier(ident.into()).into())
+        }
+    }
+
+    /// Verifies that the given identifier exists in this environment. If it
+    /// does, returns `Ok`. If it does not, returns `Err`.
+    pub fn verify_exists(&self, ident: &str) -> Result<(), Error> {
+        if self.idents.contains(ident) {
+            Ok(())
+        } else {
+            Err(CompilerError::UnknownIdentifier(ident.into()).into())
+        }
+    }
+}

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -2,7 +2,11 @@ use failure::Fail;
 
 #[derive(Debug, Fail)]
 pub enum CompilerError {
-    // placeholder error, until we have real stuff for this
-    #[fail(display = "shit!")]
-    ShitError,
+    /// Tried to declare an identifier that is already in scope
+    #[fail(display = "Duplicate identifier")]
+    DuplicateIdentifier(String),
+
+    /// Tried to use an identifier that hasn't been declared
+    #[fail(display = "Unknown identifier")]
+    UnknownIdentifier(String),
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::all)]
+#![deny(clippy::all, unused_must_use)]
 
 use crate::compiler::Compiler;
 use failure::Error;
@@ -6,7 +6,9 @@ use std::io::{Read, Write};
 
 mod ast;
 mod compiler;
+mod env;
 mod error;
+mod util;
 
 /// Reads source code from the given [`Read`](Read), compiles it, and outputs
 /// the corresponding target language code as a string.

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -1,0 +1,23 @@
+#[cfg(test)]
+pub mod test {
+    /// Asserts that a the first argument is an Err and that its error contains
+    /// the string in the argument.
+    #[macro_export]
+    macro_rules! assert_error {
+        ( $result:expr, $msg:tt ) => {
+            match $result {
+                Ok(_) => panic!("Expected Err, got Ok"),
+                Err(error) => {
+                    let error_str = error.to_string();
+                    assert!(
+                        error_str.contains($msg),
+                        format!(
+                            "Expected error \"{}\" to contain \"{}\"",
+                            error_str, $msg
+                        )
+                    );
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Wrote some dank shit. 

Set it up so you can define an AST in JSON and "compile" it. It just does the checking then spits the AST back out. Try this out:

`input.json`
```json
{
  "instructions": [
    { "Set": { "Int": 5 } },
    { "Create": "test" },
    { "Push": "test" },
    { "Pop": "test" }
  ]
}
```

`cargo run -- compile --input input.json`

It should print out basically the same thing. Neat!