### PR TITLE
Add back CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 **/*.rs.bk
 *.json
+*.gdlk
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +451,20 @@ dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -662,6 +684,7 @@ dependencies = [
  "r2d2 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -703,6 +726,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1092,6 +1123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1509,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "structopt"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1571,14 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1710,6 +1785,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1827,11 @@ dependencies = [
 [[package]]
 name = "vcpkg"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1850,6 +1940,7 @@ dependencies = [
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
@@ -1867,6 +1958,7 @@ dependencies = [
 "checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum const-random 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b641a8c9867e341f3295564203b1c250eb8ce6cb6126e007941f78c4d2ed7fe"
 "checksum const-random-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c750ec12b83377637110d5a57f5ae08e895b06c4b16e2bdbf1a94ef717428c59"
@@ -1895,6 +1987,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
@@ -1941,6 +2034,7 @@ dependencies = [
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
+"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
@@ -1987,10 +2081,14 @@ dependencies = [
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
+"checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
@@ -2008,11 +2106,14 @@ dependencies = [
 "checksum trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9992e58dba365798803c0b91018ff6c8d3fc77e06977c4539af2a6bfe0a039"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ rustup component add rustfmt-preview clippy-preview
 
 If you're using VSCode and have the RLS extension installed (you should), it'll ask to install more components, just say yes.
 
-### Running
+### Compiling and Executing Locally
+
+If you just want to compile and run a program without starting up the webserver, you can use the CLI for that. First, you'll need the environment to execute under saved in a JSON file, e.g. `env.json`. Then you need your program source in a file, e.g. `prog.gdlk`. Then run:
+
+```
+cargo run -- execute -e env.json -i prog.gdlk
+```
+
+### Running the Webserver
 
 In the repo root:
 
@@ -35,12 +43,11 @@ You can run tests with:
 cargo test
 ```
 
-#### Debugging
+### Debugging
 
-If you have a test failing, you can run just that test with:
+If you have a program or test failing, you can run with additional debug output by setting `DEBUG=true`, like so:
 
 ```sh
-cargo test test_name # Run just one test
-cargo test -- --nocapture  # Print stdout from the program
-DEBUG=true cargo test -- --nocapture # Run in debug mode (includes more useful output)
+DEBUG=true cargo run -- execute -e env.json -i prog.gdlk
+DEBUG=true cargo test -- --nocapture # --nocapture needed to make stdout visible
 ```

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -323,6 +323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +488,21 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -722,6 +746,7 @@ dependencies = [
  "r2d2",
  "serde",
  "serde_json",
+ "structopt",
 ]
 
 [[package]]
@@ -767,6 +792,15 @@ checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
  "ahash",
  "autocfg",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1202,6 +1236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+dependencies = [
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.9",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1669,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
+dependencies = [
+ "clap",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.9",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 dependencies = [
  "wincolor",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1887,6 +1970,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +2020,12 @@ name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -18,3 +18,4 @@ nom = "5.0"
 r2d2 = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+structopt = "0.3"

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -3,27 +3,33 @@ use actix_web::{HttpResponse, ResponseError};
 use failure::Fail;
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Fail, Serialize)]
 pub enum CompileError {
     /// Failed to parse the program
+    #[fail(display = "Parse error: {}", 0)]
     ParseError(String),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Fail, Serialize)]
 pub enum RuntimeError {
     /// Referenced a stack with an invalid identifier
+    #[fail(display = "Invalid reference to stack {}", 0)]
     InvalidStackReference(StackIdentifier),
 
     /// Tried to push onto stack that is at capacity
+    #[fail(display = "Overflow on stack {}", 0)]
     StackOverflow(StackIdentifier),
 
     /// READ attempted while input is empty
+    #[fail(display = "No input available to read")]
     EmptyInput,
 
     /// POP attempted while stack is empty
+    #[fail(display = "Cannot pop from empty stack {}", 0)]
     EmptyStack(StackIdentifier),
 
     /// Instruction list has been exhausted, program is terminated
+    #[fail(display = "Program has terminated, nothing left to execute")]
     ProgramTerminated,
 }
 

--- a/api/src/lang/machine.rs
+++ b/api/src/lang/machine.rs
@@ -217,6 +217,16 @@ impl Machine {
         Ok(())
     }
 
+    /// Executes this machine until termination (or error). All instructions are
+    /// executed until [is_complete](Self::is_complete) returns true. Returns
+    /// the value of [is_successful](Self::is_successful) upon termination.
+    pub fn execute_all(&mut self) -> Result<bool, RuntimeError> {
+        while !self.is_complete() {
+            self.execute_next()?;
+        }
+        Ok(self.is_successful())
+    }
+
     /// Checks if this machine has finished executing.
     pub fn is_complete(&self) -> bool {
         self.program_counter >= self.program.len()

--- a/api/src/lang/mod.rs
+++ b/api/src/lang/mod.rs
@@ -83,17 +83,15 @@ mod tests {
         let mut machine = compile(&env, src.into()).unwrap();
 
         // Execute to completion
-        while !machine.is_complete() {
-            machine.execute_next().unwrap();
-        }
+        let success = machine.execute_all().unwrap();
 
         // Make sure program terminated successfully
         // Check each bit of state individually to make debugging easier
         let state = machine.get_state();
         assert_eq!(state.input, Vec::new() as Vec<LangValue>);
         assert_eq!(state.output, env.expected_output);
-        // Final sanity check, in case we change the criteria for is_successful
-        assert!(machine.is_successful());
+        // Final sanity check, in case we change the criteria for success
+        assert!(success);
     }
 
     #[test]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -4,11 +4,15 @@
 #[macro_use]
 extern crate diesel;
 
+use crate::{lang::compile, models::Environment};
 use actix_web::{middleware, web, App, HttpServer};
 use diesel::{
     r2d2::{self, ConnectionManager},
     PgConnection,
 };
+use failure::Fallible;
+use std::{fs, path::PathBuf, process};
+use structopt::StructOpt;
 
 mod error;
 mod lang;
@@ -17,30 +21,104 @@ mod schema;
 mod server;
 mod util;
 
-fn main() -> std::io::Result<()> {
-    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
-    env_logger::init();
+#[derive(Debug, StructOpt)]
+enum Command {
+    /// Compile and execute source code. If execution terminates without error,
+    /// returns 0 for a successful execution and 1 for unsuccessful.
+    #[structopt(name = "execute")]
+    Execute {
+        /// Path to the environment file, in JSON format
+        #[structopt(parse(from_os_str), long = "env", short = "e")]
+        env_path: PathBuf,
+        /// Path to the source code file
+        #[structopt(parse(from_os_str), long = "source", short = "s")]
+        source_path: PathBuf,
+    },
 
-    let manager = ConnectionManager::<PgConnection>::new(
-        std::env::var("DATABASE_URL").unwrap(),
-    );
-    let pool = r2d2::Pool::builder()
-        .build(manager)
-        .expect("Failed to create pool.");
+    /// Start the HTTP server and listen for connections
+    #[structopt(name = "server")]
+    Server {
+        /// The IP:port to bind to
+        #[structopt(
+            long,
+            env = "SERVER_HOST",
+            default_value = "localhost:8000"
+        )]
+        host: String,
+        /// Database URL
+        #[structopt(long, env = "DATABASE_URL")]
+        database_url: String,
+    },
+}
 
-    HttpServer::new(move || {
-        App::new()
-            // Need to clone because this init occurs once per thread
-            .data(pool.clone())
-            // enable logger
-            .wrap(middleware::Logger::default())
-            // websocket route
-            .service(
-                web::resource("/ws/environments/{env_id}/")
-                    .route(web::get().to(server::ws_environments_by_id)),
-            )
-    })
-    // start http server
-    .bind(std::env::var("SERVER_HOST").unwrap())?
-    .run()
+/// GDLK executable, for executing GDLK programs or running the GDLK webserver
+#[derive(Debug, StructOpt)]
+#[structopt(name = "gdlk")]
+struct Opt {
+    #[structopt(subcommand)]
+    cmd: Command,
+}
+
+fn run(opt: Opt) -> Fallible<()> {
+    match opt.cmd {
+        // Compile and build the given program
+        Command::Execute {
+            env_path,
+            source_path,
+        } => {
+            // Read and parse the environment from a JSON file
+            let env_str = fs::read_to_string(env_path)?;
+            let env: Environment = serde_json::from_str(&env_str)?;
+
+            // Read the source code from the file
+            let source = fs::read_to_string(source_path)?;
+
+            // Compile and execute
+            let mut machine = compile(&env, source)?;
+            let success = machine.execute_all()?;
+
+            println!(
+                "Program completed with {}",
+                if success { "success" } else { "failure" }
+            );
+            process::exit(if success { 0 } else { 1 })
+        }
+        // Start the webserver
+        Command::Server { host, database_url } => {
+            // Set up logging
+            std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+            env_logger::init();
+
+            // Initialize the DB connection pool
+            let manager = ConnectionManager::<PgConnection>::new(database_url);
+            let pool = r2d2::Pool::builder()
+                .build(manager)
+                .expect("Failed to create pool.");
+
+            // Start the HTTP server
+            HttpServer::new(move || {
+                App::new()
+                    // Need to clone because this init occurs once per thread
+                    .data(pool.clone())
+                    // enable logger
+                    .wrap(middleware::Logger::default())
+                    // websocket route
+                    .service(
+                        web::resource("/ws/environments/{env_id}/").route(
+                            web::get().to(server::ws_environments_by_id),
+                        ),
+                    )
+            })
+            .bind(host)?
+            .run()?;
+        }
+    }
+    Ok(())
+}
+
+fn main() {
+    let result = run(Opt::from_args());
+    if let Err(error) = result {
+        eprintln!("Error!\n{:?}", error);
+    }
 }

--- a/api/src/models/env.rs
+++ b/api/src/models/env.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Serialize, Deserialize, Identifiable, Queryable)]
 pub struct Environment {
     /// Unique ID to refer to this environment
+    #[serde(default)]
     pub id: i32,
 
     // These two need to be i32s because postgres has no unsigned type.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   api:
     build: ./api/
-    command: cargo watch -x run
+    command: cargo watch -x "run -- server"
     tty: true # Colorize output
     volumes:
       - ./api:/app/api:rw

--- a/test_socket.py
+++ b/test_socket.py
@@ -6,8 +6,8 @@ import json
 import websockets
 
 
-async def ws(host, env_id, program):
-    with open(program) as f:
+async def ws(host, env_id, source):
+    with open(source) as f:
         source = f.read().strip()
 
     async with websockets.connect(
@@ -47,10 +47,10 @@ def main():
         help="The ID for the environment to execute under",
     )
     parser.add_argument(
-        "--program",
-        "-p",
+        "--source",
+        "-s",
         required=True,
-        help="The file to read the program from",
+        help="The file to read the program source from",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Changed the binary to be a full-blown CLI with arguments. Now when you run it you can choose to compile+execute, or run the server. `docker-compose up` still works as before, but now to compile+execute locally, you can do:

```
cargo run -- execute -e env.json -s prog.gdlk
```

`env.json`
```
{
  "num_stacks": 0,
  "max_stack_size": null,
  "input": [
    1,
    2,
    3
  ],
  "expected_output": [
    2,
    3,
    4
  ]
}
```

`prog.gdlk`
```
READ
SET 2
WRITE
READ
SET 3
WRITE
READ
SET 4
WRITE
```