### PR TITLE
Improve validate error handling

### DIFF
--- a/api/src/models/hardware.rs
+++ b/api/src/models/hardware.rs
@@ -3,6 +3,7 @@ use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
     sql_types::Text, Identifiable, Queryable,
 };
+use gdlk::Valid;
 use std::convert::TryFrom;
 use validator::{Validate, ValidationErrors};
 
@@ -55,6 +56,21 @@ impl TryFrom<HardwareSpec> for gdlk::HardwareSpec {
         };
         val.validate()?;
         Ok(val)
+    }
+}
+
+impl TryFrom<HardwareSpec> for Valid<gdlk::HardwareSpec> {
+    type Error = ValidationErrors;
+
+    fn try_from(other: HardwareSpec) -> Result<Self, Self::Error> {
+        Valid::validate(gdlk::HardwareSpec {
+            // These conversions are safe because of the validate() call.
+            // The validation _should_ never fail because of the DB constraints,
+            // but we validate here just to be safe.
+            num_registers: other.num_registers as usize,
+            num_stacks: other.num_stacks as usize,
+            max_stack_length: other.max_stack_length as usize,
+        })
     }
 }
 

--- a/api/src/models/program.rs
+++ b/api/src/models/program.rs
@@ -10,9 +10,9 @@ use diesel::{
     sql_types::{Int4, Text},
     Identifiable, Queryable,
 };
-use gdlk::ast::LangValue;
+use gdlk::{ast::LangValue, Valid};
 use std::convert::TryFrom;
-use validator::{Validate, ValidationErrors};
+use validator::ValidationErrors;
 
 /// Inner join between program_specs and hardware_specs
 type InnerJoinSpecs =
@@ -77,16 +77,14 @@ impl ProgramSpec {
     }
 }
 
