### PR TITLE
Prompt for unsaved changes in IDE

### DIFF
--- a/frontend/src/components/common/PromptOnExit.tsx
+++ b/frontend/src/components/common/PromptOnExit.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react';
+import { Prompt } from 'react-router-dom';
+
+/**
+ * Show a prompt when the user navigates away from the current page. This covers
+ * both in-app navigation (within react-router) and browser/out-of-app nav,
+ * e.g. refreshing or manually changing the URL.
+ *
+ * @param when If passed, then the prompt will only be shown when this is true
+ * @param message Message to show in the prompt, ONLY SHOWS FOR IN-APP NAV!
+ *  Browsers don't allow customers messages for browser-level navigation.
+ */
+const PromptOnExit = ({
+  when,
+  message,
+}: {
+  when: boolean;
+  message: string;
+}): React.ReactElement => {
+  // This handles browser nav (refresh, URL change, etc.)
+  useEffect(() => {
+    if (when) {
+      const prompt = (event: BeforeUnloadEvent): void => {
+        event.preventDefault();
+        event.returnValue = ''; // Needed for chrome
+      };
+
+      window.addEventListener('beforeunload', prompt);
+
+      return () => {
+        window.removeEventListener('beforeunload', prompt);
+      };
+    }
+  }, [when]);
+
+  // This handles in-app navigation (just within react-router)
+  return <Prompt when={when} message={message} />;
+};
+
+PromptOnExit.defaultProps = {
+  when: true,
+};
+
+export default PromptOnExit;

--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useMemo,
-  useCallback,
-  useRef,
-} from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { RelayProp, createFragmentContainer } from 'react-relay';
 import graphql from 'babel-plugin-relay/macro';
 import { ProgramIde_hardwareSpec } from './__generated__/ProgramIde_hardwareSpec.graphql';
@@ -21,9 +15,9 @@ import { HardwareSpec, ProgramSpec } from 'gdlk_wasm';
 import useDebouncedValue from 'hooks/useDebouncedValue';
 import { assertIsDefined } from 'util/guards';
 import NotFoundPage from 'components/NotFoundPage';
-import { Prompt } from 'react-router-dom';
 import { StorageHandler } from 'util/storage';
 import useStaticValue from 'hooks/useStaticValue';
+import PromptOnExit from 'components/common/PromptOnExit';
 
 const useLocalStyles = makeStyles(({ palette, spacing }) => {
   const border = `2px solid ${palette.divider}`;
@@ -90,25 +84,23 @@ const ProgramIde: React.FC<{
   assertIsDefined(userProgram);
 
   // These values come from wasm. They're read only, so they're safe to share
-  // with the whole component tree. They are pointed and there updates won't
-  // trigger re-renders, but these values shouldn't be changing while this
-  // component tree is mounted.
-  const wasmHardwareSpec = useMemo(
+  // with the whole component tree. They are pointers and therefore updates
+  // won't trigger re-renders, but these values shouldn't be changing while
+  // this component tree is mounted anyway.
+  const wasmHardwareSpec = useStaticValue(
     () =>
       new HardwareSpec(
         hardwareSpec.numRegisters,
         hardwareSpec.numStacks,
         hardwareSpec.maxStackLength
-      ),
-    [hardwareSpec]
+      )
   );
-  const wasmProgramSpec = useMemo(
+  const wasmProgramSpec = useStaticValue(
     () =>
       new ProgramSpec(
         Int16Array.from(programSpec.input),
         Int16Array.from(programSpec.expectedOutput)
-      ),
-    [programSpec]
+      )
   );
 
   // This wasm value is NOT safe to share outside this component. It's stored
@@ -242,7 +234,9 @@ const ProgramIde: React.FC<{
         />
         <StackInfo className={localClasses.stackInfo} />
         <CodeEditor className={localClasses.editor} />
-        <Prompt
+
+        {/* Prompt on exit for unsaved changes */}
+        <PromptOnExit
           when={sourceCode !== userProgram.sourceCode}
           message="You have unsaved changes. Are you sure you want to leave?"
         />


### PR DESCRIPTION
Added a second IDE prompt, which gets triggered for browser navs (which react-router can't trap). I moved this functionality into a utility component to keep it clean and in case we need to use it again. I tested in Firefox and Chrome, lookin good.