### PR TITLE
Add flattened AST transformations

### DIFF
--- a/lib/src/ast.rs
+++ b/lib/src/ast.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// The type of every value in our language
 pub type LangValue = i32;
@@ -24,8 +24,8 @@ pub struct Environment {
 
 // ===== AST types =====
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum Instruction {
+#[derive(Debug, PartialEq, Deserialize)]
+pub enum Instr {
     /// Reads one value from the input buffer to the workspace
     Read,
     /// Writes the workspace to the output buffer
@@ -37,13 +37,58 @@ pub enum Instruction {
     /// Pops the top value off the given stack into the workspace
     Pop(StackIdentifier),
     /// Executes the body if the workspace is != 0
-    If(Vec<Instruction>),
+    If(Vec<Instr>),
     /// Executes the body while the workspace is != 0
-    While(Vec<Instruction>),
+    While(Vec<Instr>),
 }
 
 /// A parsed program, i.e. an Abstract Syntax Tree.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize)]
 pub struct Program {
-    pub body: Vec<Instruction>,
+    pub body: Vec<Instr>,
+}
+
+/// An instruction that has been desugared (hence "diet") and flattened such
+/// that it has no nested bodies and its instruction set is as minimal as
+/// possible. This is meant to be similar to asm, where there's no nested
+/// instructions so that it's easy to track a program counter.
+#[derive(Debug, PartialEq)]
+pub enum DietInstr {
+    /// Reads one value from the input buffer to the workspace
+    Read,
+    /// Writes the workspace to the output buffer
+    Write,
+    /// Sets the workspace to the given value
+    Set(LangValue),
+    /// Pushes the workspace onto the given stack
+    Push(StackIdentifier),
+    /// Pops the top value off the given stack into the workspace
+    Pop(StackIdentifier),
+    /// A unique label, to be used as the target of jumps
+    Label(String),
+    /// Jumps to the specified label if the workspace == 0
+    Jez(String),
+    /// Jumps to the specified label if the workspace != 0
+    Jnz(String),
+}
+
+/// An instruction set that is ready to be executed by a [Machine](Machine).
+/// This instruction set is as minimal as possible, to reduce the complexity
+/// of the runtime.
+#[derive(Debug, PartialEq)]
+pub enum MachineInstr {
+    /// Reads one value from the input buffer to the workspace
+    Read,
+    /// Writes the workspace to the output buffer
+    Write,
+    /// Sets the workspace to the given value
+    Set(LangValue),
+    /// Pushes the workspace onto the given stack
+    Push(StackIdentifier),
+    /// Pops the top value off the given stack into the workspace
+    Pop(StackIdentifier),
+    /// Jumps to the specified instruction index if the workspace == 0
+    Jez(usize),
+    /// Jumps to the specified instruction index if the workspace != 0
+    Jnz(usize),
 }

--- a/lib/src/compiler/delabel.rs
+++ b/lib/src/compiler/delabel.rs
@@ -1,0 +1,152 @@
+use crate::{
+    ast::{DietInstr, MachineInstr},
+    compiler::Compiler,
+};
+use std::collections::HashMap;
+
+impl Compiler<Vec<DietInstr>> {
+    /// Strips the labels out of an instruction list, replacing them with the
+    /// appropriate line numbers. E.g.:
+    ///
+    /// 0: Set(0)
+    /// 1: Jez("label_0")
+    /// 2: Set(1)
+    /// 3: Label("label_0")
+    /// 4: Set(2)
+    ///
+    /// maps to
+    ///
+    /// 0: Set(0)
+    /// 1: Jez(3)
+    /// 2: Set(1)
+    /// 3: Set(2)
+    pub fn delabel(self) -> Compiler<Vec<MachineInstr>> {
+        // Build a mapping of label:index
+        let label_map: HashMap<String, usize> = self
+            .0
+            .iter()
+            // create a map of label:index
+            .fold((0, HashMap::new()), |(idx, mut map), instr| {
+                if let DietInstr::Label(label) = instr {
+                    // Map the label to the index where it occurred. We need a
+                    // clone here to get around the borrow checker, because it
+                    // doesn't know this is the last time we'll need the label.
+                    if let Some(dupe) = map.insert(label.clone(), idx) {
+                        panic!(format!("Duplicate label {}", dupe));
+                    }
+
+                    // return idx instead of idx+1 because this Label
+                    // instruction is going to be removed from the list
+                    (idx, map)
+                } else {
+                    (idx + 1, map) // Just count this instruction and move on
+                }
+            })
+            .1;
+        let get_idx_for_label = |label: &String| -> usize {
+            *label_map
+                .get(label)
+                .unwrap_or_else(|| panic!(format!("Unknown label: {}", label)))
+        };
+
+        // Use the label map to convert each instruction. For most instruction
+        // types this is a 1:1 mapping, but for jumps, their labels need to be
+        // replaced with the corresponding indexes.
+        let machine_instrs: Vec<MachineInstr> = self
+            .0
+            .into_iter()
+            .filter_map(|instr| match instr {
+                // Basic instructions, just map 1:1
+                DietInstr::Read => Some(MachineInstr::Read),
+                DietInstr::Write => Some(MachineInstr::Write),
+                DietInstr::Set(value) => Some(MachineInstr::Set(value)),
+                DietInstr::Push(stack_id) => Some(MachineInstr::Push(stack_id)),
+                DietInstr::Pop(stack_id) => Some(MachineInstr::Pop(stack_id)),
+
+                // We don't want labels any more, throw them away
+                DietInstr::Label(_) => None,
+
+                // Jumps - replace labels with their corresponding indexes
+                DietInstr::Jez(label) => {
+                    Some(MachineInstr::Jez(get_idx_for_label(&label)))
+                }
+                DietInstr::Jnz(label) => {
+                    Some(MachineInstr::Jez(get_idx_for_label(&label)))
+                }
+            })
+            .collect();
+
+        Compiler(machine_instrs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        let compiler = Compiler(vec![
+            DietInstr::Set(0),
+            DietInstr::Jez("label_0".into()),
+            DietInstr::Set(2),
+            DietInstr::Label("label_0".into()),
+            DietInstr::Set(1),
+        ]);
+
+        assert_eq!(
+            compiler.delabel().0,
+            vec![
+                MachineInstr::Set(0),
+                MachineInstr::Jez(3), // --+
+                MachineInstr::Set(2), //   |
+                MachineInstr::Set(1), // <-+
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_labels() {
+        let compiler = Compiler(vec![
+            DietInstr::Set(0),
+            DietInstr::Jez("label_0".into()),
+            DietInstr::Set(2),
+            DietInstr::Label("label_0".into()),
+            DietInstr::Set(1),
+            DietInstr::Jez("label_1".into()),
+            DietInstr::Set(3),
+            DietInstr::Label("label_1".into()),
+            DietInstr::Set(1),
+        ]);
+
+        assert_eq!(
+            compiler.delabel().0,
+            vec![
+                MachineInstr::Set(0),
+                MachineInstr::Jez(3), // --+
+                MachineInstr::Set(2), //   |
+                MachineInstr::Set(1), // <-+
+                MachineInstr::Jez(6), // --+
+                MachineInstr::Set(3), //   |
+                MachineInstr::Set(1), // <-+
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_duplicate_label_panic() {
+        let compiler = Compiler(vec![
+            DietInstr::Label("label_0".into()),
+            DietInstr::Label("label_0".into()),
+        ]);
+        compiler.delabel();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unknown_label_panic() {
+        let compiler = Compiler(vec![DietInstr::Jez("label_0".into())]);
+        compiler.delabel();
+    }
+}

--- a/lib/src/compiler/desugar.rs
+++ b/lib/src/compiler/desugar.rs
@@ -1,0 +1,60 @@
+use crate::{
+    ast::{DietInstr, Instr, Program},
+    compiler::Compiler,
+};
+use std::iter;
+
+/// Desugar/flatten a single instruction. `tag` should be unique to this
+/// instruction, so that unique labels can be generated where necessary.
+fn desugar_instr(instr: Instr, tag: usize) -> Vec<DietInstr> {
+    match instr {
+        Instr::Read => vec![DietInstr::Read],
+        Instr::Write => vec![DietInstr::Write],
+        Instr::Set(value) => vec![DietInstr::Set(value)],
+        Instr::Push(stack_id) => vec![DietInstr::Push(stack_id)],
+        Instr::Pop(stack_id) => vec![DietInstr::Pop(stack_id)],
+        Instr::If(body) => {
+            let label = format!("if_end_{}", tag);
+            iter::once(DietInstr::Jez(label.clone()))
+                .chain(desugar_instrs(body, tag + 1).into_iter())
+                .chain(iter::once(DietInstr::Label(label)))
+                .collect()
+        }
+        Instr::While(body) => {
+            let start_label = format!("while_start_{}", tag);
+            let end_label = format!("while_end_{}", tag);
+            // If workspace == 0, skip the WHILE
+            iter::once(DietInstr::Jez(end_label.clone()))
+                // A label to mark the start of the WHILE body
+                .chain(iter::once(DietInstr::Label(start_label.clone())))
+                // The WHILE body
+                .chain(desugar_instrs(body, tag + 1).into_iter())
+                // If workspace != 0 still, repeat
+                .chain(iter::once(DietInstr::Jnz(start_label)))
+                // A label used to skip the WHILE body
+                .chain(iter::once(DietInstr::Label(end_label)))
+                .collect()
+        }
+    }
+}
+
+/// Desugar/flatten a series of instructions. `tag` should be monotonically
+/// increasing, such that each individual instruction is desugared with a
+/// unique tag. This is used to generate unique labels.
+fn desugar_instrs(instrs: Vec<Instr>, tag: usize) -> Vec<DietInstr> {
+    instrs
+        .into_iter()
+        .enumerate()
+        .map(|(idx, instr)| desugar_instr(instr, tag + idx))
+        .flatten()
+        .collect()
+}
+
+impl Compiler<Program> {
+    /// Desugars and flattens the nested AST into a flat AST, so that it can
+    /// more easily executed. Nested instructions such as IF and WHILE get
+    /// replaced with jumps. Most remain untouched by this
+    pub fn desugar(self) -> Compiler<Vec<DietInstr>> {
+        Compiler(desugar_instrs(self.0.body, 0))
+    }
+}

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -1,0 +1,40 @@
+use crate::{
+    ast::{Environment, MachineInstr},
+    machine::Machine,
+};
+
+mod delabel;
+mod desugar;
+mod parse;
+
+/// Struct to contain all compiler pipeline steps. By having this on a struct,
+/// it makes it nice and easy to call functions in order with readability. Each
+/// compiler step should take a `self` param and return a new `Compiler`.
+///
+/// `T` is the current type of the program. This controls which compiler
+/// pipeline stages can be called. For example, if `T` is `()`, then
+/// `.parse` is the only available operation. This allows us to leverage the
+/// type system to enforce assumptions we might make in each compiler stage.
+///
+/// The value in the compiler is deliberately private, to prevent a compiler
+/// from being directly constructed from outside this module. This means that
+/// you must follow the proper pipeline stages to get the compiler to a certain
+/// state.
+pub struct Compiler<T>(T);
+
+impl Compiler<()> {
+    /// Constructs a new compiler with no internal state. This is how you start
+    /// a fresh compiler pipeline.
+    pub fn new() -> Self {
+        Compiler(())
+    }
+}
+
+impl Compiler<Vec<MachineInstr>> {
+    /// Compiles a program into a [Machine](Machine). This takes an environment,
+    /// which the program will executing in, and builds a machine around it so
+    /// that it can be executed.
+    pub fn compile(self, env: Environment) -> Machine {
+        Machine::new(env, self.0)
+    }
+}

--- a/lib/src/compiler/parse.rs
+++ b/lib/src/compiler/parse.rs
@@ -1,14 +1,14 @@
-use crate::ast::Program;
+use crate::{ast::Program, compiler::Compiler};
 use failure::Fallible;
 use std::io::Read;
 
-impl Program {
+impl Compiler<()> {
     /// Parses source code from the given input, into an abstract syntax tree.
-    pub fn parse(source: &mut impl Read) -> Fallible<Self> {
+    pub fn parse(self, source: &mut impl Read) -> Fallible<Compiler<Program>> {
         let mut source_buffer = String::new();
         source.read_to_string(&mut source_buffer)?;
         // TODO real parsing here
         let program = serde_json::from_str(&source_buffer)?;
-        Ok(program)
+        Ok(Compiler(program))
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -4,11 +4,11 @@ use failure::Fail;
 #[derive(Debug, Fail)]
 pub enum RuntimeError {
     /// Referenced a stack with an invalid identifier
-    #[fail(display = "Invalid stack reference")]
+    #[fail(display = "Invalid stack reference: {}", 0)]
     InvalidStackReference(StackIdentifier),
 
     /// Tried to push onto stack that is at capacity
-    #[fail(display = "Stack overflow")]
+    #[fail(display = "Overflow on stack {}", 0)]
     StackOverflow(StackIdentifier),
 
     /// READ attempted while input is empty
@@ -16,6 +16,6 @@ pub enum RuntimeError {
     EmptyInput,
 
     /// POP attempted while stack is empty
-    #[fail(display = "Empty stack")]
+    #[fail(display = "Stack {} is empty", 0)]
     EmptyStack(StackIdentifier),
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,26 +4,36 @@ use failure::Fallible;
 use std::io::Read;
 
 mod ast;
+mod compiler;
 mod error;
 mod machine;
-mod parse;
 mod util;
+
+use crate::compiler::Compiler;
 
 pub use crate::{
     ast::{Environment, LangValue, Program},
     machine::{Machine, MachineState, Stacks},
 };
 
+/// Compiles the given source program, with the given environment, into a
+/// [Machine](Machine). The returned machine can then be executed.
+pub fn compile(env: Environment, source: &mut impl Read) -> Fallible<Machine> {
+    Ok(Compiler::new()
+        .parse(source)?
+        .desugar()
+        .delabel()
+        .compile(env))
+}
+
 /// Reads source code from the given [`Read`](Read), validates it, and executes
 /// it. Returns `true` if the program was successful, `false` if not.
 pub fn run_program(env: Environment, source: &mut impl Read) -> Fallible<bool> {
-    let program = Program::parse(source)?;
-    let mut machine = Machine::new(&env, &program);
+    let mut machine = compile(env, source)?;
 
-    while let Some(instr) = &mut machine.execute_next()? {
-        // this hullabaloo is necessary because of lifetimes
-        let instr_str = format!("{:?}", instr);
-        println!("Executed {}; State: {:?}", instr_str, machine.get_state());
+    while !machine.is_complete() {
+        machine.execute_next()?;
+        println!("Executed instruction. State: {:?}", machine.get_state());
     }
     println!(
         "Program terminated with {}",


### PR DESCRIPTION
Added two new AST types (`DietInstr` and `MachineInstr`). Both are flattened ASTs, so they have no nested bodies. `DietInstr` is analogous to asm, and `MachineInstr` is basically `DietInstr` but without labels (they've been replaced by line numbers, to make jumping as easy as possible). 

This cleaned up the interpreter (`machine.rs`) a shit load, because we don't need to handle any nested logic at runtime. This means that the program counter can now just be a line index, instead of a complex recursive type.