### PR TITLE
Add cycle count tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ cargo test
 
 ### Debugging
 
-If you have a program or test failing, you can run with additional debug output by setting `DEBUG=true`, like so:
+If you have a program or test failing, you can run with additional debug output by setting `DEBUG=1`, like so:
 
 ```sh
-DEBUG=true cargo run -- execute -e env.json -i prog.gdlk
-DEBUG=true cargo test -- --nocapture # --nocapture needed to make stdout visible
+DEBUG=1 cargo run -- execute -e env.json -i prog.gdlk
+DEBUG=1 cargo test -- --nocapture # --nocapture needed to make stdout visible
 ```
 
 ### Updating Fixtures

--- a/api/src/server/websocket.rs
+++ b/api/src/server/websocket.rs
@@ -8,8 +8,7 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use diesel::{prelude::*, r2d2::ConnectionManager, PgConnection};
 use gdlk::{
-    compile, CompileErrors, HardwareSpec, Machine, MachineState, ProgramSpec,
-    RuntimeError,
+    compile, CompileErrors, HardwareSpec, Machine, ProgramSpec, RuntimeError,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -56,7 +55,7 @@ enum OutgoingEvent<'a> {
     },
     /// Send latest version of the machine state
     MachineState {
-        state: &'a MachineState,
+        state: &'a Machine,
         is_complete: bool,
         is_successful: bool,
     },
@@ -75,11 +74,11 @@ enum OutgoingEvent<'a> {
 // Define type conversions to make processing code a bit cleaner
 
 impl<'a> From<&'a Machine> for OutgoingEvent<'a> {
-    fn from(other: &'a Machine) -> Self {
+    fn from(machine: &'a Machine) -> Self {
         OutgoingEvent::MachineState {
-            state: other.get_state(),
-            is_complete: other.is_complete(),
-            is_successful: other.is_successful(),
+            state: machine,
+            is_complete: machine.is_complete(),
+            is_successful: machine.is_successful(),
         }
     }
 }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -105,7 +105,7 @@ pub struct Program {
 /// An instruction set that is ready to be executed by a
 /// [Machine](crate::Machine). This instruction set is as minimal as possible,
 /// to reduce the complexity of the runtime.
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MachineInstr {
     /// A simple operator (see [Operator](Operator))
     Operator(Operator),

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -48,6 +48,9 @@ pub struct Machine {
     /// The series of stacks that act as the programs RAM. The number of stacks
     /// and their capacity is determined by the initializating hardware spec.
     pub stacks: Vec<Vec<LangValue>>,
+    /// The number of instructions that have been executed so far. This is not
+    /// unique, so repeated instructions are counted multiple times.
+    pub cycle_count: usize,
 }
 
 impl Machine {
@@ -77,8 +80,12 @@ impl Machine {
             })
             .take(hardware_spec.num_stacks)
             .collect(),
+
+            // Performance stats
+            cycle_count: 0,
         }
     }
+
     /// Gets a source value, which could either be a constant or a register.
     /// If the value is a constant, just return that. If it's a register,
     /// return the value from that register. Returns `RuntimeError` if it
@@ -252,6 +259,7 @@ impl Machine {
         self.program_counter = (self.program_counter as i32
             + instrs_to_consume.unwrap_or(1))
             as usize;
+        self.cycle_count += 1;
         debug!(println!("Executed {:?}\n\tState: {:?}", instr, self));
         Ok(())
     }

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -18,7 +18,6 @@ pub struct HardwareSpec {
 }
 
 // Useful for creating this type in tests
-#[cfg(test)]
 impl Default for HardwareSpec {
     fn default() -> Self {
         Self {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -16,7 +16,9 @@ macro_rules! debug {
         #[cfg(debug_assertions)]
         {
             if let Ok(debug_val) = std::env::var("DEBUG") {
-                if debug_val.to_lowercase().as_str() == "true" {
+                if ["1", "t", "true"]
+                    .contains(&debug_val.to_lowercase().as_str())
+                {
                     $arg
                 }
             }

--- a/core/src/validate.rs
+++ b/core/src/validate.rs
@@ -68,7 +68,6 @@ fn validate_stack_ref(
     hardware_spec: &HardwareSpec,
     stack_id: StackIdentifier,
 ) -> CompileErrors {
-    // TODO clean up this num conversion
     if is_stack_ref_valid(hardware_spec, stack_id) {
         CompileErrors::none()
     } else {

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -21,9 +21,8 @@ fn execute_expect_success(
 
     // Make sure program terminated successfully
     // Check each bit of state individually to make debugging easier
-    let state = machine.get_state();
-    assert_eq!(state.input, Vec::new() as Vec<LangValue>);
-    assert_eq!(state.output, program_spec.expected_output);
+    assert_eq!(machine.input, Vec::new() as Vec<LangValue>);
+    assert_eq!(machine.output, program_spec.expected_output);
     // Final sanity check, in case we change the criteria for success
     assert!(success);
 }


### PR DESCRIPTION
- Track `cycle_count` in `Machine`
- Merged `MachineState` into `Machine`
  - I realized my original reasons for splitting it out weren't very good (wrestling with the borrow checker), and the distinction between what went in Machine vs MachineState was kinda arbitrary, so one big struct is better
- Make the `DEBUG` flag a bit more flexible