### PR TITLE
Remove validator from core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,8 +856,6 @@ dependencies = [
  "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom_locate 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)",
- "validator_derive 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)",
  "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -885,8 +883,8 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)",
- "validator_derive 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)",
+ "validator 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1441,8 +1439,8 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator_derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2201,21 +2199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "validator"
-version = "0.10.0"
-source = "git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl#f51e0d671880b32a574060c642e405c590dd0974"
-dependencies = [
- "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "validator"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2229,21 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.10.0"
-source = "git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl#f51e0d671880b32a574060c642e405c590dd0974"
-dependencies = [
- "if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2252,7 +2222,7 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2675,10 +2645,8 @@ dependencies = [
 "checksum untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-"checksum validator 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)" = "<none>"
-"checksum validator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ab5990ba09102e1ddc954d294f09b9ea00fc7831a5813bbe84bfdbcae44051e"
-"checksum validator_derive 0.10.0 (git+https://github.com/LucasPickering/validator?branch=blanket-ref-impl)" = "<none>"
-"checksum validator_derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e668e9cd05c5009b833833aa1147e5727b5396ea401f22dd1167618eed4a10c9"
+"checksum validator 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e60fadf92c22236de4028ceb0b8af50ed3430d41ad43d7a7d63b6bd1a8f47c38"
+"checksum validator_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d577dfb8ca9440a5c0b053d5a19b68f5c92ef57064bac87c8205c3f6072c20f"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -28,10 +28,8 @@ reqwest = "0.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = "^0.7.0"
-# validator = "0.10.0"
-# validator_derive = "0.10.0"
-validator = { git = "https://github.com/LucasPickering/validator", branch = "blanket-ref-impl" }
-validator_derive = { git = "https://github.com/LucasPickering/validator", branch = "blanket-ref-impl" }
+validator = "0.10.1"
+validator_derive = "0.10.1"
 
 [dev-dependencies]
 maplit = "^1.0.0"

--- a/api/src/models/hardware_spec.rs
+++ b/api/src/models/hardware_spec.rs
@@ -2,8 +2,8 @@ use crate::{models::Factory, schema::hardware_specs};
 use diesel::{
     prelude::*, query_builder::InsertStatement, Identifiable, Queryable,
 };
-use gdlk::validator::Validate;
 use uuid::Uuid;
+use validator::Validate;
 
 /// A derivative of [HardwareSpec](gdlk::HardwareSpec), containing all fields.
 /// that are present on the DB table. This should only ever be constructed from

--- a/api/src/models/program_spec.rs
+++ b/api/src/models/program_spec.rs
@@ -6,8 +6,8 @@ use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
     sql_types, Identifiable, Queryable,
 };
-use gdlk::validator::Validate;
 use uuid::Uuid;
+use validator::Validate;
 
 type WithHardwareSpec = dsl::Eq<
     program_specs::columns::hardware_spec_id,

--- a/api/src/models/user_program.rs
+++ b/api/src/models/user_program.rs
@@ -6,8 +6,8 @@ use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
     sql_types, Identifiable, Queryable,
 };
-use gdlk::validator::Validate;
 use uuid::Uuid;
+use validator::Validate;
 
 /// Expression to filter user_programs by owner's ID and program spec ID
 type WithUserAndProgramSpec = dsl::And<

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -9,13 +9,12 @@ use crate::{
         HardwareSpecConnectionFields, HardwareSpecEdgeFields,
         HardwareSpecNodeFields, PageInfo, UpdateHardwareSpecPayloadFields,
     },
-    util,
+    util::{self, Valid},
 };
 use diesel::{
     dsl, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
     QueryResult, RunQueryDsl,
 };
-use gdlk::Valid;
 use juniper::ID;
 use juniper_from_schema::{QueryTrail, Walked};
 use std::convert::TryInto;

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -11,11 +11,10 @@ use crate::{
         hardware_spec::*, mutation::*, program_spec::*, user::*,
         user_program::*,
     },
-    util::{Pool, PooledConnection},
+    util::{Pool, PooledConnection, Valid},
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
 use failure::Fallible;
