### PR TITLE
New lang features: DIV and RZR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ name = "gdlk"
 version = "0.1.0"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom_locate 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)",
@@ -1036,10 +1036,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lexical-core"
-version = "0.4.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1169,12 +1170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
-version = "5.0.1"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lexical-core 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1184,7 +1185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1815,7 +1816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2044,7 +2045,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
+"checksum lexical-core 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f86d66d380c9c5a685aaac7a11818bdfa1f733198dfd9ec09c70b762cd12ad6f"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
@@ -2061,7 +2062,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-"checksum nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
+"checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum nom_locate 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4726500a3d0297dd38edc169d919ad997a9931b4645b59ce0231e88536e213"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
@@ -2136,7 +2137,7 @@ dependencies = [
 "checksum validator_derive 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)" = "<none>"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ DEBUG=1 cargo make test
 We use nightly Rust. Here's a list of reasons why. If this list every gets empty, we should switch to stable.
 
 - Rust features
-  - [const_fn](https://github.com/rust-lang/rust/issues/57563)
+  - [or_patterns](https://github.com/rust-lang/rust/issues/54883)
 - Rustfmt
   - [merge_imports](https://github.com/rust-lang/rustfmt/issues/3362)
   - [wrap_comments](https://github.com/rust-lang/rustfmt/issues/3347)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(clippy::all, unused_must_use, unused_imports)]
 // Need to allow this because Diesel's macros violate it
 #![allow(clippy::single_component_path_imports)]
-#![feature(const_fn)]
 
 // Diesel hasn't fully moved to Rust 2018 yet so we need this
 #[macro_use]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ wasm=["wasm-bindgen"]
 
 [dependencies]
 failure = "0.1"
-nom = "5.0"
+nom = "5.1.1"
 nom_locate = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 # validator = "0.10.0"

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     consts::{
-        INPUT_LENGTH_REGISTER_REF, STACK_LENGTH_REGISTER_REF_TAG,
-        STACK_REF_TAG, USER_REGISTER_REF_TAG,
+        INPUT_LENGTH_REGISTER_REF, NULL_REGISTER_REF,
+        STACK_LENGTH_REGISTER_REF_TAG, STACK_REF_TAG, USER_REGISTER_REF_TAG,
     },
     util::Span,
 };
@@ -67,6 +67,9 @@ impl Display for StackRef {
 /// means the user can read and write freely from/to it.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum RegisterRef {
+    /// This register is both readable and writable, but it also produces zero
+    /// when read from, and anything written to it is thrown away.
+    Null,
     /// Read-only register that provides the number of elements remaining
     /// in the input buffer
     InputLength,
@@ -80,6 +83,7 @@ pub enum RegisterRef {
 impl Display for RegisterRef {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Null => write!(f, "{}", NULL_REGISTER_REF),
             Self::InputLength => write!(f, "{}", INPUT_LENGTH_REGISTER_REF),
             Self::StackLength(stack_id) => {
                 write!(f, "{}{}", STACK_LENGTH_REGISTER_REF_TAG, stack_id)

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -113,11 +113,12 @@ pub enum ValueSource<T> {
 /// NOTE: All arithmetic operations are wrapping (for overflow/underflow).
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Operator<T> {
-    /// Reads one value from the input buffer to a register
+    /// Reads one value from the input buffer to a register. If the input is
+    /// empty, triggers a runtime error.
     Read(Node<RegisterRef, T>),
-    /// Writes a value to the output buffer
+    /// Writes a value to the output buffer.
     Write(Node<ValueSource<T>, T>),
-    /// Sets a register to a value
+    /// Sets a register to a value.
     Set(Node<RegisterRef, T>, Node<ValueSource<T>, T>),
     /// Adds two values. Puts the result in the first argument.
     Add(Node<RegisterRef, T>, Node<ValueSource<T>, T>),
@@ -126,20 +127,24 @@ pub enum Operator<T> {
     Sub(Node<RegisterRef, T>, Node<ValueSource<T>, T>),
     /// Multiplies the two values. Puts the result in the first argument.
     Mul(Node<RegisterRef, T>, Node<ValueSource<T>, T>),
+    /// Divides the first value by the second. Puts the result in the first
+    /// argument. Any remainder from the division is thrown away, i.e. the
+    /// result is floored. If the divisor is zero, triggers a runtime error.
+    Div(Node<RegisterRef, T>, Node<ValueSource<T>, T>),
     /// Compares the last two arguments, and stores the comparison result in
     /// the first register. Result is -1 if the first value is less than the
     /// second, 0 if they are equal, and 1 if the first value is greater. The
     /// result will **never** be any value other than -1, 0, or 1.
-    ///
-    /// TODO: maybe we should remove this op?
     Cmp(
         Node<RegisterRef, T>,
         Node<ValueSource<T>, T>,
         Node<ValueSource<T>, T>,
     ),
-    /// Pushes the value in a register onto the given stack
+    /// Pushes the value in a register onto the given stack. If the stack is
+    /// already at capacity, triggers a runtime error.
     Push(Node<ValueSource<T>, T>, Node<StackRef, T>),
-    /// Pops the top value off the given stack into a register
+    /// Pops the top value off the given stack into a register. If the stack is
+    /// empty, triggers a runtime error.
     Pop(Node<StackRef, T>, Node<RegisterRef, T>),
 }
 

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -7,6 +7,8 @@ pub const MAX_CYCLE_COUNT: usize = 1_000_000;
 
 /// The prefix that indicates a stack reference.
 pub const STACK_REF_TAG: &str = "S";
+/// The string that refers to the null register.
+pub const NULL_REGISTER_REF: &str = "RZR";
 /// The string that refers to the input length register.
 pub const INPUT_LENGTH_REGISTER_REF: &str = "RLI";
 /// The prefix that indicates a reference to a stack length register.

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -84,11 +84,13 @@ impl SourceError for CompileError {
 /// the interpreter. Interpreter bugs will always panic.
 #[derive(Debug, Serialize)]
 pub enum RuntimeError {
+    /// DIV attempted with a zero divisor
+    DivideByZero,
     /// READ attempted while input is empty
     EmptyInput,
-    /// Tried to push onto stack that is at capacity
+    /// PUSH attemped onto a stack that is at capacity
     StackOverflow,
-    /// POP attempted while stack is empty
+    /// POP attempted from an empty stack
     EmptyStack,
     /// Too many cycles in the program
     TooManyCycles,
@@ -101,6 +103,7 @@ impl SourceError for RuntimeError {
 
     fn fmt_msg(&self, f: &mut Formatter<'_>, spanned_src: &str) -> fmt::Result {
         match self {
+            Self::DivideByZero => write!(f, "Divide by zero"),
             Self::StackOverflow => {
                 write!(f, "Overflow on stack `{}`", spanned_src)
             }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -36,6 +36,7 @@
 //! ```
 
 #![deny(clippy::all, unused_must_use, unused_imports)]
+#![feature(or_patterns)]
 
 // Re-export dependencies that consumers may need
 pub use validator;

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -236,6 +236,16 @@ impl Machine {
                             .0,
                         );
                     }
+                    Operator::Div(dst, src) => {
+                        let divisor = self.get_val_from_src(&src);
+                        let dividend = self.get_reg(*dst.value());
+                        if divisor != 0 {
+                            // This does flooring division
+                            self.set_reg(&dst, dividend / divisor);
+                        } else {
+                            return Err((RuntimeError::DivideByZero, *span));
+                        }
+                    }
                     Operator::Cmp(dst, src_1, src_2) => {
                         let val_1 = self.get_val_from_src(&src_1);
                         let val_2 = self.get_val_from_src(&src_2);

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -112,6 +112,7 @@ impl Machine {
     /// it isn't valid.
     fn get_reg(&self, reg: RegisterRef) -> LangValue {
         match reg {
+            RegisterRef::Null => 0,
             // These conversion unwraps are safe because we know that input
             // and stack lengths are bounded by validation rules to fit into an
             // i32 (max length is 256 at the time of writing this)
@@ -128,10 +129,13 @@ impl Machine {
     /// Will panic if it isn't valid/writable.
     fn set_reg(&mut self, reg: &SpanNode<RegisterRef>, value: LangValue) {
         match reg.value() {
+            RegisterRef::Null => {} // /dev/null behavior - trash any input
+            RegisterRef::InputLength | RegisterRef::StackLength(_) => {
+                panic!("Unwritable register {:?}", reg)
+            }
             RegisterRef::User(reg_id) => {
                 self.registers[*reg_id] = value;
             }
-            _ => panic!("Unwritable register {:?}", reg),
         }
     }
 

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -50,7 +50,17 @@ trait Parse<'a>: Sized {
 // covers StackId and UserRegisterId
 impl<'a> Parse<'a> for usize {
     fn parse(input: RawSpan<'a>) -> ParseResult<'a, Self> {
-        map_res(digit1, |s: RawSpan| s.fragment().parse::<usize>())(input)
+        map_res(digit1, |s: RawSpan| {
+            let frag = s.fragment();
+
+            // If the string has unnecessary leading zeroes, reject it. Use an
+            // empty error for convenience, its value won't be used anyway.
+            if frag.len() > 1 && frag.starts_with('0') {
+                Err(())
+            } else {
+                s.fragment().parse::<usize>().map_err(|_| ())
+            }
+        })(input)
     }
 }
 

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -150,6 +150,11 @@ impl<'a> Parse<'a> for Operator<Span> {
                 |(dst, src)| Operator::Mul(dst, src),
             ),
             tag_with_args(
+                "DIV",
+                tuple((register_ref_arg, value_source_arg)),
+                |(dst, src)| Operator::Div(dst, src),
+            ),
+            tag_with_args(
                 "CMP",
                 tuple((register_ref_arg, value_source_arg, value_source_arg)),
                 |(dst, src_1, src_2)| Operator::Cmp(dst, src_1, src_2),

--- a/core/src/validate.rs
+++ b/core/src/validate.rs
@@ -178,8 +178,10 @@ fn validate_writable(
 ) {
     // Only User registers are writable, all others cause an error.
     match reg_ref_node {
-        Node(RegisterRef::User(_), _) => {}
-        Node(_, span) => errors.push((CompileError::UnwritableRegister, *span)),
+        Node(RegisterRef::Null | RegisterRef::User(_), _) => {}
+        Node(RegisterRef::InputLength | RegisterRef::StackLength(_), span) => {
+            errors.push((CompileError::UnwritableRegister, *span))
+        }
     }
 }
 

--- a/core/src/validate.rs
+++ b/core/src/validate.rs
@@ -106,7 +106,8 @@ impl Validate for SpanNode<Operator<Span>> {
             Operator::Set(reg_ref, val_src)
             | Operator::Add(reg_ref, val_src)
             | Operator::Sub(reg_ref, val_src)
-            | Operator::Mul(reg_ref, val_src) => {
+            | Operator::Mul(reg_ref, val_src)
+            | Operator::Div(reg_ref, val_src) => {
                 // Make sure the first reg is valid and writable, and the
                 // second is a valid value source
                 reg_ref.validate(context, errors);

--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -36,7 +36,7 @@ macro_rules! assert_parse_error {
 
 #[test]
 fn test_parse_errors() {
-    // Operators
+    // Register references
     assert_parse_error!(
         "
         READ RX0
@@ -54,13 +54,25 @@ fn test_parse_errors() {
         "READ RW0",
         "Syntax error at 1:6: Expected register reference"
     );
-    assert_parse_error!("RAD RX0", "Syntax error at 1:1: Expected statement",);
-    assert_parse_error!("READE RX0", "Syntax error at 1:1: Expected statement",);
-    assert_parse_error!("PUSH STEVE S0", "Syntax error at 1:6: Expected value");
+    assert_parse_error!(
+        "READ RX01",
+        "Syntax error at 1:6: Expected register reference"
+    );
+
+    // Stack references
     assert_parse_error!(
         "PUSH RX0 T0",
         "Syntax error at 1:10: Expected stack reference",
     );
+    assert_parse_error!(
+        "PUSH RX0 S01",
+        "Syntax error at 1:10: Expected stack reference",
+    );
+
+    // Operators
+    assert_parse_error!("RAD RX0", "Syntax error at 1:1: Expected statement",);
+    assert_parse_error!("READE RX0", "Syntax error at 1:1: Expected statement",);
+    assert_parse_error!("PUSH STEVE S0", "Syntax error at 1:6: Expected value");
     assert_parse_error!(
         "READ RX1 WRITE RX2",
         "Syntax error at 1:10: Expected end of statement",

--- a/core/tests/runtime_error.rs
+++ b/core/tests/runtime_error.rs
@@ -21,6 +21,19 @@ macro_rules! assert_runtime_error {
 }
 
 #[test]
+fn test_divide_by_zero() {
+    assert_runtime_error!(
+        HardwareSpec::default(),
+        &ProgramSpec::default(),
+        "
+        SET RX0 1
+        DIV RX0 0
+        ",
+        "Runtime error at 3:9: Divide by zero",
+    );
+}
+
+#[test]
 fn test_stack_overflow() {
     assert_runtime_error!(
         HardwareSpec {

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -74,7 +74,7 @@ fn test_set_push_pop() {
 }
 
 #[test]
-fn test_arithmetic() {
+fn test_add_sub_mul() {
     execute_expect_success(
         HardwareSpec {
             num_registers: 2,
@@ -94,6 +94,41 @@ fn test_arithmetic() {
         MUL RX0 RX1
         SUB RX0 RX1
         WRITE RX0
+        ",
+    );
+}
+
+#[test]
+fn test_div() {
+    execute_expect_success(
+        HardwareSpec::default(),
+        ProgramSpec::new(vec![], vec![2, 3, -33, 4, 0, 0]),
+        "
+        SET RX0 6
+        DIV RX0 3
+        WRITE RX0 ; 2
+
+        SET RX0 11
+        DIV RX0 3
+        WRITE RX0 ; 3 (rounds down)
+
+        SET RX0 -100
+        DIV RX0 3
+        WRITE RX0 ; -33
+
+        SET RX0 -32
+        DIV RX0 -8
+        WRITE RX0 ; 4
+
+        SET RX0 0
+        DIV RX0 -8
+        WRITE RX0 ; 0
+
+        SET RX0 10
+        DIV RX0 20
+        WRITE RX0 ; 0
+
+        ; divide by zero test lives with the runtime error tests
         ",
     );
 }

--- a/core/tests/success.rs
+++ b/core/tests/success.rs
@@ -34,6 +34,21 @@ fn execute_expect_success(
 }
 
 #[test]
+fn test_register_null() {
+    execute_expect_success(
+        HardwareSpec::default(),
+        ProgramSpec::new(vec![1, 2], vec![0, 0]),
+        "
+        READ RZR    ; the 1 gets clobbered
+        WRITE RZR   ; writes 0
+        READ RZR    ; the 2 gets clobbered
+        SET RZR 3   ; does nothing
+        WRITE RZR   ; writes 0
+        ",
+    );
+}
+
+#[test]
 fn test_read_write() {
     execute_expect_success(
         HardwareSpec {


### PR DESCRIPTION
- Add the `DIV` instruction, which does flooring division
  - Also includes a new `DivideByZero` runtime error
- Added the `RZR` instruction (for register-zero), which emulates `/dev/null`
  - Reading from it always gives you zero
  - You can write to it, but your value just disappears
- Fixed a register/stack reference parsing bug, where it would accept leading zeroes like `RX01` and `S00`