### PR TITLE
Small API updates to support frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdlk 0.1.0",
  "juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "juniper-from-schema 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "juniper-from-schema 0.5.2 (git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -970,16 +970,16 @@ dependencies = [
 [[package]]
 name = "juniper-from-schema"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround#4c0cd8e733dddab0ba73e668a8f869394651ef33"
 dependencies = [
  "juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "juniper-from-schema-code-gen 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "juniper-from-schema-code-gen 0.5.2 (git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround)",
 ]
 
 [[package]]
 name = "juniper-from-schema-code-gen"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround#4c0cd8e733dddab0ba73e668a8f869394651ef33"
 dependencies = [
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "graphql-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1970,8 +1970,8 @@ dependencies = [
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f662ba51e2fbc3d6dd1ca66be70b44963606a34473156abddcb0351fc6caa668"
-"checksum juniper-from-schema 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ecc6f3fb3b8c143a963725b5d82d206d4822b98e4c2b739ecaf5e04d8cbe8f0c"
-"checksum juniper-from-schema-code-gen 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ca83b4fd2f19063d5744e7b39ff541996efa21d8b48e35a52ee0237c4bb57e9b"
+"checksum juniper-from-schema 0.5.2 (git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround)" = "<none>"
+"checksum juniper-from-schema-code-gen 0.5.2 (git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround)" = "<none>"
 "checksum juniper_codegen 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d40af234d8e971a9d7dda93ffbcc8a44a93f17e69e3067f72ce7a6894c41d51b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -18,7 +18,8 @@ env_logger = "0.7"
 failure = "0.1"
 gdlk = { path = "../core" }
 juniper = "0.14.2"
-juniper-from-schema = "0.5.2"
+# juniper-from-schema = "0.5.2"
+juniper-from-schema = { git = "https://github.com/LucasPickering/juniper-from-schema", branch = "fragment-bug-workaround" }
 log = "^0.4.8"
 r2d2 = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -376,7 +376,8 @@ type SaveUserProgramPayload {
   """
   The created/updated user program.
   """
-  userProgram: UserProgramNode @juniper(infallible: true)
+  userProgramEdge: UserProgramEdge
+    @juniper(infallible: true, ownership: "owned")
 }
 
 """

--- a/api/src/server/gql/internal.rs
+++ b/api/src/server/gql/internal.rs
@@ -60,6 +60,16 @@ impl<N: NodeType> GenericEdge<N> {
         &self.cursor
     }
 
+    /// Convert a single DB row into an edge. `offset` is the index of the row
+    /// in the database (with the ordering with which it was queried). The
+    /// offset is used to determine the cursor for the edge.
+    pub fn from_db_row(row: N::Model, offset: i32) -> Self {
+        Self {
+            node: row.into(),
+            cursor: Cursor::from_index(offset),
+        }
+    }
+
     /// Convert a list of DB model rows into a list of this type. `offset` is
     /// the index of the first row in the database (with the ordering with which
     /// it was queried). The offset is used to determine the cursor for each
@@ -67,9 +77,8 @@ impl<N: NodeType> GenericEdge<N> {
     pub fn from_db_rows(rows: Vec<N::Model>, offset: i32) -> Vec<Self> {
         rows.into_iter()
             .enumerate()
-            .map(|(i, row)| Self {
-                node: row.into(),
-                cursor: Cursor::from_index(offset + i32::try_from(i).unwrap()),
+            .map(|(i, row)| {
+                Self::from_db_row(row, offset + i32::try_from(i).unwrap())
             })
             .collect()
     }

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -302,9 +302,9 @@ impl MutationFields for Mutation {
             .returning(user_programs::table::all_columns())
             .get_result(conn);
 
-        let user_program_node: Option<UserProgramNode> = match result {
+        let user_program: Option<models::UserProgram> = match result {
             // Row was updated successfully, return the new row
-            Ok(updated_row) => Some(updated_row.into()),
+            Ok(updated_row) => Some(updated_row),
             // A foreign key violation means one of the given related IDs
             // was invalid. Just return None in that case.
             Err(diesel::result::Error::DatabaseError(
@@ -315,7 +315,7 @@ impl MutationFields for Mutation {
             Err(err) => return Err(err.into()),
         };
 
-        Ok(SaveUserProgramPayload { user_program_node })
+        Ok(SaveUserProgramPayload { user_program })
     }
 
     fn field_delete_user_program(

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -194,16 +194,20 @@ impl UserProgramConnectionFields for UserProgramConnection {
 }
 
 pub struct SaveUserProgramPayload {
-    pub user_program_node: Option<UserProgramNode>,
+    pub user_program: Option<models::UserProgram>,
 }
 
 impl SaveUserProgramPayloadFields for SaveUserProgramPayload {
-    fn field_user_program(
+    fn field_user_program_edge(
         &self,
         _executor: &juniper::Executor<'_, Context>,
-        _trail: &QueryTrail<'_, UserProgramNode, Walked>,
-    ) -> &Option<UserProgramNode> {
-        &self.user_program_node
+        _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
+    ) -> Option<UserProgramEdge> {
+        self.user_program
+            .as_ref()
+            // Since this wasn't queried as part of a set, we can use a
+            // bullshit offset to generate the cursor
+            .map(|row| GenericEdge::from_db_row(row.clone(), 0))
     }
 }
 

--- a/api/tests/test_graphql.rs
+++ b/api/tests/test_graphql.rs
@@ -689,14 +689,16 @@ fn test_save_user_program() {
                 fileName: $fileName,
                 sourceCode: $sourceCode,
             }) {
-                userProgram {
-                    fileName
-                    sourceCode
-                    user {
-                        username
-                    }
-                    programSpec {
-                        slug
+                userProgramEdge {
+                    node {
+                        fileName
+                        sourceCode
+                        user {
+                            username
+                        }
+                        programSpec {
+                            slug
+                        }
                     }
                 }
             }
@@ -716,15 +718,17 @@ fn test_save_user_program() {
         (
             graphql_value!({
                 "saveUserProgram": {
-                    "userProgram": {
-                        "fileName": "new.gdlk",
-                        "sourceCode": "READ RX0",
-                        "user": {
-                            "username": "user1"
-                        },
-                        "programSpec": {
-                            "slug": "prog1"
-                        },
+                    "userProgramEdge": {
+                        "node": {
+                            "fileName": "new.gdlk",
+                            "sourceCode": "READ RX0",
+                            "user": {
+                                "username": "user1"
+                            },
+                            "programSpec": {
+                                "slug": "prog1"
+                            },
+                        }
                     }
                 }
             }),
@@ -746,15 +750,17 @@ fn test_save_user_program() {
         (
             graphql_value!({
                 "saveUserProgram": {
-                    "userProgram": {
-                        "fileName": "existing.gdlk",
-                        "sourceCode": "WRITE RX0",
-                        "user": {
-                            "username": "user1"
-                        },
-                        "programSpec": {
-                            "slug": "prog1"
-                        },
+                    "userProgramEdge": {
+                        "node":{
+                            "fileName": "existing.gdlk",
+                            "sourceCode": "WRITE RX0",
+                            "user": {
+                                "username": "user1"
+                            },
+                            "programSpec": {
+                                "slug": "prog1"
+                            },
+                        }
                     }
                 }
             }),
@@ -776,7 +782,7 @@ fn test_save_user_program() {
         (
             graphql_value!({
                 "saveUserProgram": {
-                    "userProgram": None
+                    "userProgramEdge": None
                 }
             }),
             vec![]


### PR DESCRIPTION
Two API updates to support the frontend:
- There's [a bug in juniper](https://github.com/graphql-rust/juniper/issues/500) that causes a panic when trying to use the look ahead functionality for queries w/ nested fragments. juniper-from-schema automatically does look ahead on all queries. We don't actually need the look ahead, so I hacked juniper-from-schema to disable this until the bug gets fixed.
- It turns out that for mutations (other than deletions), Relay expects the API to return an edge for the modified node, instead of the node itself. Idk why, it's dumb, but I made that change on `saveUserProgram`