### PR TITLE
Better parse errors

### DIFF
--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -1,41 +1,101 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{Compiler, HardwareSpec, Valid};
+use gdlk::{ast::LangValue, Compiler, HardwareSpec, Valid};
 
 /// Compiles the program for the given hardware, expecting compile error(s).
 /// Panics if the program compiles successfully, or if the wrong set of
 /// errors is returned.
-fn expect_compile_errors(
-    hardware_spec: HardwareSpec,
-    src: &str,
-    expected_errors: &[&str],
-) {
-    // Compile from hardware+src
-    let actual_errors =
-        Compiler::compile(src.into(), Valid::validate(hardware_spec).unwrap())
-            .unwrap_err();
-    assert_eq!(format!("{}", actual_errors), expected_errors.join("\n"));
+macro_rules! assert_compile_errors {
+    ($hw_spec:expr, $src:expr, $expected_errors:expr $(,)?) => {
+        // Compile from hardware+src
+        let actual_errors: Vec<String> =
+            Compiler::compile($src.into(), Valid::validate($hw_spec).unwrap())
+                .unwrap_err()
+                .errors()
+                .iter()
+                .map(|err| format!("{}", err))
+                .collect();
+        let strs: Vec<&str> =
+            actual_errors.iter().map(String::as_str).collect();
+        assert_eq!(strs.as_slice(), $expected_errors);
+    };
+}
+
+/// Macro to compile a program and expect a particular compiler error.
+macro_rules! assert_parse_error {
+    ($src:expr, $expected_error:expr $(,)?) => {
+        let actual_errors = Compiler::compile(
+            $src.into(),
+            Valid::validate(HardwareSpec::default()).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(format!("{}", actual_errors), $expected_error);
+    };
 }
 
 #[test]
-fn test_parse_no_newline_after_inst() {
-    // TODO: make this error nicer
-    expect_compile_errors(
-        HardwareSpec {
-            num_registers: 1,
-            num_stacks: 0,
-            max_stack_length: 0,
-        },
+fn test_parse_errors() {
+    // Operators
+    assert_parse_error!(
+        "
+        READ RX0
+        READ RW0
+        READ RX0
+        ",
+        "Syntax error at 3:14: Expected register reference",
+    );
+    assert_parse_error!(
+        "READ",
+        "Syntax error at 1:5: Expected register reference",
+    );
+    assert_parse_error!("WRITE", "Syntax error at 1:6: Expected value");
+    assert_parse_error!(
+        "READ RW0",
+        "Syntax error at 1:6: Expected register reference"
+    );
+    assert_parse_error!("RAD RX0", "Syntax error at 1:1: Expected statement",);
+    assert_parse_error!("READE RX0", "Syntax error at 1:1: Expected statement",);
+    assert_parse_error!("PUSH STEVE S0", "Syntax error at 1:6: Expected value");
+    assert_parse_error!(
+        "PUSH RX0 T0",
+        "Syntax error at 1:10: Expected stack reference",
+    );
+    assert_parse_error!(
         "READ RX1 WRITE RX2",
-        &["Error on line 1: Parse error: 0: at line 0, in Eof:\
-        \nREAD RX1 WRITE RX2\n         ^\n\n"],
+        "Syntax error at 1:10: Expected end of statement",
+    );
+
+    // Jumps/labels
+    assert_parse_error!("JMP", "Syntax error at 1:4: Expected label");
+    assert_parse_error!("JEZ", "Syntax error at 1:4: Expected value");
+    assert_parse_error!("JEZ RX0", "Syntax error at 1:8: Expected label");
+    assert_parse_error!("JEZ RW0 LABEL", "Syntax error at 1:5: Expected value");
+    assert_parse_error!(
+        "LABEL:JMP LABEL",
+        "Syntax error at 1:7: Expected end of statement"
+    );
+    // These errors aren't the best, but eh close enough
+    assert_parse_error!("JMP BAD-LABEL", "Syntax error at 1:4: Expected label");
+    assert_parse_error!(
+        "BAD-LABEL:",
+        "Syntax error at 1:1: Expected statement"
+    );
+
+    // Invalid constants (out of range)
+    assert_parse_error!(
+        &format!("SET RX0 {}", LangValue::max_value() as isize + 1),
+        "Syntax error at 1:9: Expected value"
+    );
+    assert_parse_error!(
+        &format!("SET RX0 {}", LangValue::min_value() as isize - 1),
+        "Syntax error at 1:9: Expected value"
     );
 }
 
 #[test]
 fn test_invalid_user_reg_ref() {
-    expect_compile_errors(
+    assert_compile_errors!(
         HardwareSpec {
             num_registers: 1,
             num_stacks: 1,
@@ -52,21 +112,21 @@ fn test_invalid_user_reg_ref() {
         POP S0 RX8
         ",
         &[
-            "Error on line 2: Invalid reference to register `RX1`",
-            "Error on line 3: Invalid reference to register `RX2`",
-            "Error on line 4: Invalid reference to register `RX3`",
-            "Error on line 5: Invalid reference to register `RX4`",
-            "Error on line 6: Invalid reference to register `RX5`",
-            "Error on line 7: Invalid reference to register `RX6`",
-            "Error on line 8: Invalid reference to register `RX7`",
-            "Error on line 9: Invalid reference to register `RX8`",
+            "Validation error at 2:14: Invalid reference to register `RX1`",
+            "Validation error at 3:15: Invalid reference to register `RX2`",
+            "Validation error at 4:13: Invalid reference to register `RX3`",
+            "Validation error at 5:13: Invalid reference to register `RX4`",
+            "Validation error at 6:13: Invalid reference to register `RX5`",
+            "Validation error at 7:13: Invalid reference to register `RX6`",
+            "Validation error at 8:14: Invalid reference to register `RX7`",
+            "Validation error at 9:16: Invalid reference to register `RX8`",
         ],
     );
 }
 
 #[test]
 fn test_invalid_stack_reg_ref() {
-    expect_compile_errors(
+    assert_compile_errors!(
         HardwareSpec {
             num_registers: 1,
             num_stacks: 1,
@@ -75,13 +135,13 @@ fn test_invalid_stack_reg_ref() {
         "
         SET RX0 RS1
         ",
-        &["Error on line 2: Invalid reference to register `RS1`"],
+        &["Validation error at 2:17: Invalid reference to register `RS1`"],
     );
 }
 
 #[test]
 fn test_invalid_stack_ref() {
-    expect_compile_errors(
+    assert_compile_errors!(
         HardwareSpec {
             num_registers: 1,
             num_stacks: 1,
@@ -92,15 +152,15 @@ fn test_invalid_stack_ref() {
         POP S2 RX0
         ",
         &[
-            "Error on line 2: Invalid reference to stack `S1`",
-            "Error on line 3: Invalid reference to stack `S2`",
+            "Validation error at 2:16: Invalid reference to stack `S1`",
+            "Validation error at 3:13: Invalid reference to stack `S2`",
         ],
     );
 }
 
 #[test]
 fn test_unwritable_reg() {
-    expect_compile_errors(
+    assert_compile_errors!(
         HardwareSpec {
             num_registers: 1,
             num_stacks: 1,
@@ -111,8 +171,10 @@ fn test_unwritable_reg() {
         SET RS0 5
         ",
         &[
-            "Error on line 2: Cannot write to read-only register `RLI`",
-            "Error on line 3: Cannot write to read-only register `RS0`",
+            "Validation error at 2:13: \
+                Cannot write to read-only register `RLI`",
+            "Validation error at 3:13: \
+                Cannot write to read-only register `RS0`",
         ],
     );
 }

--- a/x.py
+++ b/x.py
@@ -162,10 +162,7 @@ class Test(Command):
         db_url = f"postgres://root:root@db/{API_TEST_DB}"
         run_in_docker_service(
             API_SERVICE,
-            ["diesel", "migration", "run"],
-            # TODO switch to this version once we have enough tables that
-            # diesel and rustfmt stop fighting over schema.rs
-            # ["diesel", "migration", "run", "--locked-schema"],
+            ["diesel", "migration", "run", "--locked-schema"],
             env={"DEBUG": str(int(debug)), "DATABASE_URL": db_url},
         )
         try:


### PR DESCRIPTION
Rewrote a lot of parse code to get this to work. Basically what it's doing is, when there's an error, it goes down the error chain and finds the first error with context, and uses the context to form the error message. We're not using `convert_error` anymore, cause it's kinda shit. Example:

### Source
```
READ XR0
```

### Output
```
Syntax error at 1:6: Expected register reference
    | 
  1 | READ XR0
    |      ^
    | 
```

Take a look at the tests for more examples. Lemme know if you think of any possible parse errors that I didn't cover.