### PR TITLE
Add static validation

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -1,29 +1,33 @@
-use crate::lang::{RegisterRef, StackIdentifier, UserRegisterIdentifier};
+use crate::lang::{RegisterRef, StackIdentifier};
 use actix_web::{HttpResponse, ResponseError};
 use failure::Fail;
 use serde::Serialize;
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::Try,
+};
 
-#[derive(Debug, Fail, Serialize)]
+#[derive(Debug, PartialEq, Fail, Serialize)]
 pub enum CompileError {
     /// Failed to parse the program
     #[fail(display = "Parse error: {}", 0)]
     ParseError(String),
-}
 
-#[derive(Debug, Fail, Serialize)]
-pub enum RuntimeError {
     /// Referenced a user register with an invalid identifier
     #[fail(display = "Invalid reference to register {}", 0)]
-    InvalidUserRegisterRef(UserRegisterIdentifier),
+    InvalidRegisterRef(RegisterRef),
 
     /// Referenced a stack with an invalid identifier
-    #[fail(display = "Invalid reference to stack {}", 0)]
+    #[fail(display = "Invalid reference to stack S{}", 0)]
     InvalidStackRef(StackIdentifier),
 
     /// Tried to write to a read-only register
     #[fail(display = "Cannot write to read-only register {}", 0)]
     UnwritableRegister(RegisterRef),
+}
 
