### PR TITLE
Clean up file system permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ We use nightly Rust. Here's a list of reasons why. If this list every gets empty
 
 - Rust features
   - [try_trait](https://github.com/rust-lang/rust/issues/42327)
-  - [slice_patterns](https://github.com/rust-lang/rust/issues/62254)
   - [const_fn](https://github.com/rust-lang/rust/issues/57563)
   - [trait_alias](https://github.com/rust-lang/rust/issues/41517)
 - Rustfmt

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -11,13 +11,23 @@ pub enum ServerError {
     /// Wrapper for R2D2's error type
     #[fail(display = "{}", 0)]
     R2d2Error(#[cause] r2d2::Error),
+
     /// Wrapper for Diesel's error type
     #[fail(display = "{}", 0)]
     DieselError(#[cause] diesel::result::Error),
+
+    // ===== FS errors =====
+    /// A file system node was requested, but no node exists at the given path.
     #[fail(display = "File or directory not found")]
     NodeNotFound,
+
+    /// The attempted file system operation is not supported for the node it
+    /// was attempted on.
     #[fail(display = "Operation not supported")]
     UnsupportedFileOperation,
+
+    /// The file system node does not provide the permissions required to
+    /// perform the attempted operation.
     #[fail(display = "Permission denied")]
     PermissionDenied,
 }

--- a/api/src/vfs/hardware.rs
+++ b/api/src/vfs/hardware.rs
@@ -13,7 +13,7 @@ use crate::{
     schema::hardware_specs,
     vfs::{
         internal::{Context, PathVariables, VirtualNodeHandler},
-        NodePermissions, PERMS_R, PERMS_RX,
+        NodePermissions, PERMS_R,
     },
 };
 use diesel::{
@@ -42,7 +42,7 @@ impl VirtualNodeHandler for HardwareSpecNodeHandler {
         _: &PathVariables,
         _: &str,
     ) -> Result<NodePermissions> {
-        Ok(PERMS_RX)
+        Ok(PERMS_R)
     }
 
     fn list_variable_nodes(

--- a/api/src/vfs/mod.rs
+++ b/api/src/vfs/mod.rs
@@ -150,7 +150,7 @@ impl Node {
     }
 
     /// Gets the actual data of this node. This is only possible for files, and
-    /// requires read permission. Return an error if this node is a directory,
+    /// requires read permission. Returns an error if this node is a directory,
     /// or does not have read permission.
     pub fn content(&self) -> Result<String> {
         match self.vnode.node_type {
@@ -455,7 +455,7 @@ impl VirtualNodeHandler for SimpleDirHandler {
 
 /// The entire VFS node tree. This defines the layout of the tree. Each node has
 /// a path spec, a handler that defines how it behaves, and optionally children.
-/// Obviously, only directions can have children.
+/// Obviously, only directories can have children.
 static VFS_TREE: VirtualNode = VirtualNode::dir(
     // If you update something here, make sure to update the comment above!
     SegmentSpec::Fixed(""),

--- a/api/src/vfs/mod.rs
+++ b/api/src/vfs/mod.rs
@@ -46,27 +46,72 @@ pub enum NodeType {
     Directory,
 }
 
+/// A node has two permission flags: (R)ead and (Write). These flags have
+/// different meanings for files vs directories.
+///
+/// <table>
+///   <thead>
+///     <tr>
+///       <th>Permission</th>
+///       <th>Directory</th>
+///       <th>File</th>
+///     </tr>
+///   </thead>
+///   <tbody>
+///     <tr>
+///       <td>Read</td>
+///       <td>List the directory's children</td>
+///       <td>Read a file's contents</td>
+///     </tr>
+///     <tr>
+///       <td>Write</td>
+///       <td>Create files in the directory, delete the directory</td>
+///       <td>Change the file's contents, delete the file</td>
+///     </tr>
+///   </tbody>
+/// </table>
+///
+/// Note that read permission on a node is _not_ required to view that node's
+/// metadata (name, type, permissions). That permission is implicitly granted
+/// when you have read permission on the node's parent. For example, if you
+/// have read permission on `/dir1`, then you can _always_ read the metadata
+/// for `/dir1/file1`, even if you don't have read permissions on `/dir1/file1`.
+
 #[derive(Copy, Clone, Debug, PartialEq, GraphQLObject)]
 pub struct NodePermissions {
     pub read: bool,
     pub write: bool,
-    pub execute: bool,
+}
+
+impl NodePermissions {
+    /// Check if these permissions permit reads. If not, return a
+    /// <ServerError::PermissionDenied>.
+    pub fn require_read(self) -> Result<()> {
+        if self.read {
+            Ok(())
+        } else {
+            Err(ServerError::PermissionDenied)
+        }
+    }
+
+    /// Check if these permissions permit writes. If not, return a
+    /// <ServerError::PermissionDenied>.
+    pub fn require_write(self) -> Result<()> {
+        if self.write {
+            Ok(())
+        } else {
+            Err(ServerError::PermissionDenied)
+        }
+    }
 }
 
 const PERMS_R: NodePermissions = NodePermissions {
     read: true,
     write: false,
-    execute: false,
 };
 const PERMS_RW: NodePermissions = NodePermissions {
     read: true,
     write: true,
-    execute: false,
-};
-const PERMS_RX: NodePermissions = NodePermissions {
-    read: true,
-    write: false,
-    execute: true,
 };
 
 /// A physical node in the file system. This represents exactly one
@@ -104,25 +149,31 @@ impl Node {
         )
     }
 
-    /// Gets the actual data of this node. This is only possible for files. If
-    /// called for a directory, will return
-    /// <ServerError::UnsupportedFileOperation>.
+    /// Gets the actual data of this node. This is only possible for files, and
+    /// requires read permission. Will return an error if this node is a
+    /// directory, or does not have read permission.
     pub fn content(&self) -> Result<String> {
         match self.vnode.node_type {
-            NodeType::File => self.vnode.handler.content(
-                &self.context,
-                &self.path_variables,
-                &self.path_segment,
-            ),
+            NodeType::File => {
+                self.permissions()?.require_read()?; // Require read perms
+                self.vnode.handler.content(
+                    &self.context,
+                    &self.path_variables,
+                    &self.path_segment,
+                )
+            }
             // Can't do this for directories, ya dummy
             NodeType::Directory => Err(ServerError::UnsupportedFileOperation),
         }
     }
 
     /// Gets a list of each child of this node. This is only possible for
-    /// directories, as files have no children. If called for a file, will
-    /// return <ServerError::UnsupportedFileOperation>.
+    /// directories, as files have no children. Requires read permission. Will
+    /// return an error if this node is a file or does not have read
+    /// permissions.
     pub fn children(&self) -> Result<Vec<Self>> {
+        self.permissions()?.require_read()?; // Require read perms
+
         // Include this node's name as a variable for the children. Remember
         // that PathVariables doesn't ever contain the last path segment,
         // so the name of this node won't be in path_variables. We need to add
@@ -172,20 +223,19 @@ impl Node {
         Ok(child_nodes)
     }
 
+    /// Change the content of this node to the the given value. Requires write
+    /// permission. Returns an error if this node is a directory or does not
+    /// have write permission.
     pub fn set_content(&self, content: String) -> Result<()> {
         match self.node_type() {
             NodeType::File => {
-                // Always ask for permission!
-                if self.permissions()?.write {
-                    self.vnode.handler.set_content(
-                        &self.context,
-                        &self.path_variables,
-                        &self.path_segment,
-                        &content,
-                    )
-                } else {
-                    Err(ServerError::PermissionDenied)
-                }
+                self.permissions()?.require_write()?; // Require write perms
+                self.vnode.handler.set_content(
+                    &self.context,
+                    &self.path_variables,
+                    &self.path_segment,
+                    &content,
+                )
             }
             NodeType::Directory => Err(ServerError::UnsupportedFileOperation),
         }
@@ -194,15 +244,12 @@ impl Node {
     /// Delete this node. Any node with write permissions can be deleted. Any
     /// other node will generate a <ServerError::PermissionDenied>.
     pub fn delete(&self) -> Result<()> {
-        if self.permissions()?.write {
-            self.vnode.handler.delete(
-                &self.context,
-                &self.path_variables,
-                &self.path_segment,
-            )
-        } else {
-            Err(ServerError::PermissionDenied)
-        }
+        self.permissions()?.require_write()?; // Require write perms
+        self.vnode.handler.delete(
+            &self.context,
+            &self.path_variables,
+            &self.path_segment,
+        )
     }
 }
 
@@ -285,7 +332,7 @@ impl NodeMutation {
 /// might be needed to serve file paths, e.g. DB connections.
 ///
 /// This struct is useful for getting references to particular nodes (see
-/// <Self::node>). Once you have a `Node`, you can run
+/// <Self::get_node>). Once you have a `Node`, you can run
 /// file operations on it.
 pub struct VirtualFileSystem {
     db_conn: Rc<PooledConnection>,
@@ -402,7 +449,7 @@ impl VirtualNodeHandler for SimpleDirHandler {
         _: &PathVariables,
         _: &str,
     ) -> Result<NodePermissions> {
-        Ok(PERMS_RX)
+        Ok(PERMS_R)
     }
 }
 
@@ -558,7 +605,7 @@ mod tests {
         let node = vfs.get_node("/").unwrap();
         assert_eq!(node.name(), "");
         assert_eq!(node.node_type(), NodeType::Directory);
-        assert_eq!(node.permissions().unwrap(), PERMS_RX);
+        assert_eq!(node.permissions().unwrap(), PERMS_R);
         assert_err!(node.content(), "Operation not supported");
         assert_err!(node.set_content("test".into()), "Operation not supported");
         check_node_names(&node.children().unwrap(), &["hardware"]);
@@ -571,7 +618,7 @@ mod tests {
         let node = vfs.get_node("/hardware").unwrap();
         assert_eq!(node.name(), "hardware");
         assert_eq!(node.node_type(), NodeType::Directory);
-        assert_eq!(node.permissions().unwrap(), PERMS_RX);
+        assert_eq!(node.permissions().unwrap(), PERMS_R);
         assert_err!(node.content(), "Operation not supported");
         check_node_names(&node.children().unwrap(), &["hw1"]);
         assert_err!(node.delete(), "Permission denied");
@@ -584,7 +631,7 @@ mod tests {
         let hw_spec_dir = vfs.get_node("/hardware/hw1").unwrap();
         assert_eq!(hw_spec_dir.name(), "hw1");
         assert_eq!(hw_spec_dir.node_type(), NodeType::Directory);
-        assert_eq!(hw_spec_dir.permissions().unwrap(), PERMS_RX);
+        assert_eq!(hw_spec_dir.permissions().unwrap(), PERMS_R);
         assert_err!(hw_spec_dir.content(), "Operation not supported");
         check_node_names(
             &hw_spec_dir.children().unwrap(),
@@ -611,7 +658,7 @@ mod tests {
         let node = vfs.get_node("/hardware/hw1/programs").unwrap();
         assert_eq!(node.name(), "programs");
         assert_eq!(node.node_type(), NodeType::Directory);
-        assert_eq!(node.permissions().unwrap(), PERMS_RX);
+        assert_eq!(node.permissions().unwrap(), PERMS_R);
         assert_err!(node.content(), "Operation not supported");
         check_node_names(&node.children().unwrap(), &["prog1", "prog2"]);
         assert_err!(node.delete(), "Permission denied");
@@ -625,7 +672,7 @@ mod tests {
             vfs.get_node("/hardware/hw1/programs/prog1").unwrap();
         assert_eq!(program_spec_dir.name(), "prog1");
         assert_eq!(program_spec_dir.node_type(), NodeType::Directory);
-        assert_eq!(program_spec_dir.permissions().unwrap(), PERMS_RX);
+        assert_eq!(program_spec_dir.permissions().unwrap(), PERMS_R);
         assert_err!(program_spec_dir.content(), "Operation not supported");
         check_node_names(
             &program_spec_dir.children().unwrap(),

--- a/api/src/vfs/mod.rs
+++ b/api/src/vfs/mod.rs
@@ -150,12 +150,12 @@ impl Node {
     }
 
     /// Gets the actual data of this node. This is only possible for files, and
-    /// requires read permission. Will return an error if this node is a
-    /// directory, or does not have read permission.
+    /// requires read permission. Return an error if this node is a directory,
+    /// or does not have read permission.
     pub fn content(&self) -> Result<String> {
         match self.vnode.node_type {
             NodeType::File => {
-                self.permissions()?.require_read()?; // Require read perms
+                self.permissions()?.require_read()?;
                 self.vnode.handler.content(
                     &self.context,
                     &self.path_variables,
@@ -168,11 +168,11 @@ impl Node {
     }
 
     /// Gets a list of each child of this node. This is only possible for
-    /// directories, as files have no children. Requires read permission. Will
-    /// return an error if this node is a file or does not have read
+    /// directories, as files have no children. Requires read permission.
+    /// Returns an error if this node is a file or does not have read
     /// permissions.
     pub fn children(&self) -> Result<Vec<Self>> {
-        self.permissions()?.require_read()?; // Require read perms
+        self.permissions()?.require_read()?;
 
         // Include this node's name as a variable for the children. Remember
         // that PathVariables doesn't ever contain the last path segment,
@@ -229,7 +229,7 @@ impl Node {
     pub fn set_content(&self, content: String) -> Result<()> {
         match self.node_type() {
             NodeType::File => {
-                self.permissions()?.require_write()?; // Require write perms
+                self.permissions()?.require_write()?;
                 self.vnode.handler.set_content(
                     &self.context,
                     &self.path_variables,
@@ -244,7 +244,7 @@ impl Node {
     /// Delete this node. Any node with write permissions can be deleted. Any
     /// other node will generate a <ServerError::PermissionDenied>.
     pub fn delete(&self) -> Result<()> {
-        self.permissions()?.require_write()?; // Require write perms
+        self.permissions()?.require_write()?;
         self.vnode.handler.delete(
             &self.context,
             &self.path_variables,
@@ -311,14 +311,14 @@ impl NodeMutation {
 
 #[juniper::object(Context = GqlContext)]
 impl NodeMutation {
-    /// Set the contents of a file. Will fail if the node is a directory or
-    /// a file without write permissions.
+    /// Set the contents of a file. Fails if the node is a directory or a file
+    /// without write permissions.
     fn set_content(&self, content: String) -> FieldResult<&Node> {
         self.0.set_content(content)?;
         Ok(&self.0)
     }
 
-    /// Delete a file or directory. Will fail if the node does not have write
+    /// Delete a file or directory. Fails if the node does not have write
     /// permissions. Returns the name (_not_ the full path) of the deleted file.
     fn delete(&self) -> FieldResult<String> {
         self.0.delete()?;

--- a/api/src/vfs/program.rs
+++ b/api/src/vfs/program.rs
@@ -13,7 +13,7 @@ use crate::{
     schema::{program_specs, user_programs},
     vfs::{
         internal::PathVariables, Context, NodePermissions, VirtualNodeHandler,
-        PERMS_R, PERMS_RW, PERMS_RX,
+        PERMS_R, PERMS_RW,
     },
 };
 use diesel::{
@@ -47,7 +47,7 @@ impl VirtualNodeHandler for ProgramSpecNodeHandler {
         _: &PathVariables,
         _: &str,
     ) -> Result<NodePermissions> {
-        Ok(PERMS_RX)
+        Ok(PERMS_R)
     }
 
     fn list_variable_nodes(


### PR DESCRIPTION
A few changes to fs permissions:
- Removed execute permission
  - I don't see any need for it, since all the executable commands won't actually be defined in the FS, they'll just be on the frontend. And for directories, I think it just complicates it and makes it harder to build, and harder to learn if you don't already understand unix permissions.
- Added read permission checks to `content` and `children`
- Unrelated, but removed the `slice_patterns` from the list of our nightly features, since it got stabilized in 1.42