### PR TITLE
Add createChild operation to file system

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -30,6 +30,11 @@ pub enum ServerError {
     /// perform the attempted operation.
     #[fail(display = "Permission denied")]
     PermissionDenied,
+
+    /// User attempted to create a node, but a node already exists at that
+    /// path.
+    #[fail(display = "Node already exists")]
+    AlreadyExists,
 }
 
 impl From<r2d2::Error> for ServerError {

--- a/api/src/gql.rs
+++ b/api/src/gql.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Result,
     models::User,
     util::Pool,
-    vfs::{Node, NodeMutation, VirtualFileSystem},
+    vfs::{NodeMutation, NodeReference, VirtualFileSystem},
 };
 use diesel::RunQueryDsl;
 use juniper::FieldResult;
@@ -19,13 +19,13 @@ pub struct GqlContext {
 // To make our context usable by Juniper, we have to implement a marker trait.
 impl juniper::Context for GqlContext {}
 
-/// Helper to get a Node for a context, user, and path. This is used for both
+/// Helper to get a node for a context, user, and path. This is used for both
 /// the query and mutation handlers, so we factor out the common code here.
 fn get_fs_node(
     context: &GqlContext,
     username: String,
     path: String,
-) -> Result<Node> {
+) -> Result<NodeReference> {
     // temporary way to get user -- just have the caller specify username
     let user: User =
         User::filter_by_username(&username).get_result(&context.pool.get()?)?;
@@ -45,7 +45,7 @@ impl RootQuery {
         context: &GqlContext,
         username: String,
         path: String,
-    ) -> FieldResult<Node> {
+    ) -> FieldResult<NodeReference> {
         Ok(get_fs_node(context, username, path)?)
     }
 }

--- a/api/src/vfs/internal.rs
+++ b/api/src/vfs/internal.rs
@@ -151,7 +151,7 @@ pub trait VirtualNodeHandler: Debug + Sync {
     ) -> Result<String> {
         // This only needs to be implemented for files. For directories, this
         // should never be called because the Node wrapper checks the node type.
-        panic!("Operation not supported for this node type")
+        panic!("Operation not supported for this virtual node")
     }
 
     /// Lists all physical nodes that exist for this variable virtual node.
@@ -167,9 +167,24 @@ pub trait VirtualNodeHandler: Debug + Sync {
         // This only needs to be implemented for directories with variable path
         // segments. For files and fixed directories, this should never be
         // called.
-        panic!("Operation not supported for this node type")
+        panic!("Operation not supported for this virtual node")
     }
 
+    /// Create a physical node at the given path segment. This will perform
+    /// whatever operations are necessary so that a physical node will exist
+    /// for this virtual node at that name.
+    fn create_node(
+        &self,
+        _context: &Context,
+        _path_variables: &PathVariables,
+        _path_segment: &str,
+    ) -> Result<()> {
+        // Implement this for children of writable directories that can have
+        // files created
+        panic!("Operation not supported for this virtual node")
+    }
+
+    /// Set the content of the physical node at the given path segment.
     fn set_content(
         &self,
         _context: &Context,
@@ -178,9 +193,10 @@ pub trait VirtualNodeHandler: Debug + Sync {
         _content: &str,
     ) -> Result<()> {
         // This only needs to be implemented for writable files.
-        panic!("Operation not supported for this node type")
+        panic!("Operation not supported for this virtual node")
     }
 
+    /// Delete the physical node at the given path segment.
     fn delete(
         &self,
         _context: &Context,
@@ -188,7 +204,7 @@ pub trait VirtualNodeHandler: Debug + Sync {
         _path_segment: &str,
     ) -> Result<()> {
         // This only needs to be implemented for writable files.
-        panic!("Operation not supported for this node type")
+        panic!("Operation not supported for this virtual node")
     }
 }
 

--- a/api/src/vfs/internal.rs
+++ b/api/src/vfs/internal.rs
@@ -150,7 +150,8 @@ pub trait VirtualNodeHandler: Debug + Sync {
         _path_segment: &str,
     ) -> Result<String> {
         // This only needs to be implemented for files. For directories, this
-        // should never be called because the Node wrapper checks the node type.
+        // should never be called because the NodeReference wrapper checks the
+        // node type.
         panic!("Operation not supported for this virtual node")
     }
 


### PR DESCRIPTION
- Added `create_child` operation
- Exposed that operatio as `createChild` in GQL
- Renamed `Node` to `NodeReference`
  - I realized that a `Node` is really a pointer to to an actual node, and now with the new code we have `Node`s that don't yet have corresponding physical nodes, so I think `NodeReference` is a better name
- Removed delete functionality for directories. Right now we don't have any dirs that the user will be able to delete anyway, and the permissioning rules I picked wouldn't work. I think what we'll end up wanting to do is make it so that delete permissions work like create, where you need write permissions on the _parent_ and the node itself to be able to delete.

Example query/response:

```graphql
mutation {
  fsNode(username: "user1", path: "/hardware/hw1/programs/prog1") {
    createChild(name: "program.gdlk") {
      name
      content
    }
  }
}
```

```json
{
  "data": {
    "fsNode": {
      "createChild": {
        "name": "program.gdlk",
        "content": ""
      }
    }
  }
}
```