### PR TITLE
Add logging for API errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "gdlk 0.1.0",
  "juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper-from-schema 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -19,6 +19,7 @@ failure = "0.1"
 gdlk = { path = "../core" }
 juniper = "0.14.2"
 juniper-from-schema = "0.5.2"
+log = "^0.4.8"
 r2d2 = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/api/src/bin.rs
+++ b/api/src/bin.rs
@@ -7,6 +7,7 @@ use std::env;
 // mod vfs;
 
 fn run() -> Fallible<()> {
+    env_logger::init();
     let server_host =
         env::var("SERVER_HOST").unwrap_or_else(|_| "localhost:8000".into());
     let pool = util::init_db_conn_pool()?;

--- a/api/src/server/mod.rs
+++ b/api/src/server/mod.rs
@@ -40,10 +40,6 @@ async fn route_graphql(
 
 #[actix_rt::main]
 pub async fn run_server(pool: Pool, host: String) -> io::Result<()> {
-    // Set up logging
-    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
-    env_logger::init();
-
     // Init GraphQL schema
     let gql_schema = Arc::new(create_gql_schema());
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       RUST_BACKTRACE: 1
       SERVER_HOST: 0.0.0.0:8000
       DATABASE_URL: postgres://root:root@db/gdlk
+      RUST_LOG: info
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
This adds logging for 5xx errors. Also, with the `log` crate we can now easily log whatever we want in the API.