-use gdlk::Valid;
 use juniper_from_schema::graphql_schema_from_file;
 use serde::{Serialize, Serializer};
 use std::{convert::TryInto, sync::Arc};

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -17,9 +17,9 @@ use diesel::{
     ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl,
     Table,
 };
-use gdlk::validator::Validate;
 use juniper_from_schema::{QueryTrail, Walked};
 use uuid::Uuid;
+use validator::Validate;
 
 /// The top-level mutation object.
 pub struct Mutation;

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -10,13 +10,12 @@ use crate::{
         PageInfo, ProgramSpecConnectionFields, ProgramSpecEdgeFields,
         ProgramSpecNodeFields, UpdateProgramSpecPayloadFields,
     },
-    util,
+    util::{self, Valid},
 };
 use diesel::{
     dsl, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
     QueryResult, RunQueryDsl, Table,
 };
-use gdlk::Valid;
 use juniper::ID;
 use juniper_from_schema::{QueryTrail, Walked};
 use std::convert::TryInto;

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -9,10 +9,9 @@ use crate::{
         UpdateUserProgramPayloadFields, UserNode, UserProgramConnectionFields,
         UserProgramEdgeFields, UserProgramNodeFields,
     },
-    util,
+    util::{self, Valid},
 };
 use diesel::{dsl, PgConnection, QueryDsl, QueryResult, RunQueryDsl, Table};
-use gdlk::Valid;
 use juniper::ID;
 use juniper_from_schema::{QueryTrail, Walked};
 use std::convert::TryInto;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all, unused_must_use, unused_imports)]
 
 use failure::Fallible;
-use gdlk::{Compiler, HardwareSpec, ProgramSpec, Valid};
+use gdlk::{Compiler, HardwareSpec, ProgramSpec};
 use serde::de::DeserializeOwned;
 use std::{fs, path::PathBuf, process};
 use structopt::StructOpt;
