### PR TITLE
Use base64 encoding for cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +791,7 @@ dependencies = [
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web-actors 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1903,6 +1909,7 @@ dependencies = [
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,7 @@ actix = "0.9"
 actix-web = "2.0"
 actix-web-actors = "2.0"
 actix-rt = "1.0"
+base64 = "^0.12.0"
 diesel = { version = "^1.4.3", features = ["postgres", "r2d2", "uuidv07"] }
 env_logger = "0.7"
 failure = "0.1"

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -222,21 +222,18 @@ type ProgramSpecNode implements Node {
   """
   A single user's single solution to this program spec.
 
-  TODO remove the username field and filter by the logged in user instead
+  TODO remove the userId field and filter by the logged in user instead
   """
-  userProgram(username: ID!, fileName: String!): UserProgramNode
+  userProgram(userId: ID!, fileName: String!): UserProgramNode
     @juniper(ownership: "owned")
 
   """
   All of a single user's solutions to this program spec.
 
-  TODO remove the username field and filter by the logged in user instead
+  TODO remove the userId field and filter by the logged in user instead
   """
-  userPrograms(
-    username: ID!
-    first: Int
-    after: Cursor
-  ): UserProgramConnection! @juniper(ownership: "owned")
+  userPrograms(userId: ID!, first: Int, after: Cursor): UserProgramConnection!
+    @juniper(ownership: "owned")
 }
 
 """

--- a/api/seeds/seed.sql
+++ b/api/seeds/seed.sql
@@ -1,20 +1,26 @@
 WITH user_row AS (
     INSERT INTO users (username) VALUES ('user1') RETURNING id
 ),
-hw_spec_row AS (
+hw_spec_rows AS (
     INSERT INTO hardware_specs (slug, num_registers, num_stacks, max_stack_length)
-        VALUES ('hw1', 1, 0, 0) RETURNING id
+        VALUES ('hw1', 1, 0, 0), ('hw2', 2, 1, 10), ('hw3', 5, 2, 50)
+        RETURNING id, slug
 ),
+
+-- Program specs for hw1
 prog_spec1_row AS (
     INSERT INTO program_specs (slug, hardware_spec_id, input, expected_output)
-        SELECT 'prog1', hw_spec_row.id, '{1,2,3}', '{1,2,3}'
-        FROM hw_spec_row RETURNING id
+        SELECT 'prog1', hw_spec_rows.id, '{1,2,3}', '{1,2,3}'
+        FROM hw_spec_rows WHERE hw_spec_rows.slug = 'hw1'
+        RETURNING id
 ),
 prog_spec2_row AS (
     INSERT INTO program_specs (slug, hardware_spec_id, input, expected_output)
-        SELECT 'prog2', hw_spec_row.id, '{1,2,3}', '{2,4,6}'
-        FROM hw_spec_row RETURNING id
+        SELECT 'prog2', hw_spec_rows.id, '{1,2,3}', '{2,4,6}'
+        FROM hw_spec_rows WHERE hw_spec_rows.slug = 'hw1'
+        RETURNING id
 )
+
 INSERT INTO user_programs (user_id, program_spec_id, file_name, source_code)
     SELECT
         user_row.id, prog_spec1_row.id, 'program.gdlk',

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -25,10 +25,6 @@ pub enum ServerError {
     /// Wrapper for uuid's parse error type
     #[fail(display = "{}", 0)]
     UuidParseError(#[cause] uuid::parser::ParseError),
-
-    /// Wrapper for std's TryFromIntError
-    #[fail(display = "{}", 0)]
-    TryFromIntoError(#[cause] std::num::TryFromIntError),
 }
 
 impl From<r2d2::Error> for ServerError {
@@ -52,12 +48,6 @@ impl From<ValidationErrors> for ServerError {
 impl From<uuid::parser::ParseError> for ServerError {
     fn from(other: uuid::parser::ParseError) -> Self {
         Self::UuidParseError(other)
-    }
-}
-
-impl From<std::num::TryFromIntError> for ServerError {
-    fn from(other: std::num::TryFromIntError) -> Self {
-        Self::TryFromIntoError(other)
     }
 }
 

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -26,11 +26,6 @@ pub enum ServerError {
     #[fail(display = "{}", 0)]
     UuidParseError(#[cause] uuid::parser::ParseError),
 
-    /// Wrapper for std's ParseIntError
-    /// TODO remove this once we switch to base64 for cursors
-    #[fail(display = "{}", 0)]
-    ParseIntError(#[cause] std::num::ParseIntError),
-
     /// Wrapper for std's TryFromIntError
     #[fail(display = "{}", 0)]
     TryFromIntoError(#[cause] std::num::TryFromIntError),
@@ -57,12 +52,6 @@ impl From<ValidationErrors> for ServerError {
 impl From<uuid::parser::ParseError> for ServerError {
     fn from(other: uuid::parser::ParseError) -> Self {
         Self::UuidParseError(other)
-    }
-}
-
-impl From<std::num::ParseIntError> for ServerError {
-    fn from(other: std::num::ParseIntError) -> Self {
-        Self::ParseIntError(other)
     }
 }
 

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -139,7 +139,7 @@ impl HardwareSpecConnection {
 
     fn get_total_count(&self, context: &Context) -> ServerResult<i32> {
         match hardware_specs::table
-            .select(dsl::count(dsl::count_star()))
+            .select(dsl::count_star())
             .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -143,7 +143,7 @@ impl HardwareSpecConnection {
             .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
-            Ok(count) => Ok(count.try_into()?),
+            Ok(count) => Ok(count.try_into().unwrap()),
             Err(err) => Err(err.into()),
         }
     }

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -151,7 +151,6 @@ fn validate_cursor(cursor: &Cursor) -> Result<(), ValidationError> {
 pub struct ConnectionPageParams {
     #[validate(range(min = 0))]
     first: Option<i32>,
-    // #[validate]
     #[validate(custom = "validate_cursor")]
     after: Option<Cursor>,
 }

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -162,7 +162,7 @@ impl ProgramSpecConnection {
             .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
-            Ok(count) => Ok(count.try_into()?),
+            Ok(count) => Ok(count.try_into().unwrap()),
             Err(err) => Err(err.into()),
         }
     }

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -158,7 +158,7 @@ impl ProgramSpecConnection {
             .filter(models::ProgramSpec::with_hardware_spec(
                 self.hardware_spec_id,
             ))
-            .select(dsl::count(dsl::count_star()))
+            .select(dsl::count_star())
             .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -133,7 +133,7 @@ impl UserProgramConnection {
         .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
-            Ok(count) => Ok(count.try_into()?),
+            Ok(count) => Ok(count.try_into().unwrap()),
             Err(err) => Err(err.into()),
         }
     }

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -129,7 +129,7 @@ impl UserProgramConnection {
             self.user_id,
             self.program_spec_id,
         )
-        .select(dsl::count(dsl::count_star()))
+        .select(dsl::count_star())
         .get_result::<i64>(&context.get_db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot


### PR DESCRIPTION
- base64 cursors instead of just stringified ints
- Added two more hardware specs to the seed data
- Cleaned up API errors a bit
  - I'm gonna be doing more work on this soon. We have a few other places that currently return 400-ish errors when they should be 404-ish
- Fixed a couple other API bugs
  - `totalCount` field was broken (I'm surprised diesel didn't catch this error statically)
  - Changed `username` param to `userId` on a couple fields, since they actually expect an ID

## Example Query w/ new cursors and seed data

### Query

```graphql
{
  hardwareSpecs {
    totalCount
    pageInfo {
      startCursor
      endCursor
      hasNextPage
      hasPreviousPage
    }
    edges {
      cursor
      node {
        id
        slug
        programSpecs {
          edges {
            cursor
            node {
              id
              slug
            }
          }
        }
      }
    }
  }
}
```

### Response

```json
{
  "data": {
    "hardwareSpecs": {
      "totalCount": 3,
      "pageInfo": {
        "startCursor": "AAAAAA==",
        "endCursor": "AAAAAg==",
        "hasNextPage": false,
        "hasPreviousPage": false
      },
      "edges": [
        {
          "cursor": "AAAAAA==",
          "node": {
            "id": "57939ed7-e0bd-436c-a540-7e4770facd2a",
            "slug": "hw1",
            "programSpecs": {
              "edges": [
                {
                  "cursor": "AAAAAA==",
                  "node": {
                    "id": "80477d00-89d8-436f-8cdf-3fb4257865f3",
                    "slug": "prog1"
                  }
                },
                {
                  "cursor": "AAAAAQ==",
                  "node": {
                    "id": "6610fbf6-1f90-422b-a851-4ebc7d3a03f9",
                    "slug": "prog2"
                  }
                }
              ]
            }
          }
        },
        {
          "cursor": "AAAAAQ==",
          "node": {
            "id": "4ba1fc7f-926c-43a0-a4f5-bde7f64d50f1",
            "slug": "hw2",
            "programSpecs": {
              "edges": []
            }
          }
        },
        {
          "cursor": "AAAAAg==",
          "node": {
            "id": "a7595041-f24b-429c-876f-6b421e916a3e",
            "slug": "hw3",
            "programSpecs": {
              "edges": []
            }
          }
        }
      ]
    }
  }
}
```