### PR TITLE
Memoize executeNext to improve performance

### DIFF
--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -172,7 +172,7 @@ const ProgramIde: React.FC<{
     [wasmHardwareSpec, wasmProgramSpec, updateCompiledState]
   );
 
-  const executeNext = (): void => {
+  const executeNext = useCallback((): void => {
     if (compileResult.current?.type === 'compiled') {
       compileResult.current.machine.executeNext();
       // We need to manually refresh since the wasm pointers won't change
@@ -183,7 +183,7 @@ const ProgramIde: React.FC<{
         'Program is not compiled, cannot execute next instruction.'
       );
     }
-  };
+  }, [compileResult, updateCompiledState]);
 
   // When either spec or the source changes, invalidate the compiled program
   useEffect(() => {


### PR DESCRIPTION
Turns out that because of some React fuckery, this lambda was getting re-created every render which was causing the `setInterval` to get called every render. This change improves the performance of the auto-stepper a lot which is neat.