### PR TITLE
Add function to compile program without allocating

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -12,7 +12,7 @@ use diesel::{
     PgConnection,
 };
 use failure::Fallible;
-use gdlk::{compile, HardwareSpec, ProgramSpec};
+use gdlk::{compile_and_allocate, HardwareSpec, ProgramSpec};
 use std::{fs, path::PathBuf, process};
 use structopt::StructOpt;
 
@@ -101,7 +101,8 @@ fn run(opt: Opt) -> Fallible<()> {
             let source = fs::read_to_string(source_path)?;
 
             // Compile and execute
-            let mut machine = compile(&hardware_spec, &program_spec, source)?;
+            let mut machine =
+                compile_and_allocate(&hardware_spec, &program_spec, source)?;
             let success = machine.execute_all()?;
 
             println!(

--- a/api/src/server/websocket.rs
+++ b/api/src/server/websocket.rs
@@ -4,7 +4,8 @@ use actix_web::{get, web, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use diesel::{prelude::*, PgConnection};
 use gdlk::{
-    compile, CompileErrors, HardwareSpec, Machine, ProgramSpec, RuntimeError,
+    compile_and_allocate, CompileErrors, HardwareSpec, Machine, ProgramSpec,
+    RuntimeError,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -135,7 +136,7 @@ impl ProgramWebsocket {
         Ok(match socket_msg {
             IncomingEvent::Compile { source } => {
                 // Compile the program into a machine
-                self.machine = Some(compile(
+                self.machine = Some(compile_and_allocate(
                     &self.hardware_spec,
                     &self.program_spec,
                     source,

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -1,5 +1,5 @@
 //! This module holds all the different types that can appear in our ASTs. There
-//! should be little to no functionality implemented here, just basic structs.
+//! is no functionality implemented here, just basic types.
 
 use crate::consts::{REG_INPUT_LEN, REG_STACK_LEN_PREFIX, REG_USER_PREFIX};
 use serde::Serialize;
@@ -110,33 +110,49 @@ pub enum Jump {
     Jgz(ValueSource),
 }
 
-/// A statement is one complete parseable element. Generally, each statement
-/// goes on its own line in the source.
-#[derive(Clone, Debug, PartialEq)]
-pub enum SourceStatement {
-    Label(Label),
-    Operator(Operator),
-    /// Jump to the given label
-    Jump(Jump, Label),
+/// All types unique to the source AST live here
+pub mod source {
+    use super::*;
+
+    /// A statement is one complete parseable element. Generally, each statement
+    /// goes on its own line in the source.
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum Statement {
+        Label(Label),
+        Operator(Operator),
+        /// Jump to the given label
+        Jump(Jump, Label),
+    }
+
+    /// A parsed and untransformed program
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Program {
+        pub body: Vec<Statement>,
+    }
 }
 
-/// A parsed and untransformed program
-#[derive(Clone, Debug, PartialEq)]
-pub struct SourceProgram {
-    pub body: Vec<SourceStatement>,
-}
+/// All types unique to the compiled AST live here
+pub mod compiled {
+    use super::*;
 
-/// An executable instruction. These are the instructions that machines actually
-/// execute.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum Instruction {
-    Operator(Operator),
-    /// These jumps are relative: In `Jmp(n)`, `n` is relative to the current
-    /// program counter.
-    /// - `Jmp(-1)` repeats the previous instruction
-    /// - `Jmp(0)` repeats this instruction (so create an infinite loop)
-    /// - `Jmp(1)` goes to the next instruction (a no-op)
-    /// - `Jmp(2)` skips the next instruction
-    /// - etc...
-    Jump(Jump, isize),
+    /// An executable instruction. These are the instructions that machines
+    /// actually execute.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum Instruction {
+        Operator(Operator),
+        /// These jumps are relative: In `Jmp(n)`, `n` is relative to the
+        /// current program counter.
+        /// - `Jmp(-1)` repeats the previous instruction
+        /// - `Jmp(0)` repeats this instruction (so create an infinite loop)
+        /// - `Jmp(1)` goes to the next instruction (a no-op)
+        /// - `Jmp(2)` skips the next instruction
+        /// - etc...
+        Jump(Jump, isize),
+    }
+
+    /// A compiled program, ready to be executed
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Program {
+        pub instructions: Vec<Instruction>,
+    }
 }

--- a/core/src/delabel.rs
+++ b/core/src/delabel.rs
@@ -1,15 +1,15 @@
 use crate::{
-    ast::{Instruction, Label, SourceProgram, SourceStatement},
+    ast::{compiled, source, Label},
     Compiler,
 };
 use std::collections::HashMap;
 
 /// Build a mapping of all labels to the their instruction indexes. The indexes
 /// exclude the labels themselves.
-fn map_labels(body: &[SourceStatement]) -> HashMap<Label, isize> {
+fn map_labels(body: &[source::Statement]) -> HashMap<Label, isize> {
     let mut label_map: HashMap<Label, isize> = HashMap::new();
     for (i, stmt) in body.iter().enumerate() {
-        if let SourceStatement::Label(label) = stmt {
+        if let source::Statement::Label(label) = stmt {
             // Need subtract 1 for each label above us (because they will be
             // removed from the list)
             label_map.insert(label.into(), (i - label_map.len()) as isize);
@@ -18,34 +18,39 @@ fn map_labels(body: &[SourceStatement]) -> HashMap<Label, isize> {
     label_map
 }
 
-impl Compiler<SourceProgram> {
+impl Compiler<source::Program> {
     /// Removes labels from the source, replacing their references with relative
     /// index offsets.
-    pub fn delabel(self) -> Compiler<Vec<Instruction>> {
+    pub fn delabel(self) -> Compiler<compiled::Program> {
         let label_map = map_labels(&self.0.body);
 
-        let instrs: Vec<Instruction> = self
+        let instructions: Vec<compiled::Instruction> = self
             .0
             .body
             .into_iter()
             // Need to filter FIRST so labels don't get tracked in the indexes
             .filter(|stmt| match stmt {
-                SourceStatement::Label(_) => false,
+                source::Statement::Label(_) => false,
                 _ => true,
             })
             .enumerate()
             .map(|(i, stmt)| match stmt {
-                SourceStatement::Label(_) => panic!("Shouldn't get here!"),
-                SourceStatement::Operator(op) => Instruction::Operator(op),
-                SourceStatement::Jump(jump, label) => Instruction::Jump(
-                    jump,
-                    // Get a relative offset to the label
-                    // the program would have to be VERY big for this to break
-                    *label_map.get(&label).unwrap() - i as isize,
-                ),
+                source::Statement::Label(_) => unreachable!(),
+                source::Statement::Operator(op) => {
+                    compiled::Instruction::Operator(op)
+                }
+                source::Statement::Jump(jump, label) => {
+                    compiled::Instruction::Jump(
+                        jump,
+                        // Get a relative offset to the label
+                        // the program would have to be VERY big for this to
+                        // break
+                        *label_map.get(&label).unwrap() - i as isize,
+                    )
+                }
             })
-            .collect::<Vec<Instruction>>();
-        Compiler(instrs)
+            .collect();
+        Compiler(compiled::Program { instructions })
     }
 }
 
@@ -57,23 +62,27 @@ mod tests {
     #[test]
     fn test_delabel() {
         let body = vec![
-            SourceStatement::Label("START".into()),
-            SourceStatement::Jump(Jump::Jmp, "START".into()),
-            SourceStatement::Operator(Operator::Read(RegisterRef::User(0))),
-            SourceStatement::Jump(Jump::Jmp, "START".into()),
-            SourceStatement::Jump(Jump::Jmp, "END".into()),
-            SourceStatement::Operator(Operator::Read(RegisterRef::User(0))),
-            SourceStatement::Label("END".into()),
+            source::Statement::Label("START".into()),
+            source::Statement::Jump(Jump::Jmp, "START".into()),
+            source::Statement::Operator(Operator::Read(RegisterRef::User(0))),
+            source::Statement::Jump(Jump::Jmp, "START".into()),
+            source::Statement::Jump(Jump::Jmp, "END".into()),
+            source::Statement::Operator(Operator::Read(RegisterRef::User(0))),
+            source::Statement::Label("END".into()),
         ];
-        let compiler = Compiler(SourceProgram { body });
+        let compiler = Compiler(source::Program { body });
         assert_eq!(
-            compiler.delabel().0,
+            compiler.delabel().0.instructions,
             vec![
-                Instruction::Jump(Jump::Jmp, 0),
-                Instruction::Operator(Operator::Read(RegisterRef::User(0))),
-                Instruction::Jump(Jump::Jmp, -2),
-                Instruction::Jump(Jump::Jmp, 2),
-                Instruction::Operator(Operator::Read(RegisterRef::User(0))),
+                compiled::Instruction::Jump(Jump::Jmp, 0),
+                compiled::Instruction::Operator(Operator::Read(
+                    RegisterRef::User(0)
+                )),
+                compiled::Instruction::Jump(Jump::Jmp, -2),
+                compiled::Instruction::Jump(Jump::Jmp, 2),
+                compiled::Instruction::Operator(Operator::Read(
+                    RegisterRef::User(0)
+                )),
             ]
         );
     }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -48,7 +48,7 @@ pub enum CompileError {
 #[derive(Debug, PartialEq, Fail, Serialize)]
 pub enum RuntimeError {
     /// Tried to push onto stack that is at capacity
-    #[fail(display = "Overflow on stack {}", 0)]
+    #[fail(display = "Overflow on stack S{}", 0)]
     StackOverflow(StackIdentifier),
 
     /// READ attempted while input is empty
@@ -56,7 +56,7 @@ pub enum RuntimeError {
     EmptyInput,
 
     /// POP attempted while stack is empty
-    #[fail(display = "Cannot pop from empty stack {}", 0)]
+    #[fail(display = "Cannot pop from empty stack S{}", 0)]
     EmptyStack(StackIdentifier),
 
     /// Too many cycles in the program

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -52,7 +52,7 @@ pub use error::*;
 pub use machine::*;
 pub use models::*;
 
-use ast::Instruction;
+use ast::compiled::Program;
 use std::fmt::Debug;
 use validator::Validate;
 
@@ -114,10 +114,11 @@ impl Compiler<String> {
     }
 }
 
-impl Compiler<Vec<Instruction>> {
-    /// Compiles a program into a <Machine>. This takes a hardware spec, which
-    /// the program will execute on, and a program spec, which the program will
-    /// try to match, and builds a machine around it so that it can be executed.
+impl Compiler<Program> {
+    /// Alocates a <Machine> for a compiled program. This takes a hardware spec,
+    /// which the program will execute on, and a program spec, which the
+    /// program will try to match, and builds a machine around the program so
+    /// that it can be executed.
     pub fn compile(
         self,
         hardware_spec: &HardwareSpec,

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{
-        Instruction, Jump, LangValue, Operator, RegisterRef, StackIdentifier,
-        ValueSource,
+        compiled::{Instruction, Program},
+        Jump, LangValue, Operator, RegisterRef, StackIdentifier, ValueSource,
     },
     consts::MAX_CYCLE_COUNT,
     debug,
@@ -27,7 +27,7 @@ pub struct Machine {
     // serialization. We store these ourselves instead of keeping references
     // to the originals because it just makes life a lot easier.
     #[serde(skip)]
-    program: Vec<Instruction>,
+    program: Program,
     #[serde(skip)]
     expected_output: Vec<LangValue>,
     #[serde(skip)]
@@ -59,7 +59,7 @@ impl Machine {
     pub fn new(
         hardware_spec: &HardwareSpec,
         program_spec: &ProgramSpec,
-        program: Vec<Instruction>,
+        program: Program,
     ) -> Self {
         Self {
             // Static data
@@ -174,6 +174,7 @@ impl Machine {
 
         let instr = *self
             .program
+            .instructions
             .get(self.program_counter)
             .ok_or(RuntimeError::ProgramTerminated)?;
 
@@ -280,7 +281,7 @@ impl Machine {
 
     /// Checks if this machine has finished executing.
     pub fn is_complete(&self) -> bool {
-        self.program_counter >= self.program.len()
+        self.program_counter >= self.program.instructions.len()
     }
 
     /// Checks if this machine has completed successfully. The criteria are:

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -46,3 +46,13 @@ pub struct ProgramSpec {
     #[validate(length(max = 256))]
     pub expected_output: Vec<LangValue>,
 }
+
+// Useful for creating this type in tests
+impl Default for ProgramSpec {
+    fn default() -> Self {
+        Self {
+            input: vec![],
+            expected_output: vec![],
+        }
+    }
+}

--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{compile, HardwareSpec, ProgramSpec};
+use gdlk::{compile, HardwareSpec};
 
 /// Compiles the program for the given hardware, expecting compile error(s).
 /// Panics if the program compiles successfully, or if the wrong set of
@@ -12,16 +12,7 @@ fn expect_compile_errors(
     expected_errors: &[&str],
 ) {
     // Compile from hardware+src
-    let actual_errors = compile(
-        &hardware_spec,
-        // This won't be used, just use bullshit values
-        &ProgramSpec {
-            input: vec![],
-            expected_output: vec![],
-        },
-        src.into(),
-    )
-    .unwrap_err();
+    let actual_errors = compile(&hardware_spec, src.into()).unwrap_err();
     assert_eq!(format!("{}", actual_errors), expected_errors.join("\n"));
 }
 

--- a/core/tests/runtime_error.rs
+++ b/core/tests/runtime_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{compile, HardwareSpec, ProgramSpec};
+use gdlk::{compile_and_allocate, HardwareSpec, ProgramSpec};
 
 /// Compiles the program for the given hardware, executes it under the given
 /// program spec, and expects a runtime error. Panics if the program executes
@@ -14,7 +14,8 @@ fn expect_runtime_error(
 ) {
     // Compile from hardware+src
     let mut machine =
-        compile(&hardware_spec, &program_spec, src.into()).unwrap();
+        compile_and_allocate(&hardware_spec, &program_spec, src.into())
+            .unwrap();
 
     // Execute to completion
     let actual_error = machine.execute_all().unwrap_err();

--- a/core/tests/runtime_error.rs
+++ b/core/tests/runtime_error.rs
@@ -22,8 +22,51 @@ fn expect_runtime_error(
 }
 
 #[test]
+fn test_stack_overflow() {
+    expect_runtime_error(
+        HardwareSpec {
+            num_registers: 1,
+            num_stacks: 1,
+            max_stack_length: 3,
+        },
+        ProgramSpec::default(),
+        "
+        SET RX0 4
+        START:
+        PUSH RX0 S0
+        SUB RX0 1
+        JGZ RX0 START
+        ",
+        "Overflow on stack S0",
+    );
+}
+
+#[test]
+fn test_empty_input() {
+    expect_runtime_error(
+        HardwareSpec::default(),
+        ProgramSpec::default(),
+        "READ RX0",
+        "No input available to read",
+    );
+}
+
+#[test]
+fn test_empty_stack() {
+    expect_runtime_error(
+        HardwareSpec {
+            num_registers: 1,
+            num_stacks: 1,
+            max_stack_length: 3,
+        },
+        ProgramSpec::default(),
+        "POP S0 RX0",
+        "Cannot pop from empty stack S0",
+    );
+}
+
+#[test]
 fn test_exceed_max_cycle_count() {
-    // We can exit successfully with exactly the maximum number of cycles
     expect_runtime_error(
         HardwareSpec::default(),
         ProgramSpec {

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -135,17 +135,12 @@ fn test_cmp() {
 
 #[test]
 fn test_jumps() {
-    let hw_spec = HardwareSpec {
-        num_registers: 1,
-        num_stacks: 0,
-        max_stack_length: 0,
-    };
     let program_spec = ProgramSpec {
         input: vec![],
         expected_output: vec![1],
     };
     execute_expect_success(
-        hw_spec.clone(),
+        HardwareSpec::default(),
         program_spec.clone(),
         "
         JMP GOOD
@@ -156,7 +151,7 @@ fn test_jumps() {
         ",
     );
     execute_expect_success(
-        hw_spec.clone(),
+        HardwareSpec::default(),
         program_spec.clone(),
         "
         JEZ 0 GOOD
@@ -168,7 +163,7 @@ fn test_jumps() {
         ",
     );
     execute_expect_success(
-        hw_spec.clone(),
+        HardwareSpec::default(),
         program_spec.clone(),
         "
         JNZ 1 GOOD
@@ -180,7 +175,7 @@ fn test_jumps() {
         ",
     );
     execute_expect_success(
-        hw_spec.clone(),
+        HardwareSpec::default(),
         program_spec.clone(),
         "
         JLZ -10 GOOD
@@ -192,7 +187,7 @@ fn test_jumps() {
         ",
     );
     execute_expect_success(
-        hw_spec,
+        HardwareSpec::default(),
         program_spec,
         "
         JGZ 3 GOOD

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -3,7 +3,7 @@
 //! outcome.
 
 use gdlk::{
-    ast::LangValue, compile, HardwareSpec, Machine, ProgramSpec,
+    ast::LangValue, compile_and_allocate, HardwareSpec, Machine, ProgramSpec,
     MAX_CYCLE_COUNT,
 };
 
@@ -17,7 +17,8 @@ fn execute_expect_success(
 ) -> Machine {
     // Compile from hardware+src
     let mut machine =
-        compile(&hardware_spec, &program_spec, src.into()).unwrap();
+        compile_and_allocate(&hardware_spec, &program_spec, src.into())
+            .unwrap();
 
     // Execute to completion
     let success = machine.execute_all().unwrap();


### PR DESCRIPTION
- Renamed `compile` -> `compile_and_allocate`
- Added a new `compile` that compiles the program and just returns the compiled AST
- Added more tests for runtime values