### PR TITLE
Add users and user programs to GQL API

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -24,6 +24,12 @@ type Query {
   Fetch a single node, of any type, via a UUID.
   """
   node(id: ID!): Node @juniper(ownership: "owned")
+
+  """
+  Get a single user by their username.
+  """
+  user(username: String!): UserNode @juniper(ownership: "owned")
+
   """
   Get a single hardware spec by its slug.
   """
@@ -91,6 +97,26 @@ type PageInfo {
   """
   hasNextPage: Boolean! @juniper(infallible: true, ownership: "owned")
 }
+
+# ===== USER =====
+
+"""
+A user of the platform.
+"""
+type UserNode implements Node {
+  """
+  UUID for this node.
+  """
+  id: ID! @juniper(infallible: true, ownership: "owned")
+
+  """
+  Unique name for this user. This is public, and can/should be presented to
+  the user and others.
+  """
+  username: String! @juniper(infallible: true)
+}
+
+# ===== HARDWARE SPEC =====
 
 """
 A hardware spec defines the hardware parameters that a program runs under.
@@ -160,6 +186,8 @@ type HardwareSpecConnection implements ConnectionInterface {
   edges: [HardwareSpecEdge!]! @juniper(ownership: "owned")
 }
 
+# ===== PROGRAM SPEC =====
+
 """
 A definition of a particular program for a piece of hardware. This defines the
 parameters that a program is supposed to match. In order words, this is a single
@@ -184,6 +212,30 @@ type ProgramSpecNode implements Node {
   The output that the program is expected to give.
   """
   expectedOutput: [Int!]! @juniper(infallible: true)
+
+  """
+  The hardware that this program runs on.
+  """
+  hardwareSpec: HardwareSpecNode! @juniper(ownership: "owned")
+
+  """
+  A single user's single solution to this program spec.
+
+  TODO remove the username field and filter by the logged in user instead
+  """
+  userProgram(username: String!, fileName: String!): UserProgramNode
+    @juniper(ownership: "owned")
+
+  """
+  All of a single user's solutions to this program spec.
+
+  TODO remove the username field and filter by the logged in user instead
+  """
+  userPrograms(
+    username: String!
+    first: Int
+    after: Cursor
+  ): UserProgramConnection! @juniper(ownership: "owned")
 }
 
 """
@@ -201,7 +253,7 @@ type ProgramSpecEdge implements Edge {
 }
 
 """
-A collection of HardwareSpecNodes.
+A collection of ProgramSpecNodes.
 """
 type ProgramSpecConnection implements ConnectionInterface {
   """
@@ -216,4 +268,69 @@ type ProgramSpecConnection implements ConnectionInterface {
   The queried program specs.
   """
   edges: [ProgramSpecEdge!]! @juniper(ownership: "owned")
+}
+
+# ===== USER PROGRAMS =====
+
+"""
+A user's solution to a particular program spec. One user can have multiple
+solutions per program.
+"""
+type UserProgramNode implements Node {
+  """
+  UUID for this node.
+  """
+  id: ID! @juniper(infallible: true, ownership: "owned")
+
+  """
+  Name for this source file. This is unique among the user-program spec pair.
+  """
+  fileName: String! @juniper(infallible: true)
+
+  """
+  The program source code.
+  """
+  sourceCode: String! @juniper(infallible: true)
+
+  """
+  The user who owns this program code.
+  """
+  user: UserNode! @juniper(ownership: "owned")
+
+  """
+  The program spec for which this code was written.
+  """
+  programSpec: ProgramSpecNode! @juniper(ownership: "owned")
+}
+
+"""
+Edge for UserProgramNode.
+"""
+type UserProgramEdge implements Edge {
+  """
+  The related node.
+  """
+  node: UserProgramNode! @juniper(infallible: true)
+  """
+  Identifier for this edge.
+  """
+  cursor: Cursor! @juniper(infallible: true)
+}
+
+"""
+A collection of UserProgramNodes.
+"""
+type UserProgramConnection implements ConnectionInterface {
+  """
+  See Connection definition.
+  """
+  totalCount: Int! @juniper(ownership: "owned")
+  """
+  See Connection definition.
+  """
+  pageInfo: PageInfo! @juniper(ownership: "owned")
+  """
+  The queried user programs.
+  """
+  edges: [UserProgramEdge!]! @juniper(ownership: "owned")
 }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::all, unused_must_use, unused_imports)]