-impl TryFrom<ProgramSpec> for gdlk::ProgramSpec {
+impl TryFrom<ProgramSpec> for Valid<gdlk::ProgramSpec> {
     type Error = ValidationErrors;
 
     fn try_from(other: ProgramSpec) -> Result<Self, Self::Error> {
-        let val = Self {
+        Valid::validate(gdlk::ProgramSpec {
             input: other.input,
             expected_output: other.expected_output,
-        };
-        val.validate()?;
-        Ok(val)
+        })
     }
 }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -5,7 +5,6 @@ use std::{
     fmt::{self, Display, Formatter},
     ops::Try,
 };
-use validator::ValidationErrors;
 
 // TODO re-work these error messages
 
@@ -14,11 +13,6 @@ use validator::ValidationErrors;
 /// compiler error. Compiler bugs will always cause a panic.
 #[derive(Debug, PartialEq, Fail, Serialize)]
 pub enum CompileError {
-    /// Validation failed on a [HardwareSpec](crate::HardwareSpec) or
-    /// [ProgramSpec](crate::ProgramSpec)
-    #[fail(display = "Invalid spec: {}", 0)]
-    InvalidSpec(ValidationErrors),
-
     /// Failed to parse the program
     #[fail(display = "Parse error: {}", 0)]
     ParseError(String),

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -8,6 +8,7 @@ use crate::{
     debug,
     error::RuntimeError,
     models::{HardwareSpec, ProgramSpec},
+    util::Valid,
 };
 use serde::Serialize;
 use std::{
@@ -58,29 +59,31 @@ pub struct Machine {
 impl Machine {
     /// Creates a new machine, ready to be executed.
     pub fn new(
-        hardware_spec: &HardwareSpec,
-        program_spec: &ProgramSpec,
+        hardware_spec: &Valid<HardwareSpec>,
+        program_spec: &Valid<ProgramSpec>,
         program: Program<Span>,
     ) -> Self {
+        let hw_spec_inner = hardware_spec.inner();
+        let prog_spec_inner = program_spec.inner();
         Self {
             // Static data
             program,
-            expected_output: program_spec.expected_output.clone(),
-            max_stack_length: hardware_spec.max_stack_length,
+            expected_output: prog_spec_inner.expected_output.clone(),
+            max_stack_length: hw_spec_inner.max_stack_length,
 
             // Runtime state
             program_counter: 0,
-            input: VecDeque::from_iter(program_spec.input.iter().copied()),
+            input: VecDeque::from_iter(prog_spec_inner.input.iter().copied()),
             output: Vec::new(),
             registers: iter::repeat(0)
-                .take(hardware_spec.num_registers)
+                .take(hw_spec_inner.num_registers)
                 .collect(),
             // Initialize `num_stacks` new stacks. Set an initial capacity
             // for each one to prevent grows during program operation
             stacks: iter::repeat_with(|| {
-                Vec::with_capacity(hardware_spec.max_stack_length)
+                Vec::with_capacity(hw_spec_inner.max_stack_length)
             })
-            .take(hardware_spec.num_stacks)
+            .take(hw_spec_inner.num_stacks)
             .collect(),
 
             // Performance stats

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -21,7 +21,7 @@ pub struct HardwareSpec {
     pub max_stack_length: usize,
 }
 
-// Useful for creating this type in tests
+// Useful for tests and prototyping
 impl Default for HardwareSpec {
     fn default() -> Self {
         Self {
@@ -47,7 +47,7 @@ pub struct ProgramSpec {
     pub expected_output: Vec<LangValue>,
 }
 
-// Useful for creating this type in tests
+// Useful for tests and prototyping
 impl Default for ProgramSpec {
     fn default() -> Self {
         Self {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,3 +1,40 @@
+use validator::{Validate, ValidationErrors};
+
+/// A small wrapper struct to indicate that the wrapped value has been
+/// validated. Built on top of <validate>. This struct cannot be constructed
+/// except via <Self::try_from>.
+///
+/// ```
+/// use gdlk::{HardwareSpec, Valid};
+///
+/// let maybe_valid = HardwareSpec {
+///     num_registers: 1,
+///     num_stacks: 1,
+///     max_stack_length: 10,
+/// };
+/// let valid: Valid<HardwareSpec> = Valid::validate(maybe_valid).unwrap();
+/// ```
+pub struct Valid<T: Validate> {
+    inner: T,
+}
+
+impl<T: Validate> Valid<T> {
+    /// Validate the given value, and if validation succeeds, wrap it in a
+    /// <Valid> to indicate it's valid.
+    pub fn validate(value: T) -> Result<Self, ValidationErrors> {
+        // We can't do a blanket TryFrom<T: Validate> implementation because of
+        // this bug https://github.com/rust-lang/rust/issues/50133
+        // Will have to wait for better specialization
+        value.validate()?;
+        Ok(Self { inner: value })
+    }
+
+    /// Get the inner value
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
 /// Macro that can wrap any body, and only executes the body if we are running
 /// in debug mode. Debug mode is enabled by setting the environment variable
 /// DEBUG=true. This compiles away to nothing when --release is used.

--- a/core/src/validate.rs
+++ b/core/src/validate.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     error::{CompileError, CompileErrors},
     models::HardwareSpec,
+    util::Valid,
     Compiler,
 };
 use std::collections::HashSet;
@@ -191,9 +192,9 @@ impl Compiler<Program<Span>> {
     /// errors in a collection.
     pub fn validate(
         self,
-        hardware_spec: &HardwareSpec,
+        hardware_spec: &Valid<HardwareSpec>,
     ) -> Result<Compiler<Program<Span>>, CompileErrors> {
-        validate_body(hardware_spec, &self.0.body)?;
+        validate_body(hardware_spec.inner(), &self.0.body)?;
         Ok(Compiler(self.0))
     }
 }

--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{compile, HardwareSpec};
+use gdlk::{compile, HardwareSpec, Valid};
 
 /// Compiles the program for the given hardware, expecting compile error(s).
 /// Panics if the program compiles successfully, or if the wrong set of
@@ -12,7 +12,8 @@ fn expect_compile_errors(
     expected_errors: &[&str],
 ) {
     // Compile from hardware+src
-    let actual_errors = compile(&hardware_spec, src).unwrap_err();
+    let actual_errors =
+        compile(&Valid::validate(hardware_spec).unwrap(), src).unwrap_err();
     assert_eq!(format!("{}", actual_errors), expected_errors.join("\n"));
 }
 

--- a/core/tests/runtime_error.rs
+++ b/core/tests/runtime_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{compile_and_allocate, HardwareSpec, ProgramSpec};
+use gdlk::{compile_and_allocate, HardwareSpec, ProgramSpec, Valid};
 
 /// Compiles the program for the given hardware, executes it under the given
 /// program spec, and expects a runtime error. Panics if the program executes
@@ -13,8 +13,12 @@ fn expect_runtime_error(
     expected_error: &str,
 ) {
     // Compile from hardware+src
-    let mut machine =
-        compile_and_allocate(&hardware_spec, &program_spec, src).unwrap();
+    let mut machine = compile_and_allocate(
+        &Valid::validate(hardware_spec).unwrap(),
+        &Valid::validate(program_spec).unwrap(),
+        src,
+    )
+    .unwrap();
 
     // Execute to completion
     let actual_error = machine.execute_all().unwrap_err();


### PR DESCRIPTION
Validation errors aren't really compile errors, so this new format lets us break them out, cause it forces the caller to validate the specs before passing them in.

I tried to use `TryFrom` for this, but Rust's generic rules broke it.