@@ -67,8 +67,7 @@ fn run(opt: Opt) -> Fallible<()> {
             hardware_spec_path,
             source_path,
         } => {
-            let hw_spec: Valid<HardwareSpec> =
-                Valid::validate(load_spec(&hardware_spec_path)?)?;
+            let hw_spec: HardwareSpec = load_spec(&hardware_spec_path)?;
             // Read the source code from the file
             let source = fs::read_to_string(source_path)?;
             // Compile
@@ -82,18 +81,15 @@ fn run(opt: Opt) -> Fallible<()> {
             source_path,
         } => {
             // Read and parse the hw spec and program spec from JSON files
-            let hw_spec: Valid<HardwareSpec> =
-                Valid::validate(load_spec(&hardware_spec_path)?)?;
-            let raw_program_spec: ProgramSpec = load_spec(&program_spec_path)?;
-            let program_spec: Valid<&ProgramSpec> =
-                Valid::validate(&raw_program_spec)?;
+            let hw_spec: HardwareSpec = load_spec(&hardware_spec_path)?;
+            let program_spec: ProgramSpec = load_spec(&program_spec_path)?;
 
             // Read the source code from the file
             let source = fs::read_to_string(source_path)?;
 
             // Compile and execute
             let mut machine =
-                Compiler::compile(source, hw_spec)?.allocate(program_spec);
+                Compiler::compile(source, hw_spec)?.allocate(&program_spec);
             let success = machine.execute_all().map_err(Clone::clone)?;
 
             println!(

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,10 +15,6 @@ failure = "0.1"
 nom = "5.1.1"
 nom_locate = "2.0"
 serde = { version = "1.0", features = ["derive"] }
-# validator = "0.10.0"
-# validator_derive = "0.10.0"
-validator = { git = "https://github.com/LucasPickering/validator", branch = "blanket-ref-impl" }
-validator_derive = { git = "https://github.com/LucasPickering/validator", branch = "blanket-ref-impl" }
 
 [dependencies.wasm-bindgen]
 version = "0.2.58"

--- a/core/src/delabel.rs
+++ b/core/src/delabel.rs
@@ -77,7 +77,6 @@ mod tests {
     use crate::{
         ast::{Jump, Operator, RegisterRef},
         models::HardwareSpec,
-        util::Valid,
     };
 
     #[test]
@@ -135,7 +134,7 @@ mod tests {
         ];
         let compiler = Compiler {
             source: "".into(),
-            hardware_spec: Valid::validate(HardwareSpec::default()).unwrap(),
+            hardware_spec: HardwareSpec::default(),
             ast: SourceProgram { body },
         };
         assert_eq!(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,16 +5,15 @@
 //! and expected outputs.
 //!
 //! ```
-//! use gdlk::{HardwareSpec, ProgramSpec, Valid, Compiler};
+//! use gdlk::{HardwareSpec, ProgramSpec, Compiler};
 //!
 //! // Create the specs
-//! let hardware_spec = Valid::validate(HardwareSpec {
+//! let hardware_spec = HardwareSpec {
 //!     num_registers: 1,
 //!     num_stacks: 0,
 //!     max_stack_length: 0,
-//! }).unwrap();
-//! let raw_program_spec = ProgramSpec::new(vec![1], vec![2]);
-//! let program_spec = Valid::validate(&raw_program_spec).unwrap();
+//! };
+//! let program_spec = ProgramSpec::new(vec![1], vec![2]);
 //!
 //! // Write your program
 //! let source: String = "
@@ -30,18 +29,13 @@
 //! ).unwrap();
 //!
 //! // Execute
-//! let mut machine = compiled.allocate(program_spec);
+//! let mut machine = compiled.allocate(&program_spec);
 //! machine.execute_all().unwrap();
 //! assert!(machine.successful());
 //! ```
 
 #![deny(clippy::all, unused_must_use, unused_imports)]
 #![feature(or_patterns)]
-
-// Re-export dependencies that consumers may need
-pub use validator;
-#[macro_use]
-extern crate validator_derive;
 
 pub mod ast;
 mod consts;
@@ -56,7 +50,7 @@ mod validate;
 pub use consts::MAX_CYCLE_COUNT;
 pub use machine::*;
 pub use models::*;
-pub use util::{Span, Valid};
+pub use util::Span;
 
 use ast::compiled::Program;
 use error::{CompileError, WithSource};
@@ -70,7 +64,7 @@ use std::fmt::Debug;
 pub struct Compiler<T: Debug> {
     // These are deliberately private, to prevent direct construction
     source: String,
-    hardware_spec: Valid<HardwareSpec>,
+    hardware_spec: HardwareSpec,
     ast: T,
 }
 
@@ -82,7 +76,7 @@ impl Compiler<()> {
     /// library-level documentation for more info.
     pub fn compile(
         source: String,
-        hardware_spec: Valid<HardwareSpec>,
+        hardware_spec: HardwareSpec,
     ) -> Result<Compiler<Program<Span>>, WithSource<CompileError>> {
         Ok(Self {
             source,
@@ -108,7 +102,7 @@ impl Compiler<Program<Span>> {
     /// Allocate a new [Machine] to execute a compiled program. The returned
     /// machine can then be executed. `program_spec` defines the parameters
     /// under which the program will execute.
-    pub fn allocate(self, program_spec: Valid<&ProgramSpec>) -> Machine {
+    pub fn allocate(self, program_spec: &ProgramSpec) -> Machine {
         Machine::new(self.hardware_spec, program_spec, self.ast, self.source)
     }
 }

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -10,7 +10,7 @@ use crate::{
     debug,
     error::{RuntimeError, SourceErrorWrapper, WithSource},
     models::{HardwareSpec, ProgramSpec},
-    util::{Span, Valid},
+    util::Span,
 };
 use std::{
     cmp::Ordering, collections::HashMap, convert::TryInto, iter, num::Wrapping,
@@ -31,7 +31,7 @@ pub struct Machine {
     // Static data - this is copied from the input and shouldn't be included in
     // serialization. We store these ourselves instead of keeping references
     // to the originals because it just makes life a lot easier.
-    hardware_spec: Valid<HardwareSpec>,
+    hardware_spec: HardwareSpec,
     source: String,
     program: Program<Span>,
     expected_output: Vec<LangValue>,
@@ -65,8 +65,8 @@ pub struct Machine {
 impl Machine {
     /// Creates a new machine, ready to be executed.
     pub fn new(
-        hardware_spec: Valid<HardwareSpec>,
-        program_spec: Valid<&ProgramSpec>,
+        hardware_spec: HardwareSpec,
+        program_spec: &ProgramSpec,
         program: Program<Span>,
         source: String,
     ) -> Self {

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -6,27 +6,20 @@
 use crate::ast::wasm::StringArray;
 use crate::ast::{LangValue, RegisterRef, StackRef};
 use serde::{Deserialize, Serialize};
-use validator::Validate;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::{prelude::*, JsCast};
 
 /// The "hardware" that a program can execute on. This defines computing
 /// constraints. This is needed both at compile time and runtime.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Validate)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HardwareSpec {
-    // IMPORTANT: If you change any of the range values here, update
-    // NewHardwareSpec in the api crate as well
-
     // TODO make these readonly and camel case in wasm
     /// Number of registers available
-    #[validate(range(min = 1, max = 16))]
     pub num_registers: usize,
     /// Maximum number of stacks permitted
-    #[validate(range(min = 0, max = 16))]
     pub num_stacks: usize,
     /// Maximum size of each stack
-    #[validate(range(min = 0, max = 256))]
     pub max_stack_length: usize,
 }
 
@@ -119,17 +112,13 @@ impl Default for HardwareSpec {
 /// program runs on, and defines the expected output, which is used to determine
 /// if the program is correct. Only needed at runtime.
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Validate)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProgramSpec {
-    // IMPORTANT: If you update these validation values, make sure you update
-    // NewProgramSpec in the api crate as well!
     /// The input values, where the element at position 0 is the first one that
     /// will be popped off.
-    #[validate(length(max = 256))]
     input: Vec<LangValue>,
     /// The correct value to be left in the output when the program exits. The
     /// first element will be the first one pushed, and so on.
-    #[validate(length(max = 256))]
     expected_output: Vec<LangValue>,
 }
 

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -4,9 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Formatter},
     iter,
-    ops::Deref,
 };
-use validator::{Validate, ValidationErrors};
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
@@ -101,45 +99,6 @@ impl Span {
     /// a sub-slice of the given string that corresponds to this span.
     pub fn get_source_slice<'a>(&self, src: &'a str) -> &'a str {
         &src[self.offset..(self.offset + self.length)]
-    }
-}
-
-/// A small wrapper struct to indicate that the wrapped value has been
-/// validated. Built on top of [validator]. This struct can only be constructed
-/// via [Valid::validate].
-///
-/// ```
-/// use gdlk::{HardwareSpec, Valid};
-///
-/// let maybe_valid = HardwareSpec {
-///     num_registers: 1,
-///     num_stacks: 1,
-///     max_stack_length: 10,
-/// };
-/// let valid: Valid<HardwareSpec> = Valid::validate(maybe_valid).unwrap();
-/// ```
-#[derive(Copy, Clone, Debug)]
-pub struct Valid<T: Validate> {
-    inner: T,
-}
-
-impl<T: Validate> Valid<T> {
-    /// Validate the given value. If validation succeeds, wrap it in a
-    /// [Valid] to indicate it's valid.
-    pub fn validate(value: T) -> Result<Self, ValidationErrors> {
-        // We can't do a blanket TryFrom<T: Validate> implementation because of
-        // this bug https://github.com/rust-lang/rust/issues/50133
-        // Will have to wait for better specialization
-        value.validate()?;
-        Ok(Self { inner: value })
-    }
-}
-
-impl<T: Validate> Deref for Valid<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        &self.inner
     }
 }
 

--- a/core/tests/test_compile_error.rs
+++ b/core/tests/test_compile_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during compilation.
 
-use gdlk::{ast::LangValue, Compiler, HardwareSpec, Valid};
+use gdlk::{ast::LangValue, Compiler, HardwareSpec};
 
 /// Compiles the program for the given hardware, expecting compile error(s).
 /// Panics if the program compiles successfully, or if the wrong set of
@@ -10,7 +10,7 @@ macro_rules! assert_compile_errors {
     ($hw_spec:expr, $src:expr, $expected_errors:expr $(,)?) => {
         // Compile from hardware+src
         let actual_errors: Vec<String> =
-            Compiler::compile($src.into(), Valid::validate($hw_spec).unwrap())
+            Compiler::compile($src.into(), $hw_spec)
                 .unwrap_err()
                 .errors()
                 .iter()
@@ -25,11 +25,9 @@ macro_rules! assert_compile_errors {
 /// Macro to compile a program and expect a particular compiler error.
 macro_rules! assert_parse_error {
     ($src:expr, $expected_error:expr $(,)?) => {
-        let actual_errors = Compiler::compile(
-            $src.into(),
-            Valid::validate(HardwareSpec::default()).unwrap(),
-        )
-        .unwrap_err();
+        let actual_errors =
+            Compiler::compile($src.into(), HardwareSpec::default())
+                .unwrap_err();
         assert_eq!(actual_errors.to_string(), $expected_error);
     };
 }

--- a/core/tests/test_runtime_error.rs
+++ b/core/tests/test_runtime_error.rs
@@ -1,7 +1,7 @@
 //! Integration tests for GDLK that expect compile errors. The programs in
 //! these tests should all fail during execution.
 
-use gdlk::{Compiler, HardwareSpec, ProgramSpec, Valid};
+use gdlk::{Compiler, HardwareSpec, ProgramSpec};
 
 /// Compiles the program for the given hardware, executes it under the given
 /// program spec, and expects a runtime error. Panics if the program executes
@@ -9,10 +9,9 @@ use gdlk::{Compiler, HardwareSpec, ProgramSpec, Valid};
 macro_rules! assert_runtime_error {
     ($hw_spec:expr,$program_spec:expr, $src:expr, $expected_error:expr $(,)?) => {{
         // Compile from hardware+src
-        let mut machine =
-            Compiler::compile($src.into(), Valid::validate($hw_spec).unwrap())
-                .unwrap()
-                .allocate(Valid::validate(&($program_spec)).unwrap());
+        let mut machine = Compiler::compile($src.into(), $hw_spec)
+            .unwrap()
+            .allocate(&($program_spec));
 
         // Execute to completion
         let actual_error = machine.execute_all().unwrap_err();

--- a/core/tests/test_success.rs
+++ b/core/tests/test_success.rs
@@ -2,22 +2,18 @@
 //! these tests should compile successfully, and execute with a successful
 //! outcome.
 
-use gdlk::{ast::LangValue, Compiler, HardwareSpec, ProgramSpec, Valid};
+use gdlk::{ast::LangValue, Compiler, HardwareSpec, ProgramSpec};
 
 /// Compiles the program for the given hardware, and executes it against the
 /// program spec. Panics if the compile fails or the execution isn't
 /// successful.
 macro_rules! assert_success {
     ($hardware_spec:expr, $program_spec:expr, $src:expr $(,)?) => {{
-        let program_spec_val = $program_spec;
-        let valid_program_spec = Valid::validate(&program_spec_val).unwrap();
+        let program_spec_val = &$program_spec;
         // Compile from hardware+src
-        let mut machine = Compiler::compile(
-            $src.into(),
-            Valid::validate($hardware_spec).unwrap(),
-        )
-        .unwrap()
-        .allocate(valid_program_spec);
+        let mut machine = Compiler::compile($src.into(), $hardware_spec)
+            .unwrap()
+            .allocate(program_spec_val);
 
         // Execute to completion
         let success = machine.execute_all().unwrap();
@@ -25,7 +21,7 @@ macro_rules! assert_success {
         // Make sure program terminated successfully
         // Check each bit of state individually to make debugging easier
         assert_eq!(machine.input(), &[] as &[LangValue]);
-        assert_eq!(machine.output(), valid_program_spec.expected_output());
+        assert_eq!(machine.output(), program_spec_val.expected_output());
         // Final sanity check, in case we change the criteria for success
         assert!(success);
         machine


### PR DESCRIPTION
I don't think we need the validation in the core crate. We can just validate in the API crate, then we don't need to duplicate the logic.