+// #![deny(clippy::all, unused_must_use, unused_imports)]
 // Need to allow this because Diesel's macros violate it
 #![allow(clippy::single_component_path_imports)]
 #![feature(const_fn)]

--- a/api/src/models/user.rs
+++ b/api/src/models/user.rs
@@ -6,7 +6,8 @@ use diesel::{
 use uuid::Uuid;
 
 /// Expression to filter users by username
-type WithUsername<'a> = dsl::Eq<users::columns::username, Bound<Text, &'a str>>;
+pub type WithUsername<'a> =
+    dsl::Eq<users::columns::username, Bound<Text, &'a str>>;
 
 #[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
 #[table_name = "users"]
@@ -16,12 +17,9 @@ pub struct User {
 }
 
 impl User {
-    /// Filters users by their username. The resulting queryset should contain
-    /// no more than one user.
-    pub fn filter_by_username<'a>(
-        username: &'a str,
-    ) -> dsl::Filter<users::table, WithUsername<'a>> {
-        users::table.filter(users::dsl::username.eq(username))
+    /// Eq clause to compare the username column to a value.
+    pub fn with_username(username: &str) -> WithUsername<'_> {
+        users::dsl::username.eq(username)
     }
 }
 

--- a/api/src/seed.rs
+++ b/api/src/seed.rs
@@ -53,7 +53,8 @@ pub fn seed_db(conn: &PgConnection) -> Result<(), diesel::result::Error> {
         user_id,
         program_spec_id: prog1_spec_id,
         file_name: "program.gdlk",
-        source_code: "READ\nWRITE\nREAD\nWRITE\nREAD\nWRITE\n",
+        source_code:
+            "READ RX0\nWRITE RX0\nREAD RX0\nWRITE RX0\nREAD RX0\nWRITE RX0\n",
     }
     .insert()
     .execute(conn)

--- a/api/src/server/gql/program.rs
+++ b/api/src/server/gql/program.rs
@@ -1,18 +1,21 @@
 use crate::{
     error::ServerResult,
     models,
-    schema::program_specs,
+    schema::{program_specs, user_programs},
     server::gql::{
+        hardware::HardwareSpecNode,
         internal::{GenericEdge, NodeType},
+        user::UserNode,
         ConnectionPageParams, Context, Cursor, PageInfo,
         ProgramSpecConnectionFields, ProgramSpecEdgeFields,
-        ProgramSpecNodeFields,
+        ProgramSpecNodeFields, UserProgramConnectionFields,
+        UserProgramEdgeFields, UserProgramNodeFields,
     },
     util,
 };
 use diesel::{
     dsl, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
-    QueryResult, RunQueryDsl,
+    QueryResult, RunQueryDsl, Table,
 };
 use gdlk::{ast::LangValue, Valid};
 use juniper::ID;
@@ -25,30 +28,16 @@ pub struct ProgramSpecNode {
     pub program_spec: models::ProgramSpec,
 }
 
