### PR TITLE
Make parse errors nicer

### DIFF
--- a/api/src/lang/mod.rs
+++ b/api/src/lang/mod.rs
@@ -356,4 +356,13 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn test_parse_empty_file() {
+        expect_compile_errors(
+            Environment::default(),
+            "",
+            &["Parse error: 0: in Alpha, got empty input\n\n"],
+        );
+    }
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::all, unused_must_use, unused_imports)]
-#![feature(try_trait)]
+#![feature(try_trait, slice_patterns)]
 
 // Diesel hasn't fully moved to Rust 2018 yet so we need this
 #[macro_use]

--- a/test_socket.py
+++ b/test_socket.py
@@ -19,6 +19,8 @@ async def ws(host, env_id, source):
             print(f"<<< {msg}")
             await websocket.send(msg)
             recv = json.loads(await websocket.recv())
+            if recv["type"] == "compile_error" and "ParseError" in recv["content"]:
+                print(f">>> Parse Error:\n{recv['content']['ParseError'].strip()}\n")
             print(f">>> {recv}")
             return recv
 


### PR DESCRIPTION
Started trying to make errors a little nicer. Still needs more work but since it changed up a lot i figured i'd push now.

I added `cut` after parsing tags that have arguments so we fail out of `alt` instead of trying to parse other options. Also added `context` that makes the errors have a custom name instead of `Tag` or `Alt`