### PR TITLE
Couple small cleanups

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,7 +42,7 @@
 // Re-export dependencies that consumers may need
 pub use validator;
 #[macro_use]
-pub extern crate validator_derive;
+extern crate validator_derive;
 
 pub mod ast;
 mod consts;

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -66,28 +66,26 @@ impl Machine {
         program: Program<Span>,
         source: String,
     ) -> Self {
-        let hw_spec_inner = hardware_spec.inner();
-        let prog_spec_inner = program_spec.inner();
         Self {
             // Static data
             program,
             source,
-            expected_output: prog_spec_inner.expected_output.clone(),
-            max_stack_length: hw_spec_inner.max_stack_length,
+            expected_output: program_spec.expected_output.clone(),
+            max_stack_length: hardware_spec.max_stack_length,
 
             // Runtime state
             program_counter: 0,
-            input: VecDeque::from_iter(prog_spec_inner.input.iter().copied()),
+            input: VecDeque::from_iter(program_spec.input.iter().copied()),
             output: Vec::new(),
             registers: iter::repeat(0)
-                .take(hw_spec_inner.num_registers)
+                .take(hardware_spec.num_registers)
                 .collect(),
             // Initialize `num_stacks` new stacks. Set an initial capacity
             // for each one to prevent grows during program operation
             stacks: iter::repeat_with(|| {
-                Vec::with_capacity(hw_spec_inner.max_stack_length)
+                Vec::with_capacity(hardware_spec.max_stack_length)
             })
-            .take(hw_spec_inner.num_stacks)
+            .take(hardware_spec.num_stacks)
             .collect(),
 
             // Performance stats

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::{
     fmt::{self, Formatter},
     iter,
+    ops::Deref,
 };
 use validator::{Validate, ValidationErrors};
 
@@ -128,9 +129,12 @@ impl<T: Validate> Valid<T> {
         value.validate()?;
         Ok(Self { inner: value })
     }
+}
 
-    /// Get the validated value.
-    pub fn inner(&self) -> &T {
+impl<T: Validate> Deref for Valid<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
         &self.inner
     }
 }

--- a/core/src/validate.rs
+++ b/core/src/validate.rs
@@ -235,7 +235,7 @@ impl Compiler<Program<Span>> {
     pub(crate) fn validate(
         self,
     ) -> Result<Compiler<Program<Span>>, WithSource<CompileError>> {
-        let errors = validate_body(self.hardware_spec.inner(), &self.ast.body);
+        let errors = validate_body(&self.hardware_spec, &self.ast.body);
         if errors.is_empty() {
             Ok(self)
         } else {

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -28,7 +28,7 @@ fn execute_expect_success(
     // Make sure program terminated successfully
     // Check each bit of state individually to make debugging easier
     assert_eq!(machine.input, Vec::new() as Vec<LangValue>);
-    assert_eq!(machine.output, valid_program_spec.inner().expected_output);
+    assert_eq!(machine.output, valid_program_spec.expected_output);
     // Final sanity check, in case we change the criteria for success
     assert!(success);
     machine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       POSTGRES_DB: gdlk
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
+    command: postgres -c log_statement=all
     ports:
       - "5432:5432"
 

--- a/x.py
+++ b/x.py
@@ -161,7 +161,11 @@ class Test(Command):
         run_in_docker_service(DB_SERVICE, ["createdb", API_TEST_DB])
         run_in_docker_service(
             DB_SERVICE,
-            ["psql", API_TEST_DB, "-f", "/docker-entrypoint-initdb.d/*"],
+            [
+                "sh",
+                "-c",
+                f"psql {API_TEST_DB} -f /docker-entrypoint-initdb.d/*",
+            ],
         )
 
         db_url = f"postgres://root:root@db/{API_TEST_DB}"


### PR DESCRIPTION
- Added logging to postgres in development
- Fixed DB setup during tests. I'm actually not sure why it was passing in the CI before, cause it was failing for me locally. 
- Replaced the `Valid::inner()` method with an `impl Deref`. It's easier to use and more idiomatic. Not sure why I didn't think of it originally.