+#[derive(Debug, PartialEq, Fail, Serialize)]
+pub enum RuntimeError {
     /// Tried to push onto stack that is at capacity
     #[fail(display = "Overflow on stack {}", 0)]
     StackOverflow(StackIdentifier),
@@ -60,6 +64,88 @@ impl ResponseError for ServerError {
                 HttpResponse::NotFound().into()
             }
             _ => HttpResponse::InternalServerError().into(),
+        }
+    }
+}
+
+/// A collection of compiler errors. We want to show as many errors as possible
+/// at compile time, so that the user can see everything wrong with their
+/// program at once.
+///
+/// This holds an `Option<Vec<_>>` instead of just a `Vec` so that we don't
+/// have to allocate on the heap until we know we have errors. There are some
+/// methods and traits implemented to make it easier to collect errors as you
+/// go through a program.
+#[derive(Debug, PartialEq, Fail, Serialize)]
+pub struct CompileErrors(Option<Vec<CompileError>>);
+
+impl CompileErrors {
+    /// Returns an empty set of errors. This will NOT allocate any heap memory.
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    /// Combines this error collection with another, returning a collection with
+    /// both sets of errors.
+    pub fn chain(mut self, other: Self) -> Self {
+        // If `other` has errors:
+        if let Some(other_errs) = other.0 {
+            match &mut self.0 {
+                // We don't have errors, just return the others
+                None => return Self(Some(other_errs)),
+                // Combine the two collections
+                Some(self_errs) => {
+                    self_errs.extend(other_errs);
+                }
+            }
+        }
+        self
+    }
+}
+
+// Implemented so we can use `?` with this type
+impl Try for CompileErrors {
+    type Ok = ();
+    type Error = Self;
+
+    fn into_result(self) -> Result<(), CompileErrors> {
+        match self.0 {
+            Some(errs) if !errs.is_empty() => Err(Self(Some(errs))),
+            _ => Ok(()),
+        }
+    }
+
+    fn from_ok(_: ()) -> Self {
+        Self::none()
+    }
+
+    fn from_error(errs: Self) -> Self {
+        errs
+    }
+}
+
+// For converting a single error into a collection
+impl From<CompileError> for CompileErrors {
+    fn from(error: CompileError) -> Self {
+        Self(Some(vec![error]))
+    }
+}
+
+impl Display for CompileErrors {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            None => write!(f, "No errors"),
+            Some(errors) => {
+                // Write each error, separated by a newline
+                for (i, error) in errors.iter().enumerate() {
+                    // Prefix with a newline for all errors but the first
+                    if i > 0 {
+                        writeln!(f)?;
+                    }
+                    write!(f, "{}", error)?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/api/src/lang/parse.rs
+++ b/api/src/lang/parse.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::CompileError,
+    error::{CompileError, CompileErrors},
     lang::{
         ast::{
             Instr, LangValue, Operator, Program, RegisterRef, StackIdentifier,
@@ -232,7 +232,7 @@ fn parse_gdlk(input: &str) -> IResult<&str, Vec<Instr>> {
 
 impl Compiler<String> {
     /// Parses source code from the given input, into an abstract syntax tree.
-    pub fn parse(self) -> Result<Compiler<Program>, CompileError> {
+    pub fn parse(self) -> Result<Compiler<Program>, CompileErrors> {
         match parse_gdlk(&self.0) {
             // TODO: can probably refactor the parser funcs to use
             // Verbose error to make the errors nicer
@@ -252,6 +252,7 @@ impl Compiler<String> {
                 Err(CompileError::ParseError(e.description().to_string()))
             }
         }
+        .map_err(|err| err.into())
     }
 }
 

--- a/api/src/lang/validate.rs
+++ b/api/src/lang/validate.rs
@@ -1,0 +1,131 @@
+use crate::{
+    error::{CompileError, CompileErrors},
+    lang::{
+        ast::{
+            Instr, Operator, Program, RegisterRef, StackIdentifier, ValueSource,
+        },
+        Compiler,
+    },
+    models::Environment,
+};
+
+/// Helper method to change if a stack reference is in range. This is used for
+/// mutliple error types so the comparison logic is pulled out here.
+fn is_stack_ref_valid(env: &Environment, stack_id: StackIdentifier) -> bool {
+    stack_id < (env.num_stacks as usize)
+}
+
+/// Ensures the register reference refers to a real register in the environment.
+fn validate_reg_ref(env: &Environment, reg: &RegisterRef) -> CompileErrors {
+    match reg {
+        RegisterRef::InputLength => CompileErrors::none(),
+        RegisterRef::StackLength(stack_id) => {
+            if is_stack_ref_valid(env, *stack_id) {
+                CompileErrors::none()
+            } else {
+                CompileError::InvalidRegisterRef(RegisterRef::StackLength(
+                    *stack_id,
+                ))
+                .into()
+            }
+        }
+        RegisterRef::User(reg_id) => {
+            // TODO clean up this num conversion
+            if *reg_id >= (env.num_registers as usize) {
+                CompileError::InvalidRegisterRef(RegisterRef::User(*reg_id))
+                    .into()
+            } else {
+                CompileErrors::none()
+            }
+        }
+    }
+}
+
+/// Ensures the register reference refers to a real register in the environment.
+fn validate_writeable_reg_ref(
+    env: &Environment,
+    reg: &RegisterRef,
+) -> CompileErrors {
+    // Make sure the reference points to a real register
+    validate_reg_ref(env, reg)?;
+
+    // If the reference is valid, we want to make sure it's writable too.
+    // Only User registers are writable, all others cause an error.
+    match reg {
+        RegisterRef::User(_) => CompileErrors::none(),
+        _ => CompileError::UnwritableRegister(*reg).into(),
+    }
+}
+
+/// Ensures the stack ID refers to a real stack in the environment, i.e. makes
+/// sure it's in bounds.
+fn validate_stack_ref(
+    env: &Environment,
+    stack_id: StackIdentifier,
+) -> CompileErrors {
+    // TODO clean up this num conversion
+    if is_stack_ref_valid(env, stack_id) {
+        CompileErrors::none()
+    } else {
+        CompileError::InvalidStackRef(stack_id).into()
+    }
+}
+
+/// Ensures the given ValueSource is valid. All constants are valid, but
+/// register references need to be validated to make sure they refer to real
+/// registers.
+fn validate_val_src(env: &Environment, val_src: &ValueSource) -> CompileErrors {
+    match val_src {
+        ValueSource::Const(_) => CompileErrors::none(),
+        ValueSource::Register(reg) => validate_reg_ref(env, reg),
+    }
+}
+
+/// Collects all the validation errors in the given instruction. All possible
+/// static validation is applied (mainly stack and register references).
+fn validate_instr(env: &Environment, instr: &Instr) -> CompileErrors {
+    match instr {
+        Instr::Operator(op) => match op {
+            Operator::Read(reg) | Operator::Write(reg) => {
+                validate_writeable_reg_ref(env, reg)
+            }
+            Operator::Set(reg, val_src)
+            | Operator::Add(reg, val_src)
+            | Operator::Sub(reg, val_src)
+            | Operator::Mul(reg, val_src) => {
+                // Make sure the first reg is valid and writable, and the second
+                // is a valid
+                validate_writeable_reg_ref(env, reg)
+                    .chain(validate_val_src(env, val_src))
+            }
+            Operator::Push(val_src, stack_id) => validate_val_src(env, val_src)
+                .chain(validate_stack_ref(env, *stack_id)),
+            Operator::Pop(stack_id, reg) => validate_stack_ref(env, *stack_id)
+                .chain(validate_reg_ref(env, reg)),
+        },
+        Instr::If(reg, body) | Instr::While(reg, body) => {
+            validate_reg_ref(env, reg).chain(validate_body(env, body))
+        }
+    }
+}
+
+/// Collects all the validation errors in all the instructions in the body.
+fn validate_body(env: &Environment, body: &[Instr]) -> CompileErrors {
+    body.iter().fold(CompileErrors::none(), |acc, instr| {
+        acc.chain(validate_instr(env, instr))
+    })
+}
+
+impl Compiler<Program> {
+    /// Performs all possible static validation on the program. The environment
+    /// is needed to determine what values and references are valid. If any
+    /// errors occur, `Err` will be returned with all the errors in a
+    /// collection.
+    pub fn validate(
+        self,
+        env: &Environment,
+    ) -> Result<Compiler<Program>, CompileErrors> {
+        validate_body(env, &self.0.body)?;
+        Ok(Compiler(self.0))
+    }
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,5 +1,5 @@
-#![deny(clippy::all, unused_must_use)]
-#![feature(map_entry_replace, trait_alias)]
+#![deny(clippy::all, unused_must_use, unused_imports)]
+#![feature(try_trait)]
 
 // Diesel hasn't fully moved to Rust 2018 yet so we need this
 #[macro_use]

--- a/api/src/models/env.rs
+++ b/api/src/models/env.rs
@@ -26,3 +26,16 @@ pub struct Environment {
     /// first element will be the first one pushed, and so on.
     pub expected_output: Vec<LangValue>,
 }
+
+impl Default for Environment {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            num_registers: 1,
+            num_stacks: 0,
+            max_stack_length: 0,
+            input: vec![],
+            expected_output: vec![],
+        }
+    }
+}

--- a/api/src/server/websocket.rs
+++ b/api/src/server/websocket.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{CompileError, RuntimeError, ServerError},
+    error::{CompileErrors, RuntimeError, ServerError},
     lang::{compile, Machine, MachineState},
     models::Environment,
     schema::environments,
@@ -62,7 +62,7 @@ enum OutgoingEvent<'a> {
     /// Failed to parse websocket message
     MalformedMessage(String),
     /// Failed to parse the sent program
-    CompileError(CompileError),
+    CompileError(CompileErrors),
     /// Error occurred while running a program
     RuntimeError(RuntimeError),
     /// "Step" message occurred before "Compile" message
@@ -87,15 +87,15 @@ impl<'a> From<serde_json::Error> for OutgoingEvent<'a> {
     }
 }
 
-impl<'a> From<CompileError> for OutgoingEvent<'a> {
-    fn from(other: CompileError) -> Self {
-        OutgoingEvent::CompileError(other)
+impl<'a> From<CompileErrors> for OutgoingEvent<'a> {
+    fn from(errors: CompileErrors) -> Self {
+        OutgoingEvent::CompileError(errors)
     }
 }
 
 impl<'a> From<RuntimeError> for OutgoingEvent<'a> {
-    fn from(other: RuntimeError) -> Self {
-        OutgoingEvent::RuntimeError(other)
+    fn from(error: RuntimeError) -> Self {
+        OutgoingEvent::RuntimeError(error)
     }
 }
 


### PR DESCRIPTION
Added static validation for:

- Invalid register references
- Invalid stack references
- Writes to read-only registers

I added a new type called `CompileErrors`, which is just a wrapper around a vec of `CompileError`. Since we want to return all the errors possible, we return this from `parse` and `validate` now instead of just `CompileError`. Let me know if anything doesn't make sense, some of the code is a bit nasty.