### PR TITLE
Assorted random shit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,8 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator_derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -694,6 +696,8 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator_derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -804,6 +808,11 @@ dependencies = [
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "indexmap"
@@ -1834,6 +1843,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "validator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2041,7 @@ dependencies = [
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+"checksum if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
@@ -2121,6 +2159,8 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+"checksum validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ab5990ba09102e1ddc954d294f09b9ea00fc7831a5813bbe84bfdbcae44051e"
+"checksum validator_derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e668e9cd05c5009b833833aa1147e5727b5396ea401f22dd1167618eed4a10c9"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # GDLK
 
+## About
+
+GDLK is a programming language, as well as a game based on solving puzzles with the language.
+
+### What does GDLK stand for?
+
+GDLK Development Language Kit
+
+#### Wait, but, what does GDLK stand for?
+
+GDLK Development Language Kit!
+
 ## Development
 
 ### Setup

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -739,6 +739,8 @@ dependencies = [
  "failure",
  "nom",
  "serde",
+ "validator",
+ "validator_derive",
 ]
 
 [[package]]
@@ -756,6 +758,8 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "validator",
+ "validator_derive",
 ]
 
 [[package]]
@@ -878,6 +882,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 
 [[package]]
 name = "indexmap"
@@ -2022,6 +2032,36 @@ dependencies = [
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "validator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab5990ba09102e1ddc954d294f09b9ea00fc7831a5813bbe84bfdbcae44051e"
+dependencies = [
+ "idna 0.2.0",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url 2.1.0",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e668e9cd05c5009b833833aa1147e5727b5396ea401f22dd1167618eed4a10c9"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "regex",
+ "syn 1.0.9",
+ "validator",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -19,3 +19,5 @@ r2d2 = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
+validator = "0.10.0"
+validator_derive = "0.10.0"

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -1,6 +1,8 @@
 use crate::schema::{hardware_specs, program_specs};
 use diesel::{Identifiable, Queryable};
 use gdlk::{ast::LangValue, HardwareSpec, ProgramSpec};
+use std::convert::TryFrom;
+use validator::{Validate, ValidationErrors};
 
 /// A derivative of [HardwareSpec](gdlk::HardwareSpec), built from a DB query.
 #[derive(Debug, PartialEq, Identifiable, Queryable)]
@@ -19,14 +21,20 @@ pub struct QueryHardwareSpec {
     pub max_stack_length: i32,
 }
 
-impl From<QueryHardwareSpec> for HardwareSpec {
-    fn from(other: QueryHardwareSpec) -> Self {
-        Self {
-            // TODO make these conversions safe
+impl TryFrom<QueryHardwareSpec> for HardwareSpec {
+    type Error = ValidationErrors;
+
+    fn try_from(other: QueryHardwareSpec) -> Result<Self, Self::Error> {
+        let val = Self {
+            // These conversions are safe because of the .validate() call below.
+            // The validation _should_ never fail because of the DB constraints,
+            // but we validate here just to be safe
             num_registers: other.num_registers as usize,
             num_stacks: other.num_stacks as usize,
             max_stack_length: other.max_stack_length as usize,
-        }
+        };
+        val.validate()?;
+        Ok(val)
     }
 }
 
@@ -48,11 +56,15 @@ pub struct QueryProgramSpec {
     pub expected_output: Vec<LangValue>,
 }
 
-impl From<QueryProgramSpec> for ProgramSpec {
-    fn from(other: QueryProgramSpec) -> Self {
-        Self {
+impl TryFrom<QueryProgramSpec> for ProgramSpec {
+    type Error = ValidationErrors;
+
+    fn try_from(other: QueryProgramSpec) -> Result<Self, Self::Error> {
+        let val = Self {
             input: other.input,
             expected_output: other.expected_output,
-        }
+        };
+        val.validate()?;
+        Ok(val)
     }
 }

--- a/api/src/server/websocket.rs
+++ b/api/src/server/websocket.rs
@@ -13,6 +13,7 @@ use gdlk::{
 use serde::{Deserialize, Serialize};
 use std::{
     convert,
+    convert::TryInto,
     time::{Duration, Instant},
 };
 
@@ -228,7 +229,12 @@ pub fn ws_program_specs_by_id(
             .get_result(conn)
             .map_err(ServerError::from)?;
     ws::start(
-        ProgramWebsocket::new(hardware_spec.into(), program_spec.into()),
+        ProgramWebsocket::new(
+            // These unwraps _should_ be safe because our DB constraints
+            // and input validation prevent validation errors here
+            hardware_spec.try_into().unwrap(),
+            program_spec.try_into().unwrap(),
+        ),
         &r,
         stream,
     )

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,3 +11,5 @@ edition = "2018"
 failure = "0.1"
 nom = "5.0"
 serde = { version = "1.0", features = ["derive"] }
+validator = "0.10.0"
+validator_derive = "0.10.0"

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -4,3 +4,9 @@ pub const REG_INPUT_LEN: &str = "RLI";
 pub const REG_STACK_LEN_PREFIX: &str = "RS";
 /// The prefix for all user registers (e.g. "RX0")
 pub const REG_USER_PREFIX: &str = "RX";
+
+/// The maximum number of cycles that a program can run for before being killed.
+/// Programs that take this number of cycles WILL terminate normally, but going
+/// over this number will cause an error when trying to execute additional
+/// instructions.
+pub const MAX_CYCLE_COUNT: usize = 1000;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -45,6 +45,10 @@ pub enum RuntimeError {
     #[fail(display = "Cannot pop from empty stack {}", 0)]
     EmptyStack(StackIdentifier),
 
+    /// Too many cycles in the program
+    #[fail(display = "The maximum number of cycles has been reached")]
+    TooManyCycles,
+
     /// Instruction list has been exhausted, program is terminated
     #[fail(display = "Program has terminated, nothing left to execute")]
     ProgramTerminated,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -5,12 +5,18 @@ use std::{
     fmt::{self, Display, Formatter},
     ops::Try,
 };
+use validator::ValidationErrors;
 
 /// An error that occurs during compilation of a program. The error will be
 /// due to a flaw in the program. This indicates a user error, _not_ an internal
 /// compiler error. Compiler bugs will always cause a panic.
 #[derive(Debug, PartialEq, Fail, Serialize)]
 pub enum CompileError {
+    /// Validation failed on a [HardwareSpec](crate::HardwareSpec) or
+    /// [ProgramSpec](crate::ProgramSpec)
+    #[fail(display = "Invalid spec: {}", 0)]
+    InvalidSpec(ValidationErrors),
+
     /// Failed to parse the program
     #[fail(display = "Parse error: {}", 0)]
     ParseError(String),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,9 @@
 #![deny(clippy::all, unused_must_use, unused_imports)]
 #![feature(try_trait, slice_patterns)]
 
+#[macro_use]
+extern crate validator_derive;
+
 pub mod ast;
 mod consts;
 mod desugar;
@@ -50,6 +53,7 @@ pub use error::*;
 pub use machine::*;
 pub use models::*;
 use std::fmt::Debug;
+use validator::Validate;
 
 /// Compiles the given source program, with the given specs, into a
 /// [Machine](Machine). The returned machine can then be executed.
@@ -58,6 +62,12 @@ pub fn compile(
     program_spec: &ProgramSpec,
     source: String,
 ) -> Result<Machine, CompileErrors> {
+    // Validate the specs, so we know that shit is clean
+    hardware_spec
+        .validate()
+        .map_err(CompileError::InvalidSpec)?;
+    program_spec.validate().map_err(CompileError::InvalidSpec)?;
+
     Ok(Compiler::new(source)
         .debug()
         .parse()?

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,6 +45,7 @@ mod util;
 mod validate;
 
 use ast::MachineInstr;
+pub use consts::MAX_CYCLE_COUNT;
 pub use error::*;
 pub use machine::*;
 pub use models::*;

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -3,6 +3,7 @@ use crate::{
         LangValue, MachineInstr, Operator, RegisterRef, StackIdentifier,
         ValueSource,
     },
+    consts::MAX_CYCLE_COUNT,
     debug,
     error::RuntimeError,
     models::{HardwareSpec, ProgramSpec},
@@ -165,6 +166,11 @@ impl Machine {
     /// Executes the next instruction in the program. If there are no
     /// instructions left to execute, this panics.
     pub fn execute_next(&mut self) -> Result<(), RuntimeError> {
+        // Prevent infinite loops
+        if self.cycle_count >= MAX_CYCLE_COUNT {
+            return Err(RuntimeError::TooManyCycles);
+        }
+
         let instr = *self
             .program
             .get(self.program_counter)

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -4,16 +4,20 @@
 
 use crate::ast::LangValue;
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 /// The "hardware" that a program can execute on. This defines computing
 /// constraints. This is needed both at compile time and runtime.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Validate)]
 pub struct HardwareSpec {
     /// Number of registers available
+    #[validate(range(min = 1, max = 16))]
     pub num_registers: usize,
     /// Maximum number of stacks permitted
+    #[validate(range(min = 0, max = 16))]
     pub num_stacks: usize,
     /// Maximum size of each stack
+    #[validate(range(min = 0, max = 256))]
     pub max_stack_length: usize,
 }
 
@@ -31,12 +35,14 @@ impl Default for HardwareSpec {
 /// Specification that defines a correct program. Provides the input that a
 /// program runs on, and defines the expected output, which is used to determine
 /// if the program is correct. Only needed at runtime.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Validate)]
 pub struct ProgramSpec {
     /// The input values, where the element at position 0 is the first one that
     /// will be popped off.
+    #[validate(length(max = 256))]
     pub input: Vec<LangValue>,
     /// The correct value to be left in the output when the program exits. The
     /// first element will be the first one pushed, and so on.
+    #[validate(length(max = 256))]
     pub expected_output: Vec<LangValue>,
 }

--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -7,13 +7,13 @@ use gdlk::{compile, HardwareSpec, ProgramSpec};
 /// Panics if the program compiles successfully, or if the wrong set of
 /// errors is returned.
 fn expect_compile_errors(
-    env: HardwareSpec,
+    hardware_spec: HardwareSpec,
     src: &str,
     expected_errors: &[&str],
 ) {
     // Compile from hardware+src
     let actual_errors = compile(
-        &env,
+        &hardware_spec,
         // This won't be used, just use bullshit values
         &ProgramSpec {
             input: vec![],

--- a/core/tests/runtime_error.rs
+++ b/core/tests/runtime_error.rs
@@ -1,0 +1,39 @@
+//! Integration tests for GDLK that expect compile errors. The programs in
+//! these tests should all fail during compilation.
+
+use gdlk::{compile, HardwareSpec, ProgramSpec};
+
+/// Compiles the program for the given hardware, executes it under the given
+/// program spec, and expects a runtime error. Panics if the program executes
+/// successfully, or if the wrong set of errors is returned.
+fn expect_runtime_error(
+    hardware_spec: HardwareSpec,
+    program_spec: ProgramSpec,
+    src: &str,
+    expected_error: &str,
+) {
+    // Compile from hardware+src
+    let mut machine =
+        compile(&hardware_spec, &program_spec, src.into()).unwrap();
+
+    // Execute to completion
+    let actual_error = machine.execute_all().unwrap_err();
+    assert_eq!(format!("{}", actual_error), expected_error);
+}
+
+#[test]
+fn test_exceed_max_cycle_count() {
+    // We can exit successfully with exactly the maximum number of cycles
+    expect_runtime_error(
+        HardwareSpec::default(),
+        ProgramSpec {
+            input: vec![],
+            expected_output: vec![],
+        },
+        "
+        SET RX0 1
+        WHILE RX0 {}
+        ",
+        "The maximum number of cycles has been reached",
+    );
+}

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -2,7 +2,10 @@
 //! these tests should compile successfully, and execute with a successful
 //! outcome.
 
-use gdlk::{ast::LangValue, compile, HardwareSpec, Machine, ProgramSpec};
+use gdlk::{
+    ast::LangValue, compile, HardwareSpec, Machine, ProgramSpec,
+    MAX_CYCLE_COUNT,
+};
 
 /// Compiles the program for the given hardware, and executes it against the
 /// program spec. Panics if the compile fails or the execution isn't
@@ -333,4 +336,23 @@ fn test_cycle_count_while() {
     // The initial WHILE check counts as one instruction, plus one more for
     // each subsequent loop
     assert_eq!(m1.cycle_count, 10);
+}
+
+#[test]
+fn test_equal_max_cycle_count() {
+    // We can exit successfully with exactly the maximum number of cycles
+    let machine = execute_expect_success(
+        HardwareSpec::default(),
+        ProgramSpec {
+            input: vec![(MAX_CYCLE_COUNT as i32 - 1) / 2],
+            expected_output: vec![],
+        },
+        "
+        READ RX0
+        WHILE RX0 {
+            SUB RX0 1
+        }
+        ",
+    );
+    assert_eq!(machine.cycle_count, MAX_CYCLE_COUNT);
 }

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -245,26 +245,32 @@ fn test_insertion_sort() {
             expected_output: vec![1, 1, 2, 3, 3, 4, 4, 5, 5, 8, 8, 8, 9, 9, 10],
         },
         "
+        ; RX0:  the last element pulled off the input
+        ; RX1:  the current element in the sorted list we're comparing to
+        ; RX2:  scratch space for comparisons and such
+        ; S0:   the sorted list so far, with greatest at the bottom
+        ; S1:   scratch spaced used during insertion, to hold the chunk of the
+        ;       list that's less than RX0
         WHILE RLI {
             READ RX0
             SET RX2 RS0
             WHILE RX2 {
                 POP S0 RX1
 
+                ; check if
                 CMP RX2 RX0 RX1
                 SUB RX2 1
                 IF RX2 {
-                    SET RX2 0
-                    SUB RX2 1
+                    SET RX2 -1
                 }
-                IF RX2 {
-                    PUSH RX1 S0
+                IF RX2 { ; RX0 <= RX1
+                    PUSH RX1 S0 ; RX1 > RX0, put it back on the stack
                 }
                 ADD RX2 1
-                IF RX2 {
+                IF RX2 { ; RX0 > RX1
                     PUSH RX1 S1
                 }
-                MUL RX2 RS0
+                MUL RX2 RS0 ; iterate if RX0 > RX1 and there's more left in S0
             }
             PUSH RX0 S0
             WHILE RS1 {
@@ -273,6 +279,7 @@ fn test_insertion_sort() {
             }
         }
 
+        ; write the sorted list to output
         WHILE RS0 {
             POP S0 RX0
             WRITE RX0

--- a/test_socket.py
+++ b/test_socket.py
@@ -19,13 +19,19 @@ async def ws(host, program_spec_id, source):
             print(f"<<< {msg}")
             await websocket.send(msg)
             recv = json.loads(await websocket.recv())
-            if recv["type"] == "compile_error" and "ParseError" in recv["content"][0]:
-                print(f">>> Parse Error:\n{recv['content'][0]['ParseError'].strip()}\n")
+            if (
+                recv["type"] == "compile_error"
+                and "ParseError" in recv["content"]
+            ):
+                print(
+                    f">>> Parse Error:\n{recv['content']['ParseError'].strip()}\n"
+                )
             print(f">>> {recv}")
             return recv
 
-        await send_and_recv(event_type="edit", content={"source": source})
-        state_resp = await send_and_recv(event_type="compile")
+        state_resp = await send_and_recv(
+            event_type="compile", content={"source": source}
+        )
 
         while (
             state_resp["type"] == "machine_state"


### PR DESCRIPTION
- Removed the `Edit` event from websocket, since we decided we're only going to send source at compile time, not periodically
- Added cycle limit to `Machine` (closes #13)
- Add GDLK acronym to README
- Add some numeric validation to make number conversions safer (Closes #11)
- Add comments to insertion sort, and use a negative lit to eliminate an instruction