### PR TITLE
Add GQL operations to create and mutate hardware and program specs (spec ops)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -871,7 +871,7 @@ dependencies = [
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web-actors 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdlk 0.1.0",
@@ -2508,7 +2508,7 @@ dependencies = [
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum data-encoding 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
 "checksum derive_more 0.99.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a806e96c59a76a5ba6e18735b6cf833344671e61e7863f2edb5c518ea2cac95c"
-"checksum diesel 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d7cc03b910de9935007861dce440881f69102aaaedfd4bc5a6f40340ca5840c"
+"checksum diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "33d7ca63eb2efea87a7f56a283acc49e2ce4b2bd54adf7465dc1d81fef13d8fc"
 "checksum diesel_derives 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"

--- a/api/Makefile.toml
+++ b/api/Makefile.toml
@@ -25,6 +25,11 @@ extend = "diesel"
 dependencies = ["wait-for-db"]
 args = ["db", "setup"]
 
+[tasks.db-reset]
+extend = "diesel"
+dependencies = ["wait-for-db"]
+args = ["db", "reset"]
+
 [tasks.migrations]
 extend = "diesel"
 dependencies = ["db-setup"]

--- a/api/migrations/2020-05-30-210421_init_models/up.sql
+++ b/api/migrations/2020-05-30-210421_init_models/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE hardware_specs (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     slug VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(slug) > 0),
-    name VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(slug) > 0),
+    name VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(name) > 0),
     num_registers INTEGER NOT NULL CHECK(num_registers >= 1),
     num_stacks INTEGER NOT NULL CHECK(num_stacks >= 0),
     max_stack_length INTEGER NOT NULL CHECK(num_stacks >= 0)
@@ -16,9 +16,11 @@ CREATE TABLE program_specs (
     name VARCHAR(50) NOT NULL CHECK (char_length(name) > 0),
     description TEXT NOT NULL,
     hardware_spec_id UUID NOT NULL REFERENCES hardware_specs(id),
-    input SMALLINT[] NOT NULL,
-    expected_output SMALLINT[] NOT NULL,
-    UNIQUE(slug, hardware_spec_id)
+    -- TODO add constraint to make sure all values in range
+    input INT[] NOT NULL CHECK (array_length(input, 1) <= 256),
+    expected_output INT[] NOT NULL CHECK (array_length(input, 1) <= 256),
+    UNIQUE(slug, hardware_spec_id),
+    UNIQUE(name, hardware_spec_id)
 );
 -- autogenerate slug from name
 CREATE TRIGGER "t_program_specs_insert" BEFORE INSERT ON "program_specs"
@@ -26,14 +28,14 @@ FOR EACH ROW EXECUTE PROCEDURE set_slug_from_name();
 
 CREATE TABLE users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    username VARCHAR(20) NOT NULL UNIQUE
