### PR TITLE
Add some compiler integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ First, you'll need to install:
 
 Then, for development you'll probably want to install:
 
-```
+```sh
 rustup component add rustfmt-preview clippy-preview
 ```
 
@@ -21,8 +21,26 @@ If you're using VSCode and have the RLS extension installed (you should), it'll 
 
 In the repo root:
 
-```
+```sh
 docker-compose up
 # Wait for DB to start up
 docker exec gdlk_api_1 diesel migration run
+```
+
+### Tests
+
+You can run tests with:
+
+```sh
+cargo test
+```
+
+#### Debugging
+
+If you have a test failing, you can run just that test with:
+
+```sh
+cargo test test_name # Run just one test
+cargo test -- --nocapture  # Print stdout from the program
+DEBUG=true cargo test -- --nocapture # Run in debug mode (includes more useful output)
 ```

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -329,6 +329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +718,7 @@ dependencies = [
  "diesel",
  "env_logger",
  "failure",
+ "nom",
  "r2d2",
  "serde",
  "serde_json",
@@ -885,6 +895,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "rustc_version",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1049,23 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1569,6 +1609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1925,12 @@ name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "wasi"

--- a/api/src/lang/machine.rs
+++ b/api/src/lang/machine.rs
@@ -1,4 +1,5 @@
 use crate::{
+    debug,
     error::RuntimeError,
     lang::ast::{LangValue, MachineInstr, StackIdentifier},
     models::Environment,
@@ -191,7 +192,7 @@ impl Machine {
                 None
             }
             MachineInstr::Pop(stack_id) => {
-                self.state.stacks.pop(*stack_id)?;
+                self.state.workspace = self.state.stacks.pop(*stack_id)?;
                 None
             }
             MachineInstr::Jez(next_pc) => {
@@ -212,6 +213,7 @@ impl Machine {
 
         // Advance the pc
         self.program_counter = next_pc.unwrap_or(self.program_counter + 1);
+        debug!(println!("Executed {:?}; State: {:?}", instr, self.state));
         Ok(())
     }
 

--- a/api/src/lang/parse.rs
+++ b/api/src/lang/parse.rs
@@ -14,7 +14,6 @@ use nom::{
     sequence::{delimited, preceded, terminated},
     IResult,
 };
-use std::io::Read;
 
 fn parse_read(input: &str) -> IResult<&str, Instr> {
     // tag_no_case returns a (str, str) tuple
@@ -104,17 +103,10 @@ fn parse_gdlk(input: &str) -> IResult<&str, Vec<Instr>> {
     Ok((input, res))
 }
 
-impl Compiler<()> {
+impl Compiler<String> {
     /// Parses source code from the given input, into an abstract syntax tree.
-    pub fn parse(
-        self,
-        source: &mut impl Read,
-    ) -> Result<Compiler<Program>, CompileError> {
-        let mut source_buffer = String::new();
-        source
-            .read_to_string(&mut source_buffer)
-            .map_err(|err| CompileError::ParseError(format!("{}", err)))?;
-        match parse_gdlk(&source_buffer) {
+    pub fn parse(self) -> Result<Compiler<Program>, CompileError> {
+        match parse_gdlk(&self.0) {
             // TODO: can probably refactor the parser funcs to use
             // Verbose error to make the errors nicer
             // example: https://github.com/Geal/nom/blob/master/examples/s_expression.rs

--- a/api/src/server/websocket.rs
+++ b/api/src/server/websocket.rs
@@ -147,11 +147,8 @@ impl ProgramWebsocket {
             }
             IncomingEvent::Compile => {
                 // Compile the program into a machine
-
-                // Clone the source so the parsing doesn't mutate our copy
-                let src_copy = self.source_code.clone();
                 self.machine =
-                    Some(compile(&self.env, &mut src_copy.as_bytes())?);
+                    Some(compile(&self.env, self.source_code.clone())?);
 
                 // we need this fuckery cause lol borrow checker
                 self.machine.as_ref().unwrap().into()

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -1,3 +1,28 @@
+/// Macro that can wrap any body, and only executes the body if we are running
+/// in debug mode. Debug mode is enabled by setting the environment variable
+/// DEBUG=true. This compiles away to nothing when --release is used.
+///
+/// Example:
+/// ```
+/// debug!(println!("Hello!"));
+/// ```
+///
+/// BTW that last assertion about --release hasn't _actually_ been confirmed,
+/// feel free to test that yourself.
+#[macro_export]
+macro_rules! debug {
+    ($arg:expr) => {
+        #[cfg(debug_assertions)]
+        {
+            if let Ok(debug_val) = std::env::var("DEBUG") {
+                if debug_val.to_lowercase().as_str() == "true" {
+                    $arg
+                }
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 pub mod test {
     /// Asserts that a the first argument is an Err and that its error contains


### PR DESCRIPTION
- Added a few integration tests
- Added the `debug!` macro, which will only execute the stuff inside it when `DEBUG=true`
- Reconfigured the compiler a tiny bit, so instead of doing `Compiler::new().parse(source)`, you do `Compiler::new(source).parse()`. I also changed the source to be just a `String` instead of a `Read`, which makes the code simpler in a few places.
  - This included a small change to `parse.rs`, sorry if that creates conflicts :(