-impl ProgramSpecNode {
-    /// Query for a program spec by its parent hardware spec, and by slug.
-    pub fn from_slug(
-        conn: &PgConnection,
-        hardware_spec_id: Uuid,
-        slug: &str,
-    ) -> ServerResult<Option<Self>> {
-        Ok(program_specs::table
-            .filter(program_specs::dsl::hardware_spec_id.eq(hardware_spec_id))
-            .filter(program_specs::dsl::slug.eq(slug))
-            .get_result::<models::ProgramSpec>(conn)
-            .optional()?
-            .map(Self::from_model))
+impl From<models::ProgramSpec> for ProgramSpecNode {
+    fn from(model: models::ProgramSpec) -> Self {
+        Self {
+            program_spec: model,
+        }
     }
 }
 
 impl NodeType for ProgramSpecNode {
     type Model = models::ProgramSpec;
-
-    fn from_model(model: Self::Model) -> Self {
-        Self {
-            program_spec: model,
-        }
-    }
 
     fn find(conn: &PgConnection, id: Uuid) -> QueryResult<Self::Model> {
         program_specs::table.find(id).get_result(conn)
@@ -79,6 +68,47 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         _executor: &juniper::Executor<'_, Context>,
     ) -> &Vec<LangValue> {
         &self.program_spec.expected_output
+    }
+
+    fn field_hardware_spec(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, HardwareSpecNode, Walked>,
+    ) -> ServerResult<HardwareSpecNode> {
+        Ok(HardwareSpecNode::find(
+            &executor.context().get_db_conn()? as &PgConnection,
+            self.program_spec.hardware_spec_id,
+        )?
+        .into())
+    }
+
+    fn field_user_program(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserProgramNode, Walked>,
+        username: String,
+        file_name: String,
+    ) -> ServerResult<Option<UserProgramNode>> {
+        Ok(models::UserProgram::filter_by_username_and_program_spec(
+            &username,
+            self.program_spec.id,
+        )
+        .filter(user_programs::dsl::file_name.eq(&file_name))
+        .select(user_programs::table::all_columns())
+        .get_result::<models::UserProgram>(&executor.context().get_db_conn()?)
+        .optional()?
+        .map(UserProgramNode::from))
+    }
+
+    fn field_user_programs(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserProgramConnection, Walked>,
+        username: String,
+        first: Option<i32>,
+        after: Option<Cursor>,
+    ) -> ServerResult<UserProgramConnection> {
+        UserProgramConnection::new(username, self.program_spec.id, first, after)
     }
 }
 
@@ -121,10 +151,10 @@ impl ProgramSpecConnection {
 
     fn get_total_count(&self, context: &Context) -> ServerResult<i32> {
         match program_specs::table
-            .filter(
-                program_specs::dsl::hardware_spec_id.eq(self.hardware_spec_id),
-            )
-            .select(dsl::count(program_specs::id))
+            .filter(models::ProgramSpec::with_hardware_spec(
+                self.hardware_spec_id,
+            ))
+            .select(dsl::count(dsl::count_star()))
             .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
@@ -132,6 +162,7 @@ impl ProgramSpecConnection {
             Err(err) => Err(err.into()),
         }
     }
+
     fn get_edges(
         &self,
         context: &Context,
@@ -140,9 +171,9 @@ impl ProgramSpecConnection {
 
         // Load data from the query
         let mut query = program_specs::table
-            .filter(
-                program_specs::dsl::hardware_spec_id.eq(self.hardware_spec_id),
-            )
+            .filter(models::ProgramSpec::with_hardware_spec(
+                self.hardware_spec_id,
+            ))
             .offset(offset.into())
             .into_boxed();
 
@@ -182,6 +213,181 @@ impl ProgramSpecConnectionFields for ProgramSpecConnection {
         executor: &juniper::Executor<'_, Context>,
         _trail: &QueryTrail<'_, ProgramSpecEdge, Walked>,
     ) -> ServerResult<Vec<ProgramSpecEdge>> {
+        self.get_edges(executor.context())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UserProgramNode {
+    pub user_program: models::UserProgram,
+}
+
+impl From<models::UserProgram> for UserProgramNode {
+    fn from(model: models::UserProgram) -> Self {
+        Self {
+            user_program: model,
+        }
+    }
+}
+
+impl NodeType for UserProgramNode {
+    type Model = models::UserProgram;
+
+    fn find(conn: &PgConnection, id: Uuid) -> QueryResult<Self::Model> {
+        user_programs::table.find(id).get_result(conn)
+    }
+}
+
+impl UserProgramNodeFields for UserProgramNode {
+    fn field_id(&self, _executor: &juniper::Executor<'_, Context>) -> ID {
+        util::uuid_to_gql_id(&self.user_program.id)
+    }
+
+    fn field_file_name(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &String {
+        &self.user_program.file_name
+    }
+
+    fn field_source_code(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &String {
+        &self.user_program.source_code
+    }
+
+    fn field_user(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserNode, Walked>,
+    ) -> ServerResult<UserNode> {
+        Ok(UserNode::find(
+            &executor.context().get_db_conn()? as &PgConnection,
+            self.user_program.user_id,
+        )?
+        .into())
+    }
+
+    fn field_program_spec(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, ProgramSpecNode, Walked>,
+    ) -> ServerResult<ProgramSpecNode> {
+        Ok(ProgramSpecNode::find(
+            &executor.context().get_db_conn()? as &PgConnection,
+            self.user_program.program_spec_id,
+        )?
+        .into())
+    }
+}
+
+pub type UserProgramEdge = GenericEdge<UserProgramNode>;
+
+impl UserProgramEdgeFields for UserProgramEdge {
+    fn field_node(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserProgramNode, Walked>,
+    ) -> &UserProgramNode {
+        self.node()
+    }
+
+    fn field_cursor(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &Cursor {
+        self.cursor()
+    }
+}
+
+/// "Connection" is a concept from Relay. Read more: https://graphql.org/learn/pagination/
+pub struct UserProgramConnection {
+    username: String,
+    program_spec_id: Uuid,
+    page_params: Valid<ConnectionPageParams>,
+}
+
+impl UserProgramConnection {
+    pub fn new(
+        username: String,
+        program_spec_id: Uuid,
+        first: Option<i32>,
+        after: Option<Cursor>,
+    ) -> ServerResult<Self> {
+        Ok(Self {
+            username,
+            program_spec_id,
+            page_params: ConnectionPageParams::new(first, after)?,
+        })
+    }
+
+    fn get_total_count(&self, context: &Context) -> ServerResult<i32> {
+        match models::UserProgram::filter_by_username_and_program_spec(
+            &self.username,
+            self.program_spec_id,
+        )
+        .select(dsl::count(dsl::count_star()))
+        .get_result::<i64>(&context.get_db_conn()?)
+        {
+            // Convert i64 to i32 - if this fails, we're in a rough spot
+            Ok(count) => Ok(count.try_into()?),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn get_edges(
+        &self,
+        context: &Context,
+    ) -> ServerResult<Vec<UserProgramEdge>> {
+        let offset = self.page_params.offset();
+
+        // Load data from the query
+        let mut query =
+            models::UserProgram::filter_by_username_and_program_spec(
+                &self.username,
+                self.program_spec_id,
+            )
+            .select(user_programs::table::all_columns())
+            .offset(offset.into())
+            .into_boxed();
+
+        // Conditionally include limit param
+        if let Some(limit) = self.page_params.limit() {
+            query = query.limit(limit.into());
+        }
+
+        let rows: Vec<models::UserProgram> =
+            query.get_results(&context.get_db_conn()?)?;
+
+        Ok(UserProgramEdge::from_db_rows(rows, offset))
+    }
+}
+
+impl UserProgramConnectionFields for UserProgramConnection {
+    fn field_total_count(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+    ) -> ServerResult<i32> {
+        self.get_total_count(executor.context())
+    }
+
+    fn field_page_info(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, PageInfo, Walked>,
+    ) -> ServerResult<PageInfo> {
+        Ok(PageInfo::from_page_params(
+            &self.page_params,
+            self.get_total_count(executor.context())?,
+        ))
+    }
+
+    fn field_edges(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
+    ) -> ServerResult<Vec<UserProgramEdge>> {
         self.get_edges(executor.context())
     }
 }

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -1,0 +1,41 @@
+use crate::{
+    models,
+    schema::users,
+    server::gql::{internal::NodeType, Context, UserNodeFields},
+    util,
+};
+use diesel::{PgConnection, QueryDsl, QueryResult, RunQueryDsl};
+use juniper::ID;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct UserNode {
+    pub user: models::User,
+}
+
+impl From<models::User> for UserNode {
+    fn from(model: models::User) -> Self {
+        Self { user: model }
+    }
+}
+
+impl NodeType for UserNode {
+    type Model = models::User;
+
+    fn find(conn: &PgConnection, id: Uuid) -> QueryResult<Self::Model> {
+        users::table.find(id).get_result(conn)
+    }
+}
+
+impl UserNodeFields for UserNode {
+    fn field_id(&self, _executor: &juniper::Executor<'_, Context>) -> ID {
+        util::uuid_to_gql_id(&self.user.id)
+    }
+
+    fn field_username(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &String {
+        &self.user.username
+    }
+}

--- a/api/src/server/websocket.rs
+++ b/api/src/server/websocket.rs
@@ -7,7 +7,7 @@ use crate::{
 use actix::{Actor, ActorContext, AsyncContext, StreamHandler};
 use actix_web::{get, web, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
-use diesel::{associations::HasTable, prelude::*, PgConnection};
+use diesel::{prelude::*, PgConnection};
 use gdlk::{
     error::{CompileError, RuntimeError, WithSource},
     validator::ValidationErrors,
@@ -246,8 +246,8 @@ pub async fn ws_program_specs_by_slugs(
     let (program_spec, hardware_spec): (
         models::ProgramSpec,
         models::HardwareSpec,
-    ) = models::ProgramSpec::table()
-        .inner_join(models::HardwareSpec::table())
+    ) = program_specs::table
+        .inner_join(hardware_specs::table)
         .filter(hardware_specs::dsl::slug.eq(&hw_spec_slug))
         .filter(program_specs::dsl::slug.eq(&program_spec_slug))
         .get_result(conn)


### PR DESCRIPTION
Added some new fields to the GQL API, to expose the `users` and `user_programs` tables. I also added a field to go `ProgramSpecNode` -> `HardwareSpecNode`.

I shuffled some query code around, in favor of moving stuff back onto the model types. I think this makes the queries easier to read, let me know what you think.

### Example

#### Query
```graphql
{
  hardwareSpec(slug: "hw1") {
    id
    numRegisters
    programSpec(slug: "prog1") {
      id
      input
      expectedOutput
      userPrograms(username: "user1") {
        edges {
          node {
            fileName
            id
            user {
              id
              username
            }
            sourceCode
          }
        }
      }
    }
  }
}
```

#### Response

```json
{
  "data": {
    "hardwareSpec": {
      "id": "cd22fcb3-00e4-4335-a197-fc97528f9dc6",
      "numRegisters": 1,
      "programSpec": {
        "id": "10dc9147-87b0-4fe4-b626-8e2098aae699",
        "input": [
          1,
          2,
          3
        ],
        "expectedOutput": [
          1,
          2,
          3
        ],
        "userPrograms": {
          "edges": [
            {
              "node": {
                "fileName": "program.gdlk",
                "id": "7f44549f-b1df-4a84-b3e4-63b6465c7a0a",
                "user": {
                  "id": "d0cc05c4-d0c8-4885-8b20-ef8323109f92",
                  "username": "user1"
                },
                "sourceCode": "READ\nWRITE\nREAD\nWRITE\nREAD\nWRITE\n"
              }
            }
          ]
        }
      }
    }
  }
}
```