### PR TITLE
Fix some bugs around program termination

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -94,7 +94,7 @@ fn run(opt: Opt) -> Fallible<()> {
             // Compile and execute
             let mut machine =
                 Compiler::compile(source, hw_spec)?.allocate(program_spec);
-            let success = machine.execute_all()?;
+            let success = machine.execute_all().map_err(Clone::clone)?;
 
             println!(
                 "Registers: {:#?}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -22,7 +22,7 @@ pub trait SourceError: 'static + Send + Sync + Debug + Serialize {
 /// An error that occurs during compilation of a program. The error will be
 /// due to a flaw in the program. This indicates a user error, _not_ an internal
 /// compiler error. Compiler bugs will always cause a panic.
-#[derive(Debug, Serialize)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub enum CompileError {
     /// Failed to parse the program because of a syntax error. `expected` is
     /// the name of the type of element that was expected where the error
@@ -82,7 +82,7 @@ impl SourceError for CompileError {
 /// An error that occurs during execution of a program. The error will be
 /// due to a flaw in the program. This indicates a user error, _not_ a bug in
 /// the interpreter. Interpreter bugs will always panic.
-#[derive(Debug, Serialize)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub enum RuntimeError {
     /// DIV attempted with a zero divisor
     DivideByZero,
@@ -92,7 +92,7 @@ pub enum RuntimeError {
     StackOverflow,
     /// POP attempted from an empty stack
     EmptyStack,
-    /// Too many cycles in the program
+    /// Execution attempted after the program has hit the CPU cycle limit
     TooManyCycles,
 }
 
@@ -128,7 +128,7 @@ impl SourceError for RuntimeError {
 /// - The offending chunk of source code itself
 ///
 /// This type on its own can be formatted, without any external data.
-#[derive(Debug, Fail, Serialize)]
+#[derive(Clone, Debug, Fail, Serialize)]
 pub struct SourceErrorWrapper<E: SourceError> {
     error: E,
     span: Span,
@@ -177,7 +177,7 @@ impl<E: SourceError> From<&SourceErrorWrapper<E>> for SourceElement {
 /// A wrapper around of a collection of errors. This holds the errors as well as
 /// the source code, and can be used to render associated source code with each
 /// error.
-#[derive(Debug, Fail, Serialize)]
+#[derive(Clone, Debug, Fail, Serialize)]
 pub struct WithSource<E: SourceError> {
     errors: Vec<SourceErrorWrapper<E>>,
     #[serde(skip)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,7 +32,7 @@
 //! // Execute
 //! let mut machine = compiled.allocate(program_spec);
 //! machine.execute_all().unwrap();
-//! assert!(machine.is_successful());
+//! assert!(machine.successful());
 //! ```
 
 #![deny(clippy::all, unused_must_use, unused_imports)]

--- a/core/tests/compile_error.rs
+++ b/core/tests/compile_error.rs
@@ -14,7 +14,7 @@ macro_rules! assert_compile_errors {
                 .unwrap_err()
                 .errors()
                 .iter()
-                .map(|err| format!("{}", err))
+                .map(|err| err.to_string())
                 .collect();
         let strs: Vec<&str> =
             actual_errors.iter().map(String::as_str).collect();
@@ -30,7 +30,7 @@ macro_rules! assert_parse_error {
             Valid::validate(HardwareSpec::default()).unwrap(),
         )
         .unwrap_err();
-        assert_eq!(format!("{}", actual_errors), $expected_error);
+        assert_eq!(actual_errors.to_string(), $expected_error);
     };
 }
 

--- a/frontend/src/components/ide/IdeControls.tsx
+++ b/frontend/src/components/ide/IdeControls.tsx
@@ -101,14 +101,14 @@ const IdeControls: React.FC<{
     }
   }, [executeNext, stepping, stepSpeed, intervalIdRef]);
 
-  // When the program completes, stop the stepper
-  const isComplete = Boolean(machineState?.isComplete);
+  // When the program terminates, stop the stepper
+  const terminated = Boolean(machineState?.terminated);
   useEffect(() => {
-    if (isComplete) {
+    if (terminated) {
       window.clearInterval(intervalIdRef.current);
       setStepping(false);
     }
-  }, [isComplete]);
+  }, [terminated]);
 
   return (
     <div className={clsx(localClasses.controls, className)}>
@@ -135,7 +135,7 @@ const IdeControls: React.FC<{
 
         <IconButton
           title="Execute Next Instruction"
-          disabled={!machineState || machineState.isComplete || stepping}
+          disabled={!machineState || machineState.terminated || stepping}
           onClick={executeNext}
         >
           <IconChevronRight />
@@ -143,7 +143,7 @@ const IdeControls: React.FC<{
 
         <IconButton
           title={stepping ? 'Pause Execution' : 'Execute Program'}
-          disabled={!machineState || machineState.isComplete}
+          disabled={!machineState || machineState.terminated}
           onClick={() => setStepping((prev) => !prev)}
         >
           {stepping ? <IconPause /> : <IconPlayArrow />}

--- a/frontend/src/components/ide/ProgramStatus.tsx
+++ b/frontend/src/components/ide/ProgramStatus.tsx
@@ -19,8 +19,8 @@ const ProgramStatus: React.FC<{ className?: string }> = ({ className }) => {
   return (
     <div className={clsx(className, localClasses.programStatus)}>
       <div>CPU Cycles: {machineState?.cycleCount ?? '-'}</div>
-      {machineState?.isComplete && (
-        <div>{machineState?.isSuccessful ? 'SUCCESS' : 'FAILURE'}</div>
+      {machineState?.terminated && (
+        <div>{machineState?.successful ? 'SUCCESS' : 'FAILURE'}</div>
       )}
     </div>
   );


### PR DESCRIPTION
Previously the machine allowed you to continue to execute a program after a runtime error had occured. Now, it stores any error that occurs and prevents further execution. This cleaned up some of the logic in the frontend too, since we no longer have to capture and store those errors.