### PR TITLE
Add arithmetic instructions

### DIFF
--- a/api/src/lang/ast.rs
+++ b/api/src/lang/ast.rs
@@ -10,16 +10,29 @@ pub type StackIdentifier = usize;
 
 #[derive(Debug, PartialEq, Deserialize)]
 pub enum Instr {
+    // I/O
     /// Reads one value from the input buffer to the workspace
     Read,
     /// Writes the workspace to the output buffer
     Write,
+
+    // Value manipulation
     /// Sets the workspace to the given value
     Set(LangValue),
+    /// Adds a constant value to the workspace
+    Add(LangValue),
+    /// Substracts a constant value from the workspace
+    Sub(LangValue),
+    /// Multiplies the workspace by a constant value
+    Mul(LangValue),
+
+    // Stack manipulation
     /// Pushes the workspace onto the given stack
     Push(StackIdentifier),
     /// Pops the top value off the given stack into the workspace
     Pop(StackIdentifier),
+
+    // Control flow
     /// Executes the body if the workspace is != 0
     If(Vec<Instr>),
     /// Executes the body while the workspace is != 0
@@ -37,12 +50,23 @@ pub struct Program {
 /// of the runtime.
 #[derive(Debug, PartialEq)]
 pub enum MachineInstr {
+    // I/O
     /// Reads one value from the input buffer to the workspace
     Read,
     /// Writes the workspace to the output buffer
     Write,
+
+    // Value manipulation
     /// Sets the workspace to the given value
     Set(LangValue),
+    /// Adds the given value to the workspace
+    Add(LangValue),
+    /// Substracts the given value from the workspace
+    Sub(LangValue),
+    /// Multiplies the workspace by the given value
+    Mul(LangValue),
+
+    // Stack manipulation
     /// Pushes the workspace onto the given stack
     Push(StackIdentifier),
     /// Pops the top value off the given stack into the workspace

--- a/api/src/lang/desugar.rs
+++ b/api/src/lang/desugar.rs
@@ -10,9 +10,15 @@ fn desugar_instr(instr: Instr) -> Vec<MachineInstr> {
     match instr {
         Instr::Read => vec![MachineInstr::Read],
         Instr::Write => vec![MachineInstr::Write],
+
         Instr::Set(value) => vec![MachineInstr::Set(value)],
+        Instr::Add(value) => vec![MachineInstr::Add(value)],
+        Instr::Sub(value) => vec![MachineInstr::Sub(value)],
+        Instr::Mul(value) => vec![MachineInstr::Mul(value)],
+
         Instr::Push(stack_id) => vec![MachineInstr::Push(stack_id)],
         Instr::Pop(stack_id) => vec![MachineInstr::Pop(stack_id)],
+
         Instr::If(body) => {
             // This conversion looks like:
             //

--- a/api/src/lang/machine.rs
+++ b/api/src/lang/machine.rs
@@ -5,7 +5,7 @@ use crate::{
     models::Environment,
 };
 use serde::Serialize;
-use std::{convert::TryFrom, iter};
+use std::{convert::TryFrom, iter, num::Wrapping};
 
 /// Wrapper around a vec of stacks, to make it a bit easier to initialize/use.
 ///
@@ -183,10 +183,27 @@ impl Machine {
                 self.state.output.push(self.state.workspace);
                 None
             }
+
             MachineInstr::Set(val) => {
                 self.state.workspace = *val;
                 None
             }
+            MachineInstr::Add(val) => {
+                self.state.workspace =
+                    (Wrapping(self.state.workspace) + Wrapping(*val)).0;
+                None
+            }
+            MachineInstr::Sub(val) => {
+                self.state.workspace =
+                    (Wrapping(self.state.workspace) - Wrapping(*val)).0;
+                None
+            }
+            MachineInstr::Mul(val) => {
+                self.state.workspace =
+                    (Wrapping(self.state.workspace) * Wrapping(*val)).0;
+                None
+            }
+
             MachineInstr::Push(stack_id) => {
                 self.state.stacks.push(*stack_id, self.state.workspace)?;
                 None

--- a/api/src/lang/mod.rs
+++ b/api/src/lang/mod.rs
@@ -175,4 +175,23 @@ mod tests {
             ",
         );
     }
+
+    #[test]
+    fn test_arithmetic() {
+        execute_expect_success(
+            Environment {
+                id: 0,
+                num_stacks: 0,
+                max_stack_size: None,
+                input: vec![],
+                expected_output: vec![-3],
+            },
+            "
+            ADD 1
+            SUB 2
+            MUL 3
+            WRITE
+            ",
+        );
+    }
 }

--- a/api/src/lang/parse.rs
+++ b/api/src/lang/parse.rs
@@ -37,6 +37,33 @@ fn parse_set(input: &str) -> IResult<&str, Instr> {
     Ok((input, Instr::Set(val)))
 }
 
+fn parse_add(input: &str) -> IResult<&str, Instr> {
+    let (input, _) = tag_no_case("Add")(input)?;
+    let (input, val) = preceded(
+        multispace0,
+        map_res(digit1, |s: &str| s.parse::<LangValue>()),
+    )(input)?;
+    Ok((input, Instr::Add(val)))
+}
+
+fn parse_sub(input: &str) -> IResult<&str, Instr> {
+    let (input, _) = tag_no_case("Sub")(input)?;
+    let (input, val) = preceded(
+        multispace0,
+        map_res(digit1, |s: &str| s.parse::<LangValue>()),
+    )(input)?;
+    Ok((input, Instr::Sub(val)))
+}
+
+fn parse_mul(input: &str) -> IResult<&str, Instr> {
+    let (input, _) = tag_no_case("Mul")(input)?;
+    let (input, val) = preceded(
+        multispace0,
+        map_res(digit1, |s: &str| s.parse::<LangValue>()),
+    )(input)?;
+    Ok((input, Instr::Mul(val)))
+}
+
 fn parse_push(input: &str) -> IResult<&str, Instr> {
     let (input, _) = tag_no_case("Push")(input)?;
     let (input, val) = preceded(
@@ -74,6 +101,9 @@ fn try_each(input: &str) -> IResult<&str, Instr> {
             parse_read,
             parse_write,
             parse_set,
+            parse_add,
+            parse_sub,
+            parse_mul,
             parse_push,
             parse_pop,
             parse_if,


### PR DESCRIPTION
Added ADD, SUB, and MUL. Each one takes a constant, and applies the operation with that constant to the workspace, e.g. `ADD 2` or `MUL -3`. In the future, these will be able to apply to any register, and they'll also be able to read values from other registers, e.g. `ADD EBX EAX`.