### PR TITLE
Add date columns to userProgram, store source code in browser local storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_derives 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,6 +881,7 @@ dependencies = [
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web-actors 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,12 +14,13 @@ actix-web = "2.0"
 actix-web-actors = "2.0"
 actix-rt = "1.0"
 base64 = "^0.12.0"
+chrono = "0.4"
 config = { version = "0.10", default-features = false, features = ["json"] }
-diesel = { version = "^1.4.3", features = ["postgres", "r2d2", "uuidv07"] }
+diesel = { version = "^1.4.3", default-features = false, features = ["chrono", "postgres", "r2d2", "uuidv07"] }
 env_logger = "0.7"
 failure = "0.1"
 gdlk = { path = "../core" }
-juniper = "0.14.2"
+juniper = { version = "0.14.2", default-features = false, features = ["chrono"] }
 # juniper-from-schema = "0.5.2"
 juniper-from-schema = { git = "https://github.com/LucasPickering/juniper-from-schema", branch = "fragment-bug-workaround" }
 log = "^0.4.8"

--- a/api/migrations/2020-05-30-210416_init_db/up.sql
+++ b/api/migrations/2020-05-30-210416_init_db/up.sql
@@ -42,7 +42,7 @@ END
 $$;
 
 -- A function to update the `last_modified` col. To be used as a BEFORE UPDATE trigger
-CREATE FUNCTION public.sync_lastmod() RETURNS trigger
+CREATE FUNCTION public.update_last_modified() RETURNS trigger
   LANGUAGE plpgsql
   AS $$
 BEGIN

--- a/api/migrations/2020-05-30-210416_init_db/up.sql
+++ b/api/migrations/2020-05-30-210416_init_db/up.sql
@@ -31,11 +31,22 @@ RETURNS TEXT AS $$
   SELECT "value" FROM "trimmed";
 $$ LANGUAGE SQL STRICT IMMUTABLE;
 
+-- A function to automatically set the `slug` col from the `name` col
 CREATE FUNCTION public.set_slug_from_name() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
+  LANGUAGE plpgsql
+  AS $$
 BEGIN
   NEW.slug := slugify(NEW.name);
+  RETURN NEW;
+END
+$$;
+
+-- A function to update the `last_modified` col. To be used as a BEFORE UPDATE trigger
+CREATE FUNCTION public.sync_lastmod() RETURNS trigger
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  NEW.last_modified := NOW();
   RETURN NEW;
 END
 $$;

--- a/api/migrations/2020-05-30-210421_init_models/up.sql
+++ b/api/migrations/2020-05-30-210421_init_models/up.sql
@@ -37,9 +37,16 @@ CREATE TABLE user_programs (
     program_spec_id UUID NOT NULL REFERENCES program_specs(id),
     file_name TEXT NOT NULL CHECK (char_length(file_name) > 0),
     source_code TEXT NOT NULL,
-    last_modified TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_modified TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     UNIQUE(user_id, program_spec_id, file_name)
 );
+CREATE TRIGGER
+  update_last_modified
+BEFORE UPDATE ON
+  user_programs
+FOR EACH ROW EXECUTE PROCEDURE
+  update_last_modified();
 
 CREATE TABLE user_providers (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),

--- a/api/migrations/2020-05-30-210421_init_models/up.sql
+++ b/api/migrations/2020-05-30-210421_init_models/up.sql
@@ -37,6 +37,7 @@ CREATE TABLE user_programs (
     program_spec_id UUID NOT NULL REFERENCES program_specs(id),
     file_name TEXT NOT NULL CHECK (char_length(file_name) > 0),
     source_code TEXT NOT NULL,
+    last_modified TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UNIQUE(user_id, program_spec_id, file_name)
 );
 

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -12,6 +12,10 @@ mutated.
 """
 scalar Cursor
 
+# We can't put a description here because of juniper limitations so we have to
+# disable the types-have-descriptions lint rule. After
+# https://github.com/cjoudrey/graphql-schema-linter/issues/18 we can add a
+# disable just to this type
 scalar DateTimeUtc
 
 schema {

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -12,6 +12,8 @@ mutated.
 """
 scalar Cursor
 
+scalar DateTimeUtc
+
 schema {
   query: Query
   mutation: Mutation
@@ -372,6 +374,16 @@ type UserProgramNode implements Node {
   The program source code.
   """
   sourceCode: String! @juniper(infallible: true)
+
+  """
+  The date/time when this object was created.
+  """
+  created: DateTimeUtc! @juniper(infallible: true)
+
+  """
+  The date/time when this object was last modified.
+  """
+  lastModified: DateTimeUtc! @juniper(infallible: true)
 
   """
   The user who owns this program code.

--- a/api/src/models/user_program.rs
+++ b/api/src/models/user_program.rs
@@ -2,6 +2,7 @@ use crate::{
     models::{Factory, ProgramSpec, User},
     schema::user_programs,
 };
+use chrono::{offset::Utc, DateTime};
 use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
     sql_types, Identifiable, Queryable,
@@ -28,6 +29,8 @@ pub struct UserProgram {
     pub program_spec_id: Uuid,
     pub file_name: String,
     pub source_code: String,
+    pub created: DateTime<Utc>,
+    pub last_modified: DateTime<Utc>,
 }
 
 impl UserProgram {

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -28,6 +28,7 @@ table! {
         program_spec_id -> Uuid,
         file_name -> Text,
         source_code -> Text,
+        last_modified -> Nullable<Timestamptz>,
     }
 }
 

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -28,7 +28,8 @@ table! {
         program_spec_id -> Uuid,
         file_name -> Text,
         source_code -> Text,
-        last_modified -> Nullable<Timestamptz>,
+        created -> Timestamptz,
+        last_modified -> Timestamptz,
     }
 }
 

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     util::{self, Valid},
 };
+use chrono::{offset::Utc, DateTime};
 use diesel::{dsl, PgConnection, QueryDsl, QueryResult, RunQueryDsl, Table};
 use juniper::ID;
 use juniper_from_schema::{QueryTrail, Walked};
@@ -55,6 +56,20 @@ impl UserProgramNodeFields for UserProgramNode {
         _executor: &juniper::Executor<'_, Context>,
     ) -> &String {
         &self.user_program.source_code
+    }
+
+    fn field_created(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &DateTime<Utc> {
+        &self.user_program.created
+    }
+
+    fn field_last_modified(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &DateTime<Utc> {
+        &self.user_program.last_modified
     }
 
     fn field_user(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,8 +96,7 @@
       "input-object-values-have-descriptions",
       "relay-connection-types-spec",
       "relay-connection-arguments-spec",
-      "types-are-capitalized",
-      "types-have-descriptions"
+      "types-are-capitalized"
     ]
   }
 }

--- a/frontend/relay.config.js
+++ b/frontend/relay.config.js
@@ -3,4 +3,8 @@ module.exports = {
   schema: '../api/schema.graphql',
   language: 'typescript',
   exclude: ['node_modules/**', '**/__mocks__/**', '**/__generated__/**'],
+  customScalars: {
+    // We'll need to manually convert to Date until https://github.com/facebook/relay/issues/91
+    DateTimeUtc: 'string',
+  },
 };

--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -21,6 +21,7 @@ import { HardwareSpec, ProgramSpec } from 'gdlk_wasm';
 import useDebouncedValue from 'hooks/useDebouncedValue';
 import { assertIsDefined } from 'util/guards';
 import NotFoundPage from 'components/NotFoundPage';
+import { Prompt } from 'react-router-dom';
 
 const useLocalStyles = makeStyles(({ palette, spacing }) => {
   const border = `2px solid ${palette.divider}`;
@@ -217,6 +218,10 @@ const ProgramIde: React.FC<{
         />
         <StackInfo className={localClasses.stackInfo} />
         <CodeEditor className={localClasses.editor} />
+        <Prompt
+          when={sourceCode !== userProgram.sourceCode}
+          message="You have unsaved changes. Are you sure you want to leave?"
+        />
       </div>
     </IdeContext.Provider>
   );

--- a/frontend/src/hooks/useStaticValue.ts
+++ b/frontend/src/hooks/useStaticValue.ts
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+
+/**
+ * Store a static, immutable value that is initialized lazily. An alternative
+ * to useRef, for when the value is expensive to initialize but doesn't need to
+ * be changed.
+ * @param init The function to initialize the static value
+ * @return The initialized value.
+ */
+const useStaticValue = <T>(init: () => T): T => {
+  const ref = useRef<{ initialized: boolean; value: T | undefined }>({
+    initialized: false,
+    value: undefined,
+  });
+
+  if (!ref.current.initialized) {
+    ref.current = { initialized: true, value: init() };
+  }
+
+  // At this point we know `value` is a T, but we  have to convince the typechecker
+  return ref.current.value as T;
+};
+
+export default useStaticValue;

--- a/frontend/src/util/storage.ts
+++ b/frontend/src/util/storage.ts
@@ -1,0 +1,54 @@
+export interface StorageValue<T> {
+  value: T;
+  lastModified: Date;
+}
+
+/**
+ * A utility class to handle storing values in browser local storage.This
+ * handles serializing/deserialize the value via JSON, and also tags it with
+ * a lastModified field automatically.
+ */
+export class StorageHandler<T> {
+  private key: string;
+
+  constructor(key: string) {
+    this.key = key;
+  }
+
+  public get(): StorageValue<T> | undefined {
+    const rawValue = window.localStorage.getItem(this.key);
+    if (rawValue !== null) {
+      try {
+        const objValue = JSON.parse(rawValue);
+
+        // If we get an unexpected value, just return undefined
+        if (
+          typeof objValue === 'object' &&
+          typeof objValue.value !== undefined &&
+          typeof objValue.lastModified === 'string'
+        ) {
+          return {
+            value: objValue.value as T,
+            lastModified: new Date(objValue.lastModified),
+          };
+        }
+      } catch (e) {
+        // Invalid value, just fall through to the default case
+      }
+    }
+
+    return undefined;
+  }
+
+  public set(value: T): void {
+    const storedObj: StorageValue<T> = {
+      value,
+      lastModified: new Date(), // This will be serialized as an ISO string
+    };
+    window.localStorage.setItem(this.key, JSON.stringify(storedObj));
+  }
+
+  public delete(): void {
+    window.localStorage.removeItem(this.key);
+  }
+}


### PR DESCRIPTION
The main purpose here is to store the user's source code in the browser's local storage, so that they don't lose unsaved changes (and this would make it easier to have the IDE work entirely offline). To make this work tho, I added two new columns to `user_programs`:

- `created` (this one wasn't exactly necessary but it seemed useful and it was easy)
- `last_modified`

I also added a prompt that appears if you navigate away from the page without saving your changes. Unfortunately it only works if you're staying within the app, so hitting refresh or the back button won't trigger it. We still have local storage to cover those cases tho.
