### PR TITLE
Add set_content and delete file operations

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -18,6 +18,8 @@ pub enum ServerError {
     NodeNotFound,
     #[fail(display = "Operation not supported")]
     UnsupportedFileOperation,
+    #[fail(display = "Permission denied")]
+    PermissionDenied,
 }
 
 impl From<r2d2::Error> for ServerError {

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -13,7 +13,7 @@ pub type PooledConnection =
 #[cfg(test)]
 mod tests {
     use super::*;
-    use diesel::{Connection, PgConnection};
+    use diesel::Connection;
 
     /// Helper to create a database connection for testing. This establishes
     /// the connection, then starts a test transaction on it so that no changes
@@ -30,5 +30,17 @@ mod tests {
 
         (&conn as &PgConnection).begin_test_transaction().unwrap();
         conn
+    }
+
+    /// Assert that the first value is an Err, and that its string form matches
+    /// the second argument.
+    #[macro_export]
+    macro_rules! assert_err {
+        ($res:expr, $msg:tt $(,)?) => {
+            match $res {
+                Ok(_) => panic!("Expected Err, got Ok"),
+                Err(err) => assert_eq!(format!("{}", err), $msg),
+            }
+        };
     }
 }

--- a/api/src/vfs/internal.rs
+++ b/api/src/vfs/internal.rs
@@ -169,6 +169,27 @@ pub trait VirtualNodeHandler: Debug + Sync {
         // called.
         panic!("Operation not supported for this node type")
     }
+
+    fn set_content(
+        &self,
+        _context: &Context,
+        _path_variables: &PathVariables,
+        _path_segment: &str,
+        _content: &str,
+    ) -> Result<()> {
+        // This only needs to be implemented for writable files.
+        panic!("Operation not supported for this node type")
+    }
+
+    fn delete(
+        &self,
+        _context: &Context,
+        _path_variables: &PathVariables,
+        _path_segment: &str,
+    ) -> Result<()> {
+        // This only needs to be implemented for writable files.
+        panic!("Operation not supported for this node type")
+    }
 }
 
 /// A virtual node in the file system. In this context, "virtual" means that

--- a/api/src/vfs/program.rs
+++ b/api/src/vfs/program.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use diesel::{
     dsl::{exists, select},
-    QueryDsl, RunQueryDsl,
+    ExpressionMethods, QueryDsl, RunQueryDsl,
 };
 use gdlk::ast::LangValue;
 
@@ -107,6 +107,24 @@ impl VirtualNodeHandler for ProgramSpecFileNodeHandler {
 pub struct ProgramSourceNodeHandler();
 
 impl VirtualNodeHandler for ProgramSourceNodeHandler {
+    fn exists(
+        &self,
+        context: &Context,
+        path_variables: &PathVariables,
+        path_segment: &str,
+    ) -> Result<bool> {
+        let hw_spec_slug = path_variables.get_var("hw_spec_slug");
+        let program_spec_slug = path_variables.get_var("program_spec_slug");
+
+        Ok(select(exists(UserProgram::filter_by_file_name(
+            context.user.id,
+            hw_spec_slug,
+            program_spec_slug,
+            path_segment,
+        )))
+        .get_result(context.conn())?)
+    }
+
     fn permissions(
         &self,
         _: &Context,
@@ -126,12 +144,12 @@ impl VirtualNodeHandler for ProgramSourceNodeHandler {
         let program_spec_slug = path_variables.get_var("program_spec_slug");
 
         // Get the source stored for this hw/program/user combo
-        let source: String = UserProgram::filter_by_specs(
+        let source: String = UserProgram::filter_by_file_name(
             context.user.id,
             hw_spec_slug,
             program_spec_slug,
+            path_segment,
         )
-        .filter(UserProgram::with_file_name(path_segment))
         .select(user_programs::dsl::source_code)
         .get_result(context.conn())?;
         Ok(source)
@@ -152,5 +170,60 @@ impl VirtualNodeHandler for ProgramSourceNodeHandler {
         )
         .select(user_programs::dsl::file_name)
         .get_results(context.conn())?)
+    }
+
+    fn set_content(
+        &self,
+        context: &Context,
+        path_variables: &PathVariables,
+        path_segment: &str,
+        content: &str,
+    ) -> Result<()> {
+        use self::user_programs::dsl::*;
+
+        let hw_spec_slug = path_variables.get_var("hw_spec_slug");
+        let program_spec_slug = path_variables.get_var("program_spec_slug");
+
+        // Diesel doesn't support updates with joins, so we have to fetch the
+        // ID of the UserProgram first, then do the update in a second query.
+        let user_program_id: i32 = UserProgram::filter_by_file_name(
+            context.user.id,
+            hw_spec_slug,
+            program_spec_slug,
+            path_segment,
+        )
+        .select(id)
+        .get_result(context.conn())?;
+        diesel::update(user_programs.filter(id.eq(user_program_id)))
+            .set(source_code.eq(content))
+            .execute(context.conn())?;
+
+        Ok(())
+    }
+
+    fn delete(
+        &self,
+        context: &Context,
+        path_variables: &PathVariables,
+        path_segment: &str,
+    ) -> Result<()> {
+        use self::user_programs::dsl::*;
+
+        let hw_spec_slug = path_variables.get_var("hw_spec_slug");
+        let program_spec_slug = path_variables.get_var("program_spec_slug");
+
+        // Diesel doesn't support updates with joins, so we have to fetch the
+        // ID of the UserProgram first, then do the update in a second query.
+        let user_program_id: i32 = UserProgram::filter_by_file_name(
+            context.user.id,
+            hw_spec_slug,
+            program_spec_slug,
+            path_segment,
+        )
+        .select(id)
+        .get_result(context.conn())?;
+        diesel::delete(user_programs.filter(id.eq(user_program_id)))
+            .execute(context.conn())?;
+        Ok(())
     }
 }


### PR DESCRIPTION
Added two write operations: `set_content` and `delete`. Will do create and rename later. Also fixed a bug cause I forgot to implement `exists` for the program source node handler, which meant it always returned `true` for `exists()`.