### PR TITLE
Add spans to errors and clean up a lot of compiler code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 pkg/*
 node_modules/*
 */target/*
+*.json

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ DEBUG=1 cargo run -- execute -e env.json -i prog.gdlk
 We use nightly Rust. Here's a list of reasons why. If this list every gets empty, we should switch to stable.
 
 - Rust features
-  - [try_trait](https://github.com/rust-lang/rust/issues/42327)
   - [const_fn](https://github.com/rust-lang/rust/issues/57563)
-  - [trait_alias](https://github.com/rust-lang/rust/issues/41517)
 - Rustfmt
   - [merge_imports](https://github.com/rust-lang/rustfmt/issues/3362)
   - [wrap_comments](https://github.com/rust-lang/rustfmt/issues/3347)

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all, unused_must_use, unused_imports)]
 // Need to allow this because Diesel's macros violate it
 #![allow(clippy::single_component_path_imports)]
-#![feature(const_fn, trait_alias)]
+#![feature(const_fn)]
 
 // Diesel hasn't fully moved to Rust 2018 yet so we need this
 #[macro_use]

--- a/api/src/vfs/mod.rs
+++ b/api/src/vfs/mod.rs
@@ -85,7 +85,7 @@ pub struct NodePermissions {
 
 impl NodePermissions {
     /// Check if these permissions permit reads. If not, return a
-    /// <ServerError::PermissionDenied>.
+    /// [ServerError::PermissionDenied].
     pub fn require_read(self) -> Result<()> {
         if self.read {
             Ok(())
@@ -95,7 +95,7 @@ impl NodePermissions {
     }
 
     /// Check if these permissions permit writes. If not, return a
-    /// <ServerError::PermissionDenied>.
+    /// [ServerError::PermissionDenied].
     pub fn require_write(self) -> Result<()> {
         if self.write {
             Ok(())
@@ -121,11 +121,11 @@ const PERMS_RW: NodePermissions = NodePermissions {
 /// reference. In those cases, the only operation that is possible is `create`,
 /// which will create the corresponding node.
 ///
-/// To get a reference to a node, you can use <VirtualFileSystem::get_node>.
+/// To get a reference to a node, you can use [VirtualFileSystem::get_node].
 ///
-/// This type needs to be able to outlive the <VirtualFileSystem> that creates
+/// This type needs to be able to outlive the [VirtualFileSystem] that creates
 /// it, so that it can be passed around for GraphQL purposes. Because of that,
-/// it owns its own copy of <Context>, and that copy holds <Rc>s instead of
+/// it owns its own copy of [Context], and that copy holds [Rc]s instead of
 /// references.
 #[derive(Clone)]
 pub struct NodeReference {
@@ -233,7 +233,7 @@ impl NodeReference {
     /// Create a persistent node for this dangling reference. This function
     /// creates a physical entry for the reference node, so that the reference
     /// is no longer a dangling reference. If this reference is _not_ dangling,
-    /// then this operation should fail with a <ServerError::AlreadyExists>.
+    /// then this operation should fail with a [ServerError::AlreadyExists].
     fn create(&self) -> Result<()> {
         self.vnode.handler.create_node(
             &self.context,
@@ -395,7 +395,7 @@ impl NodeMutation {
 /// might be needed to serve file paths, e.g. DB connections.
 ///
 /// This struct is useful for getting references to particular nodes (see
-/// <Self::get_node>). Once you have a <NodeReference>, you can run
+/// [Self::get_node]). Once you have a [NodeReference], you can run
 /// file operations on it.
 pub struct VirtualFileSystem {
     db_conn: Rc<PooledConnection>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,12 +1,13 @@
 //! Core implementation of the GDLK language. The main usage of this crate is
 //! to compile and execute GDLK programs from source. A GDLK program runs under
-//! a certain [HardwareSpec](HardwareSpec), which defines what resources it
-//! can access during execution. It also runs against a
-//! [ProgramSpec](ProgramSpec), which defines the inputs and expected outputs.
+//! a certain [HardwareSpec], which defines what resources it can access during
+//! execution. It also runs against a [ProgramSpec], which defines the inputs
+//! and expected outputs.
 //!
 //! ```
-//! use gdlk::{HardwareSpec, ProgramSpec, Valid, compile_and_allocate};
+//! use gdlk::{HardwareSpec, ProgramSpec, Valid, Compiler};
 //!
+//! // Create the specs
 //! let hardware_spec = Valid::validate(HardwareSpec {
 //!     num_registers: 1,
 //!     num_stacks: 0,
@@ -16,23 +17,27 @@
 //!     input: vec![1],
 //!     expected_output: vec![2],
 //! }).unwrap();
-//! let source = "
+//!
+//! // Write your program
+//! let source: String = "
 //! READ RX0
 //! ADD RX0 1
 //! WRITE RX0
-//! ";
+//! ".into();
 //!
-//! let mut machine = compile_and_allocate(
-//!     &hardware_spec,
-//!     &program_spec,
-//!     source.into(),
+//! // Compile
+//! let compiled = Compiler::compile(
+//!     source,
+//!     hardware_spec,
 //! ).unwrap();
+//!
+//! // Execute
+//! let mut machine = compiled.allocate(&program_spec);
 //! machine.execute_all().unwrap();
 //! assert!(machine.is_successful());
 //! ```
 
 #![deny(clippy::all, unused_must_use, unused_imports)]
-#![feature(try_trait)]
 
 #[macro_use]
 extern crate validator_derive;
@@ -40,7 +45,7 @@ extern crate validator_derive;
 pub mod ast;
 mod consts;
 mod delabel;
-mod error;
+pub mod error;
 mod machine;
 mod models;
 mod parse;
@@ -48,77 +53,67 @@ mod util;
 mod validate;
 
 pub use consts::MAX_CYCLE_COUNT;
-pub use error::*;
 pub use machine::*;
 pub use models::*;
-pub use util::Valid;
+pub use util::{Span, Valid};
 pub use validator; // Consumers may need this
 
-use ast::{compiled::Program, Span};
+use ast::compiled::Program;
+use error::{CompileError, WithSource};
 use std::fmt::Debug;
 
-/// Compiles a source program, under the constraints of a hardware spec. Returns
-/// the compiled program, or any errors that occurred.
-pub fn compile(
-    hardware_spec: &Valid<HardwareSpec>,
-    source: &str,
-) -> Result<Program<Span>, CompileErrors> {
-    Ok(Compiler::new(source)
+/// Struct used to compile a program. `T` represents the current type of the
+/// program. It starts as a [String], and as the compiler executes, the program
+/// gets transformed. See the library-level documentation for examples on how to
+/// compile and execute a program.
+#[derive(Debug)]
+pub struct Compiler<T: Debug> {
+    // These are deliberately private, to prevent direct construction
+    source: String,
+    hardware_spec: Valid<HardwareSpec>,
+    ast: T,
+}
+
+impl Compiler<()> {
+    /// Compile a source program. Compiles under the constraints of a
+    /// [HardwareSpec], which defines which registers and stacks are valid. The
+    /// resulting compiled program can be used directly (e.g. for interactive
+    /// syntax) or used to allocate a [Machine] that can be executed. See
+    /// library-level documentation for more info.
+    pub fn compile(
+        source: String,
+        hardware_spec: Valid<HardwareSpec>,
+    ) -> Result<Compiler<Program<Span>>, WithSource<CompileError>> {
+        Ok(Self {
+            source,
+            hardware_spec,
+            ast: (),
+        }
         .debug()
         .parse()?
         .debug()
-        .validate(hardware_spec)?
+        .validate()?
         .debug()
         .delabel()
-        .debug()
-        .0)
-}
-
-/// Compiles a source program, under a hardware spec. Then, allocates a new
-/// <Machine> to execute that program. The returned machine can then be
-/// executed.
-pub fn compile_and_allocate(
-    hardware_spec: &Valid<HardwareSpec>,
-    program_spec: &Valid<ProgramSpec>,
-    source: &str,
-) -> Result<Machine, CompileErrors> {
-    Ok(Machine::new(
-        hardware_spec,
-        program_spec,
-        compile(hardware_spec, source)?,
-    ))
-}
-
-/// Struct to contain all compiler pipeline steps. By having this on a struct,
-/// it makes it nice and easy to call functions in order with readability. Each
-/// compiler step should take a `self` param and return a new `Compiler`.
-///
-/// `T` is the current type of the program. This controls which compiler
-/// pipeline stages can be called. For example, if `T` is `()`, then
-/// `.parse` is the only available operation. This allows us to leverage the
-/// type system to enforce assumptions we might make in each compiler stage.
-///
-/// The value in the compiler is deliberately private, to prevent a compiler
-/// from being directly constructed from outside this module. This means that
-/// you must follow the proper pipeline stages to get the compiler to a certain
-/// state.
-#[derive(Debug)]
-struct Compiler<T: Debug>(T);
-
-impl<T: Debug> Compiler<T> {
-    /// Prints out the current state of this compiler, if debug mode is enabled.
-    /// Takes in self and returns the same value, so that this can be used
-    /// in the function call chain.
-    pub fn debug(self) -> Self {
-        debug!(println!("{:?}", &self));
-        self
+        .debug())
     }
 }
 
-impl<'a> Compiler<&'a str> {
-    /// Constructs a new compiler with no internal state. This is how you start
-    /// a fresh compiler pipeline.
-    pub fn new(source: &'a str) -> Self {
-        Compiler(source)
+impl Compiler<Program<Span>> {
+    /// Allocate a new [Machine] to execute a compiled program. The returned
+    /// machine can then be executed. `program_spec` defines the parameters
+    /// under which the program will execute.
+    pub fn allocate(self, program_spec: &Valid<ProgramSpec>) -> Machine {
+        Machine::new(&self.hardware_spec, program_spec, self.ast, self.source)
+    }
+}
+
+impl<T: Debug> Compiler<T> {
+    /// Print out the current state of this compiler, if debug mode is enabled.
+    /// Takes in self and returns the same value, so that this can be used
+    /// in the function call chain.
+    fn debug(self) -> Self {
+        debug!(println!("{:?}", &self));
+        self
     }
 }

--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{compile, HardwareSpec, Valid};
+use gdlk::{Compiler, HardwareSpec, Valid};
 
 /// Compiles the program for the given hardware, expecting compile error(s).
 /// Panics if the program compiles successfully, or if the wrong set of
@@ -13,7 +13,8 @@ fn expect_compile_errors(
 ) {
     // Compile from hardware+src
     let actual_errors =
-        compile(&Valid::validate(hardware_spec).unwrap(), src).unwrap_err();
+        Compiler::compile(src.into(), Valid::validate(hardware_spec).unwrap())
+            .unwrap_err();
     assert_eq!(format!("{}", actual_errors), expected_errors.join("\n"));
 }
 
@@ -27,7 +28,8 @@ fn test_parse_no_newline_after_inst() {
             max_stack_length: 0,
         },
         "READ RX1 WRITE RX2",
-        &["Parse error: Invalid keyword: WRITE RX2"],
+        &["Error on line 1: Parse error: 0: at line 0, in Eof:\
+        \nREAD RX1 WRITE RX2\n         ^\n\n"],
     );
 }
 
@@ -50,14 +52,14 @@ fn test_invalid_user_reg_ref() {
         POP S0 RX8
         ",
         &[
-            "Invalid reference to register @ 2:14 to 2:17",
-            "Invalid reference to register @ 3:15 to 3:18",
-            "Invalid reference to register @ 4:13 to 4:16",
-            "Invalid reference to register @ 5:13 to 5:16",
-            "Invalid reference to register @ 6:13 to 6:16",
-            "Invalid reference to register @ 7:13 to 7:16",
-            "Invalid reference to register @ 8:14 to 8:17",
-            "Invalid reference to register @ 9:16 to 9:19",
+            "Error on line 2: Invalid reference to register `RX1`",
+            "Error on line 3: Invalid reference to register `RX2`",
+            "Error on line 4: Invalid reference to register `RX3`",
+            "Error on line 5: Invalid reference to register `RX4`",
+            "Error on line 6: Invalid reference to register `RX5`",
+            "Error on line 7: Invalid reference to register `RX6`",
+            "Error on line 8: Invalid reference to register `RX7`",
+            "Error on line 9: Invalid reference to register `RX8`",
         ],
     );
 }
@@ -73,7 +75,7 @@ fn test_invalid_stack_reg_ref() {
         "
         SET RX0 RS1
         ",
-        &["Invalid reference to register @ 2:17 to 2:20"],
+        &["Error on line 2: Invalid reference to register `RS1`"],
     );
 }
 
@@ -90,8 +92,8 @@ fn test_invalid_stack_ref() {
         POP S2 RX0
         ",
         &[
-            "Invalid reference to stack @ 2:16 to 2:18",
-            "Invalid reference to stack @ 3:13 to 3:15",
+            "Error on line 2: Invalid reference to stack `S1`",
+            "Error on line 3: Invalid reference to stack `S2`",
         ],
     );
 }
@@ -109,8 +111,8 @@ fn test_unwritable_reg() {
         SET RS0 5
         ",
         &[
-            "Cannot write to read-only register @ 2:13 to 2:16",
-            "Cannot write to read-only register @ 3:13 to 3:16",
+            "Error on line 2: Cannot write to read-only register `RLI`",
+            "Error on line 3: Cannot write to read-only register `RS0`",
         ],
     );
 }

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -3,8 +3,8 @@
 //! outcome.
 
 use gdlk::{
-    ast::LangValue, compile_and_allocate, HardwareSpec, Machine, ProgramSpec,
-    Valid, MAX_CYCLE_COUNT,
+    ast::LangValue, Compiler, HardwareSpec, Machine, ProgramSpec, Valid,
+    MAX_CYCLE_COUNT,
 };
 
 /// Compiles the program for the given hardware, and executes it against the
@@ -17,12 +17,10 @@ fn execute_expect_success(
 ) -> Machine {
     let valid_program_spec = Valid::validate(program_spec).unwrap();
     // Compile from hardware+src
-    let mut machine = compile_and_allocate(
-        &Valid::validate(hardware_spec).unwrap(),
-        &valid_program_spec,
-        src,
-    )
-    .unwrap();
+    let mut machine =
+        Compiler::compile(src.into(), Valid::validate(hardware_spec).unwrap())
+            .unwrap()
+            .allocate(&valid_program_spec);
 
     // Execute to completion
     let success = machine.execute_all().unwrap();


### PR DESCRIPTION
- Added a new `Span` type to hold span metadata
- Reworked the external compiler API so you construct a `Compiler` and call methods on it, instead of just having public functions
- Reworked the errors a lot to hold span and source data
  - Each individual error holds the error type, the span of the code that triggered it, and the source located at that span (just a small copy of the full source code).
  - The parse errors still aren't good (I actually prob made them worse in this PR), I'm gonna work on that next.
- Fixed a bunch of broken doc links
  - Turns out the `<Target>` syntax doesn't work, idk why I thought it did. I changed those all to `[Target]` instead.
- Cleaned up a few feature flags that we aren't using anymore

## Examples

### Compile Errors

#### Source

```
READ RX1
PUSH RX1 S0
POP S0 RLI
LBL:
LBL:
LBL:
JMP LBL1
```

#### Output

```
Error on line 5: Duplicate decalaration of label `LBL:`, originally defined on line 4
    |
  4 | LBL:
  5 | LBL:
    | ^^^^
  6 | LBL:
    |

Error on line 6: Duplicate decalaration of label `LBL:`, originally defined on line 4
    |
  5 | LBL:
  6 | LBL:
    | ^^^^
  7 | JMP LBL1
    |

Error on line 1: Invalid reference to register `RX1`
    |
  1 | READ RX1
    |      ^^^
  2 | PUSH RX1 S0
    |

Error on line 2: Invalid reference to register `RX1`
    |
  1 | READ RX1
  2 | PUSH RX1 S0
    |      ^^^
  3 | POP S0 RLI
    |

Error on line 2: Invalid reference to stack `S0`
    |
  1 | READ RX1
  2 | PUSH RX1 S0
    |          ^^
  3 | POP S0 RLI
    |

Error on line 3: Invalid reference to stack `S0`
    |
  2 | PUSH RX1 S0
  3 | POP S0 RLI
    |     ^^
  4 | LBL:
    |

Error on line 7: Invalid reference to label `LBL1`
    |
  6 | LBL:
  7 | JMP LBL1
    |     ^^^^
    |
```

### Runtime Errors

#### Source

```
START:
READ RX0
JMP START
```

#### Output

```
Error on line 2: Read attempted while input is empty
    |
  1 | START:
  2 | READ RX0
    | ^^^^^^^^
  3 | JMP START
    |
```