+    username VARCHAR(20) NOT NULL UNIQUE CHECK (char_length(username) > 0)
 );
 
 CREATE TABLE user_programs (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     user_id UUID NOT NULL REFERENCES users(id),
     program_spec_id UUID NOT NULL REFERENCES program_specs(id),
-    file_name TEXT NOT NULL,
+    file_name TEXT NOT NULL CHECK (char_length(file_name) > 0),
     source_code TEXT NOT NULL,
     UNIQUE(user_id, program_spec_id, file_name)
 );

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -421,13 +421,64 @@ type UserProgramConnection implements ConnectionInterface {
 # +-----------------------------+
 
 """
-The root mutation.
+The root mutation. Some general notes about mutations:
+- Slugs are generally derived from names, and cannot be set or changed manually
+- Slugs are unique among some pool of rows. Because they are derived, it is
+  possible to have two different values convert to the same slug, causing a
+  collision. Keep this in mind.
+- Slugs cannot be changed, in order to prevent breaking URLs.
+- When modifying, if a field that is required on the node type is not required
+  in the mutation input, then supplying no value will cause it to not change.
 """
 type Mutation {
   """
-  Create a new user program spec and file name (belonging to the current user).
-  An error is returned if there is already a user program with this program
-  spec ID/file name, or if the program spec ID is invalid.
+  Create a new hardware spec. An error is returned if the given name is
+  already taken, or if the slug derived from that name is already taken.
+  """
+  createHardwareSpec(
+    """
+    All input fields.
+    """
+    input: CreateHardwareSpecInput!
+  ): CreateHardwareSpecPayload! @juniper(ownership: "owned")
+
+  """
+  Modify an existing hardware spec. The spec to modify will be identified by
+  ID, and any field that is given a value will be updated.
+  """
+  updateHardwareSpec(
+    """
+    All input fields.
+    """
+    input: UpdateHardwareSpecInput!
+  ): UpdateHardwareSpecPayload! @juniper(ownership: "owned")
+
+  """
+  Create a new program spec. An error is returned if the given name is
+  already taken, or if the slug derived from that name is already taken.
+  """
+  createProgramSpec(
+    """
+    All input fields.
+    """
+    input: CreateProgramSpecInput!
+  ): CreateProgramSpecPayload! @juniper(ownership: "owned")
+
+  """
+  Modify an existing program spec. The spec to modify will be identified by
+  ID, and any field that is given a value will be updated.
+  """
+  updateProgramSpec(
+    """
+    All input fields.
+    """
+    input: UpdateProgramSpecInput!
+  ): UpdateProgramSpecPayload! @juniper(ownership: "owned")
+
+  """
+  Create a new user program with a program spec and file name (belonging to the
+  current user). An error is returned if there is already a user program with
+  this program spec ID/file name, or if the program spec ID is invalid.
   """
   createUserProgram(
     """
@@ -458,6 +509,151 @@ type Mutation {
 }
 
 """
+Input to the `createHardwareSpec` mutation.
+"""
+input CreateHardwareSpecInput {
+  """
+  The name of the hardware spec (must be unique).
+  """
+  name: String!
+  """
+  See `numRegisters` field on `HardwareSpecNode`.
+  """
+  numRegisters: Int!
+  """
+  See `numStacks` field on `HardwareSpecNode`.
+  """
+  numStacks: Int!
+  """
+  See `maxStackLength` field on `HardwareSpecNode`.
+  """
+  maxStackLength: Int!
+}
+
+"""
+Output from the `createHardwareSpec` mutation.
+"""
+type CreateHardwareSpecPayload {
+  """
+  The created hardware spec.
+  """
+  hardwareSpecEdge: HardwareSpecEdge!
+    @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Input to the `updateHardwareSpec` mutation.
+"""
+input UpdateHardwareSpecInput {
+  """
+  The ID of the existing hardware spec to modify.
+  """
+  id: ID!
+  """
+  The new name of the hardware spec (must be unique).
+  """
+  name: String
+  """
+  See `numRegisters` field on `HardwareSpecNode`.
+  """
+  numRegisters: Int
+  """
+  See `numStacks` field on `HardwareSpecNode`.
+  """
+  numStacks: Int
+  """
+  See `maxStackLength` field on `HardwareSpecNode`.
+  """
+  maxStackLength: Int
+}
+
+"""
+Output from the `updateHardwareSpec` mutation.
+"""
+type UpdateHardwareSpecPayload {
+  """
+  The modified hardware spec. `null` if the ID did not match any hardware specs.
+  """
+  hardwareSpecEdge: HardwareSpecEdge
+    @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Input to the `createProgramSpec` mutation.
+"""
+input CreateProgramSpecInput {
+  """
+  The ID of the hardware spec to create this program spec under.
+  """
+  hardwareSpecId: ID!
+
+  """
+  The name of the new program spec (must be unique).
+  """
+  name: String!
+  """
+  A description of the problem that this program spec defines.
+  """
+  description: String!
+  """
+  See `input` field on `ProgramSpecNode`.
+  """
+  input: [Int!]!
+  """
+  See `expectedOutput` field on `ProgramSpecNode`.
+  """
+  expectedOutput: [Int!]!
+}
+
+"""
+Output from the `createProgramSpec` mutation.
+"""
+type CreateProgramSpecPayload {
+  """
+  The created program spec.
+  """
+  programSpecEdge: ProgramSpecEdge!
+    @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Input to the `updateProgramSpec` mutation.
+"""
+input UpdateProgramSpecInput {
+  """
+  The ID of the existing program spec to modify.
+  """
+  id: ID!
+  """
+  The new name of the program spec (must be unique).
+  """
+  name: String
+  """
+  A description of the problem that this program spec defines.
+  """
+  description: String
+  """
+  See `input` field on `ProgramSpecNode`.
+  """
+  input: [Int!]
+  """
+  See `expectedOutput` field on `ProgramSpecNode`.
+  """
+  expectedOutput: [Int!]
+}
+
+"""
+Output from the `updateProgramSpec` mutation.
+"""
+type UpdateProgramSpecPayload {
+  """
+  The modified program spec. `null` if the ID did not match any program specs.
+  """
+  programSpecEdge: ProgramSpecEdge
+    @juniper(infallible: true, ownership: "owned")
+}
+
+"""
 Input to the `createUserProgram` mutation.
 """
 input CreateUserProgramInput {
@@ -476,7 +672,7 @@ input CreateUserProgramInput {
 }
 
 """
-Output from the `saveUserProgram` mutation.
+Output from the `createUserProgram` mutation.
 """
 type CreateUserProgramPayload {
   """
@@ -487,7 +683,7 @@ type CreateUserProgramPayload {
 }
 
 """
-Input to the `saveUserProgram` mutation.
+Input to the `updateUserProgram` mutation.
 """
 input UpdateUserProgramInput {
   """
@@ -506,11 +702,11 @@ input UpdateUserProgramInput {
 }
 
 """
-Output from the `saveUserProgram` mutation.
+Output from the `updateUserProgram` mutation.
 """
 type UpdateUserProgramPayload {
   """
-  The updated user program.
+  The updated user program. `null` if the ID did not match any user programs.
   """
   userProgramEdge: UserProgramEdge
     @juniper(infallible: true, ownership: "owned")

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -158,22 +158,32 @@ type HardwareSpecNode implements Node {
   UUID for this node.
   """
   id: ID! @juniper(infallible: true, ownership: "owned")
+
   """
-  Human-readable name for this spec. Unique across all hardware specs.
+  URL-friendly slug for this spec. Unique across all hardware specs.
   """
   slug: String! @juniper(infallible: true)
+
+  """
+  User-friendly name for this spec. Unique across all hardware specs.
+  """
+  name: String! @juniper(infallible: true)
+
   """
   Number of registers that this hardware provides to a program.
   """
   numRegisters: Int! @juniper(infallible: true, ownership: "owned")
+
   """
   Number of stacks that this hardware provides to a program.
   """
   numStacks: Int! @juniper(infallible: true, ownership: "owned")
+
   """
   The maximum length for each stack while the program is running.
   """
   maxStackLength: Int! @juniper(infallible: true, ownership: "owned")
+
   """
   A single program spec that runs on this hardware.
   """
@@ -184,6 +194,7 @@ type HardwareSpecNode implements Node {
     """
     slug: String!
   ): ProgramSpecNode @juniper(ownership: "owned")
+
   """
   All the program specs that can run on this hardware spec.
   """
@@ -245,16 +256,31 @@ type ProgramSpecNode implements Node {
   UUID for this node.
   """
   id: ID! @juniper(infallible: true, ownership: "owned")
+
   """
-  Human-readable name for this program spec. Unique across the program specs
+  URL-friendly name for this program spec. Unique across the program specs
   for a particular hardware spec. Two program specs can have the same slug iff
   they run on different hardware.
   """
   slug: String! @juniper(infallible: true)
+
+  """
+  User-friendly name for this program spec. Unique across the program specs
+  for a particular hardware spec.
+  """
+  name: String! @juniper(infallible: true)
+
+  """
+  Description of the program spec. Could generally describe it, describe the
+  input and expected output, etc.
+  """
+  description: String! @juniper(infallible: true)
+
   """
   The input to the program.
   """
   input: [Int!]! @juniper(infallible: true, ownership: "owned")
+
   """
   The output that the program is expected to give.
   """

--- a/api/src/models/user_program.rs
+++ b/api/src/models/user_program.rs
@@ -6,6 +6,7 @@ use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
     sql_types, Identifiable, Queryable,
 };
+use gdlk::validator::Validate;
 use uuid::Uuid;
 
 /// Expression to filter user_programs by owner's ID and program spec ID
@@ -42,11 +43,12 @@ impl UserProgram {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Insertable)]
+#[derive(Clone, Debug, PartialEq, Insertable, Validate)]
 #[table_name = "user_programs"]
 pub struct NewUserProgram<'a> {
     pub user_id: Uuid,
     pub program_spec_id: Uuid,
+    #[validate(length(min = 1))]
     pub file_name: &'a str,
     pub source_code: &'a str,
 }
@@ -75,10 +77,13 @@ impl Factory for NewUserProgram<'_> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Identifiable, AsChangeset)]
+#[derive(Clone, Debug, PartialEq, Identifiable, AsChangeset, Validate)]
 #[table_name = "user_programs"]
 pub struct ModifiedUserProgram<'a> {
     pub id: Uuid,
+
+    // TODO de-dupe this validation logic
+    #[validate(length(min = 1))]
     pub file_name: Option<&'a str>,
     pub source_code: Option<&'a str>,
 }

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -16,8 +16,8 @@ table! {
         name -> Varchar,
         description -> Text,
         hardware_spec_id -> Uuid,
-        input -> Array<Int2>,
-        expected_output -> Array<Int2>,
+        input -> Array<Int4>,
+        expected_output -> Array<Int4>,
     }
 }
 

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -5,8 +5,9 @@ use crate::{
     server::gql::{
         internal::{GenericEdge, NodeType},
         program_spec::{ProgramSpecConnection, ProgramSpecNode},
-        ConnectionPageParams, Context, Cursor, HardwareSpecConnectionFields,
-        HardwareSpecEdgeFields, HardwareSpecNodeFields, PageInfo,
+        ConnectionPageParams, Context, CreateHardwareSpecPayloadFields, Cursor,
+        HardwareSpecConnectionFields, HardwareSpecEdgeFields,
+        HardwareSpecNodeFields, PageInfo, UpdateHardwareSpecPayloadFields,
     },
     util,
 };
@@ -201,5 +202,35 @@ impl HardwareSpecConnectionFields for HardwareSpecConnection {
         _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
     ) -> ResponseResult<Vec<HardwareSpecEdge>> {
         self.get_edges(executor.context())
+    }
+}
+
+pub struct CreateHardwareSpecPayload {
+    pub hardware_spec: models::HardwareSpec,
+}
+
+impl CreateHardwareSpecPayloadFields for CreateHardwareSpecPayload {
+    fn field_hardware_spec_edge(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
+    ) -> HardwareSpecEdge {
+        GenericEdge::from_db_row(self.hardware_spec.clone(), 0)
+    }
+}
+
+pub struct UpdateHardwareSpecPayload {
+    pub hardware_spec: Option<models::HardwareSpec>,
+}
+
+impl UpdateHardwareSpecPayloadFields for UpdateHardwareSpecPayload {
+    fn field_hardware_spec_edge(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
+    ) -> Option<HardwareSpecEdge> {
+        self.hardware_spec
+            .as_ref()
+            .map(|row| GenericEdge::from_db_row(row.clone(), 0))
     }
 }

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -53,6 +53,13 @@ impl HardwareSpecNodeFields for HardwareSpecNode {
         &self.hardware_spec.slug
     }
 
+    fn field_name(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &String {
+        &self.hardware_spec.name
+    }
+
     fn field_num_registers(
         &self,
         _executor: &juniper::Executor<'_, Context>,

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -1,0 +1,283 @@
+use crate::{
+    error::{DbErrorConverter, ResponseResult},
+    models,
+    schema::{hardware_specs, program_specs, user_programs, users},
+    server::gql::{
+        Context, CreateHardwareSpecInput, CreateHardwareSpecPayload,
+        CreateProgramSpecInput, CreateProgramSpecPayload,
+        CreateUserProgramInput, CreateUserProgramPayload,
+        DeleteUserProgramInput, DeleteUserProgramPayload, MutationFields,
+        UpdateHardwareSpecInput, UpdateHardwareSpecPayload,
+        UpdateProgramSpecInput, UpdateProgramSpecPayload,
+        UpdateUserProgramInput, UpdateUserProgramPayload,
+    },
+    util,
+};
+use diesel::{
+    ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
+    Table,
+};
+use gdlk::validator::Validate;
+use juniper_from_schema::{QueryTrail, Walked};
+use uuid::Uuid;
+
+/// The top-level mutation object.
+pub struct Mutation;
+
+impl MutationFields for Mutation {
+    fn field_create_hardware_spec(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, CreateHardwareSpecPayload, Walked>,
+        input: CreateHardwareSpecInput,
+    ) -> ResponseResult<CreateHardwareSpecPayload> {
+        let conn: &PgConnection =
+            &executor.context().get_db_conn()? as &PgConnection;
+
+        // User a helper type to do the insert
+        let new_hardware_spec = models::NewHardwareSpec {
+            name: &input.name,
+            num_registers: input.num_registers,
+            num_stacks: input.num_stacks,
+            max_stack_length: input.max_stack_length,
+        };
+        new_hardware_spec.validate()?;
+
+        // Insert the new row and return the whole row
+        let result: Result<models::HardwareSpec, _> = new_hardware_spec
+            .insert()
+            .returning(hardware_specs::table::all_columns())
+            .get_result(conn);
+
+        let hardware_spec: models::HardwareSpec = DbErrorConverter {
+            // HardwareSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            ..Default::default()
+        }
+        .convert(result)?;
+
+        Ok(CreateHardwareSpecPayload { hardware_spec })
+    }
+
+    fn field_update_hardware_spec(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UpdateHardwareSpecPayload, Walked>,
+        input: UpdateHardwareSpecInput,
+    ) -> ResponseResult<UpdateHardwareSpecPayload> {
+        let conn: &PgConnection =
+            &executor.context().get_db_conn()? as &PgConnection;
+
+        // User a helper type to do the insert
+        let modified_hardware_spec = models::ModifiedHardwareSpec {
+            id: util::gql_id_to_uuid(&input.id),
+            name: input.name.as_deref(),
+            num_registers: input.num_registers,
+            num_stacks: input.num_stacks,
+            max_stack_length: input.max_stack_length,
+        };
+        modified_hardware_spec.validate()?;
+
+        // Update the row, returning the new value. If the row doesn't exist,
+        // this will return None.
+        let result: Result<Option<models::HardwareSpec>, _> = diesel::update(
+            hardware_specs::table.find(modified_hardware_spec.id),
+        )
+        .set(modified_hardware_spec)
+        .returning(hardware_specs::table::all_columns())
+        .get_result(conn)
+        .optional();
+
+        let updated_row: Option<models::HardwareSpec> = DbErrorConverter {
+            // HardwareSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            // No update fields were given
+            query_builder_to_no_update: true,
+            ..Default::default()
+        }
+        .convert(result)?;
+
+        Ok(UpdateHardwareSpecPayload {
+            hardware_spec: updated_row,
+        })
+    }
+
+    fn field_create_program_spec(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, CreateProgramSpecPayload, Walked>,
+        input: CreateProgramSpecInput,
+    ) -> ResponseResult<CreateProgramSpecPayload> {
+        let conn: &PgConnection =
+            &executor.context().get_db_conn()? as &PgConnection;
+
+        // User a helper type to do the insert
+        let new_program_spec = models::NewProgramSpec {
+            hardware_spec_id: util::gql_id_to_uuid(&input.hardware_spec_id),
+            name: &input.name,
+            description: &input.description,
+            input: input.input,
+            expected_output: input.expected_output,
+        };
+        new_program_spec.validate()?;
+
+        // Insert the new row and return the whole row
+        let result: Result<models::ProgramSpec, _> = new_program_spec
+            .insert()
+            .returning(program_specs::table::all_columns())
+            .get_result(conn);
+
+        let program_spec: models::ProgramSpec = DbErrorConverter {
+            // Given hardware spec ID was invalid
+            fk_violation_to_not_found: true,
+            // ProgramSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            ..Default::default()
+        }
+        .convert(result)?;
+
+        Ok(CreateProgramSpecPayload { program_spec })
+    }
+
+    fn field_update_program_spec(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UpdateProgramSpecPayload, Walked>,
+        input: UpdateProgramSpecInput,
+    ) -> ResponseResult<UpdateProgramSpecPayload> {
+        let conn: &PgConnection =
+            &executor.context().get_db_conn()? as &PgConnection;
+
+        // Use a helper type to do the insert
+        let modified_program_spec = models::ModifiedProgramSpec {
+            id: util::gql_id_to_uuid(&input.id),
+            name: input.name.as_deref(),
+            description: input.description.as_deref(),
+            input: input.input,
+            expected_output: input.expected_output,
+        };
+        modified_program_spec.validate()?;
+
+        // Update the row, returning the new value. If the row doesn't exist,
+        // this will return None.
+        let result: Result<Option<models::ProgramSpec>, _> =
+            diesel::update(program_specs::table.find(modified_program_spec.id))
+                .set(modified_program_spec)
+                .returning(program_specs::table::all_columns())
+                .get_result(conn)
+                .optional();
+
+        let updated_row: Option<models::ProgramSpec> = DbErrorConverter {
+            // ProgramSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            // No update fields were given
+            query_builder_to_no_update: true,
+            ..Default::default()
+        }
+        .convert(result)?;
+
+        Ok(UpdateProgramSpecPayload {
+            program_spec: updated_row,
+        })
+    }
+
+    fn field_create_user_program(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, CreateUserProgramPayload, Walked>,
+        input: CreateUserProgramInput,
+    ) -> ResponseResult<CreateUserProgramPayload> {
+        let conn: &PgConnection =
+            &executor.context().get_db_conn()? as &PgConnection;
+        let user_id: Uuid = models::User::tmp_user()
+            .select(users::columns::id)
+            .get_result(conn)?;
+
+        // User a helper type to do the insert
+        let new_user_program = models::NewUserProgram {
+            user_id,
+            program_spec_id: util::gql_id_to_uuid(&input.program_spec_id),
+            file_name: &input.file_name,
+            // If no source is provided, default to an empty string
+            source_code: input.source_code.as_deref().unwrap_or(""),
+        };
+        new_user_program.validate()?;
+
+        // Insert the new row and return the whole row
+        let result: Result<models::UserProgram, _> = new_user_program
+            .insert()
+            .returning(user_programs::table::all_columns())
+            .get_result(conn);
+
+        let user_program: models::UserProgram = DbErrorConverter {
+            // Given program spec ID was invalid. Note: this can also indicate
+            // an invalid user ID which would be a server-side bug, but fuck it
+            fk_violation_to_not_found: true,
+            // UserProgram already exists with this program spec/file name
+            unique_violation_to_exists: true,
+            ..Default::default()
+        }
+        .convert(result)?;
+
+        Ok(CreateUserProgramPayload { user_program })
+    }
+
+    fn field_update_user_program(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UpdateUserProgramPayload, Walked>,
+        input: UpdateUserProgramInput,
+    ) -> ResponseResult<UpdateUserProgramPayload> {
+        let conn: &PgConnection =
+            &executor.context().get_db_conn()? as &PgConnection;
+
+        // User a helper type to do the insert
+        let modified_user_program = models::ModifiedUserProgram {
+            id: util::gql_id_to_uuid(&input.id),
+            file_name: input.file_name.as_deref(),
+            source_code: input.source_code.as_deref(),
+        };
+        modified_user_program.validate()?;
+
+        // Update the row, returning the new value. If the row doesn't exist,
+        // this will return None.
+        let result: Result<Option<models::UserProgram>, _> =
+            diesel::update(user_programs::table.find(modified_user_program.id))
+                .set(modified_user_program)
+                .returning(user_programs::table::all_columns())
+                .get_result(conn)
+                .optional();
+
+        let updated_row: Option<models::UserProgram> = DbErrorConverter {
+            // UserProgram already exists with this program spec/file name
+            unique_violation_to_exists: true,
+            // No update fields were given
+            query_builder_to_no_update: true,
+            ..Default::default()
+        }
+        .convert(result)?;
+
+        Ok(UpdateUserProgramPayload {
+            user_program: updated_row,
+        })
+    }
+
+    fn field_delete_user_program(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, DeleteUserProgramPayload, Walked>,
+        input: DeleteUserProgramInput,
+    ) -> ResponseResult<DeleteUserProgramPayload> {
+        use self::user_programs::dsl::*;
+
+        // Delete and get the ID back
+        let row_id = util::gql_id_to_uuid(&input.user_program_id);
+        let deleted_id: Option<Uuid> =
+            diesel::delete(user_programs.filter(id.eq(row_id)))
+                .returning(id)
+                .get_result(&executor.context().get_db_conn()?)
+                .optional()?;
+
+        Ok(DeleteUserProgramPayload { deleted_id })
+    }
+}

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -55,6 +55,20 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         &self.program_spec.slug
     }
 
+    fn field_name(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &String {
+        &self.program_spec.name
+    }
+
+    fn field_description(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &String {
+        &self.program_spec.description
+    }
+
     fn field_input(
         &self,
         _executor: &juniper::Executor<'_, Context>,

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -6,9 +6,9 @@ use crate::{
         hardware_spec::HardwareSpecNode,
         internal::{GenericEdge, NodeType},
         user_program::{UserProgramConnection, UserProgramNode},
-        ConnectionPageParams, Context, Cursor, PageInfo,
-        ProgramSpecConnectionFields, ProgramSpecEdgeFields,
-        ProgramSpecNodeFields,
+        ConnectionPageParams, Context, CreateProgramSpecPayloadFields, Cursor,
+        PageInfo, ProgramSpecConnectionFields, ProgramSpecEdgeFields,
+        ProgramSpecNodeFields, UpdateProgramSpecPayloadFields,
     },
     util,
 };
@@ -245,5 +245,34 @@ impl ProgramSpecConnectionFields for ProgramSpecConnection {
         _trail: &QueryTrail<'_, ProgramSpecEdge, Walked>,
     ) -> ResponseResult<Vec<ProgramSpecEdge>> {
         self.get_edges(executor.context())
+    }
+}
+pub struct CreateProgramSpecPayload {
+    pub program_spec: models::ProgramSpec,
+}
+
+impl CreateProgramSpecPayloadFields for CreateProgramSpecPayload {
+    fn field_program_spec_edge(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, ProgramSpecEdge, Walked>,
+    ) -> ProgramSpecEdge {
+        GenericEdge::from_db_row(self.program_spec.clone(), 0)
+    }
+}
+
+pub struct UpdateProgramSpecPayload {
+    pub program_spec: Option<models::ProgramSpec>,
+}
+
+impl UpdateProgramSpecPayloadFields for UpdateProgramSpecPayload {
+    fn field_program_spec_edge(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, ProgramSpecEdge, Walked>,
+    ) -> Option<ProgramSpecEdge> {
+        self.program_spec
+            .as_ref()
+            .map(|row| GenericEdge::from_db_row(row.clone(), 0))
     }
 }

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -4,11 +4,9 @@ use crate::{
     schema::user_programs,
     server::gql::{
         internal::{GenericEdge, NodeType},
-        program_spec::ProgramSpecNode,
-        user::UserNode,
         ConnectionPageParams, Context, CreateUserProgramPayloadFields, Cursor,
-        DeleteUserProgramPayloadFields, PageInfo,
-        UpdateUserProgramPayloadFields, UserProgramConnectionFields,
+        DeleteUserProgramPayloadFields, PageInfo, ProgramSpecNode,
+        UpdateUserProgramPayloadFields, UserNode, UserProgramConnectionFields,
         UserProgramEdgeFields, UserProgramNodeFields,
     },
     util,

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -15,6 +15,9 @@ use wasm_bindgen::{prelude::*, JsCast};
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Validate)]
 pub struct HardwareSpec {
+    // IMPORTANT: If you change any of the range values here, update
+    // NewHardwareSpec in the api crate as well
+
     // TODO make these readonly and camel case in wasm
     /// Number of registers available
     #[validate(range(min = 1, max = 16))]
@@ -118,6 +121,8 @@ impl Default for HardwareSpec {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Validate)]
 pub struct ProgramSpec {
+    // IMPORTANT: If you update these validation values, make sure you update
+    // NewProgramSpec in the api crate as well!
     /// The input values, where the element at position 0 is the first one that
     /// will be popped off.
     #[validate(length(max = 256))]


### PR DESCRIPTION
- Added the new `name` column to the hardware spec accessor
- Added the new `name` and `description` columnds to the program spec accessor
- Added for new mutations
  - `createHardwareSpec`
  - `updateHardwareSpec`
  - `createProgramSpec`
  - `updateProgramSpec`

For the create mutations, I made the slugs auto-generated based on the name. For the update mutations, you can change the name but the slug doesn't get re-generated. This is to prevent slugs getting invalidated and breaking links.

Then some other random shit:
- Added a `db-reset` task to `cargo make` for the API crate
- Fixed up some missing DB constraints
- Split all the mutations into a separate file
- Added the new `NoUpdate` API error and a field in `DbErrorConverter` to generate it
- Split apart the `DbErrorConverter` tests into multiple funcs