### PR TITLE
Use authenticated user in graphql responses

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -37,6 +37,10 @@ pub enum ResponseError {
     #[fail(display = "No fields were given to update")]
     NoUpdate,
 
+    /// Action cannot be performed because the user is not authenticated.
+    #[fail(display = "Not logged in")]
+    Unauthenticated,
+
     /// User submitted invalid/incorrect credentials for auth
     #[fail(display = "Invalid credentials")]
     InvalidCredentials,

--- a/api/src/models/user.rs
+++ b/api/src/models/user.rs
@@ -28,13 +28,6 @@ impl User {
     ) -> dsl::Filter<users::table, WithUsername<'_>> {
         users::table.filter(Self::with_username(username))
     }
-
-    /// TEMPORARY function that filters for a hard-coded user in the DB. This is
-    /// to be used for operations that require a user, before we implement
-    /// auth.
-    pub fn tmp_user() -> dsl::Filter<users::table, WithUsername<'static>> {
-        Self::filter_by_username("user1")
-    }
 }
 
 #[derive(Debug, Default, PartialEq, Insertable)]

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -31,11 +31,18 @@ graphql_schema_from_file!("schema.graphql", error_type: ResponseError);
 
 pub struct Context {
     pub pool: Arc<Pool>,
+    pub user: Option<models::User>,
 }
 
 impl Context {
     pub fn get_db_conn(&self) -> Result<PooledConnection, ResponseError> {
         Ok(self.pool.get()?)
+    }
+
+    /// Get the authentiated user. If they're not authenticated, return an
+    /// error.
+    pub fn user(&self) -> Result<&models::User, ResponseError> {
+        self.user.as_ref().ok_or(ResponseError::Unauthenticated)
     }
 }
 

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -58,7 +58,13 @@ pub fn uuid_to_gql_id(uuid: Uuid) -> juniper::ID {
 /// the API because we want to handle malformed UUIDs the same way we handle
 /// UUIDs that aren't in the database.
 pub fn gql_id_to_uuid(id: &juniper::ID) -> Uuid {
-    Uuid::parse_str(&id.to_string()).unwrap_or_default()
+    parse_uuid(&id.to_string())
+}
+
+/// Parses the given string into a UUID. If the string cannot be parsed
+/// properly, this just returns the default UUID (all zeroes).
+pub fn parse_uuid(id: &str) -> Uuid {
+    Uuid::parse_str(id).unwrap_or_default()
 }
 
 /// Converts a map to a GraphQL object. Takes in an iterator of (K, V) so that

--- a/api/tests/test_create_hardware_spec.rs
+++ b/api/tests/test_create_hardware_spec.rs
@@ -38,7 +38,7 @@ static QUERY: &str = r#"
 /// Test the standard success state of createHardwareSpec
 #[test]
 fn test_create_hardware_spec_success() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     // We'll test collisions against this
@@ -80,7 +80,7 @@ fn test_create_hardware_spec_success() {
 /// [ERROR] Test createHardwareSpec when you try to use a pre-existing name
 #[test]
 fn test_create_hardware_spec_duplicate() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     // We'll test collisions against this
@@ -114,7 +114,7 @@ fn test_create_hardware_spec_duplicate() {
 /// [ERROR] Test createHardwareSpec when you pass invalid data
 #[test]
 fn test_create_hardware_spec_invalid_values() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
 
     assert_eq!(
         runner.query(

--- a/api/tests/test_create_program_spec.rs
+++ b/api/tests/test_create_program_spec.rs
@@ -40,7 +40,7 @@ static QUERY: &str = r#"
 /// Create a program spec successfully
 #[test]
 fn test_create_program_spec_success() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -85,7 +85,7 @@ fn test_create_program_spec_success() {
 /// [ERROR] References an invalid hardware spec
 #[test]
 fn test_create_program_spec_invalid_hw_spec() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
@@ -115,7 +115,7 @@ fn test_create_program_spec_invalid_hw_spec() {
 /// [ERROR] Program spec name is already taken
 #[test]
 fn test_create_program_spec_duplicate() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
@@ -160,7 +160,7 @@ fn test_create_program_spec_duplicate() {
 /// [ERROR] Values given are invalid
 #[test]
 fn test_create_program_spec_invalid_values() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",

--- a/api/tests/test_delete_user_program.rs
+++ b/api/tests/test_delete_user_program.rs
@@ -23,12 +23,13 @@ static QUERY: &str = r#"
 "#;
 
 #[test]
-fn test_delete_user_program() {
-    let runner = QueryRunner::new().unwrap();
+fn test_delete_user_program_success() {
+    let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
+    let user = NewUser { username: "user1" }.create(conn);
     let user_program_id = NewUserProgram {
-        user_id: NewUser { username: "user1" }.create(conn).id,
+        user_id: user.id,
         program_spec_id: NewProgramSpec {
             name: "prog1",
             hardware_spec_id: NewHardwareSpec {
@@ -46,6 +47,7 @@ fn test_delete_user_program() {
     }
     .create(conn)
     .id;
+    runner.set_user(user); // Log in
 
     // Known row
     assert_eq!(
@@ -76,6 +78,96 @@ fn test_delete_user_program() {
     );
 
     // Deleting again gives a null result
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program_id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "deleteUserProgram": {
+                    "deletedId": serde_json::Value::Null
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+#[test]
+fn test_delete_user_program_not_logged_in() {
+    let runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    let user_program_id = NewUserProgram {
+        user_id: NewUser { username: "user1" }.create(conn).id,
+        program_spec_id: NewProgramSpec {
+            name: "prog1",
+            hardware_spec_id: NewHardwareSpec {
+                name: "hw1",
+                ..Default::default()
+            }
+            .create(conn)
+            .id,
+            ..Default::default()
+        }
+        .create(conn)
+        .id,
+        file_name: "existing.gdlk",
+        source_code: "READ RX0",
+    }
+    .create(conn)
+    .id;
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program_id.to_string()),
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                "locations": [{"line": 3, "column": 9}],
+                "message": "Not logged in",
+                "path": ["deleteUserProgram"],
+            })]
+        )
+    );
+}
+
+/// Test that you can't delete someone else's user_program
+#[test]
+fn test_delete_user_program_wrong_owner() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    let user_program_id = NewUserProgram {
+        user_id: NewUser { username: "user1" }.create(conn).id,
+        program_spec_id: NewProgramSpec {
+            name: "prog1",
+            hardware_spec_id: NewHardwareSpec {
+                name: "hw1",
+                ..Default::default()
+            }
+            .create(conn)
+            .id,
+            ..Default::default()
+        }
+        .create(conn)
+        .id,
+        file_name: "existing.gdlk",
+        source_code: "READ RX0",
+    }
+    .create(conn)
+    .id;
+    let not_owner = NewUser { username: "user2" }.create(conn);
+    runner.set_user(not_owner); // Log in as someone else
+
+    // It should pretend like the user_program doesn't exist
     assert_eq!(
         runner.query(
             QUERY,

--- a/api/tests/test_query_hardware_spec.rs
+++ b/api/tests/test_query_hardware_spec.rs
@@ -11,7 +11,7 @@ mod utils;
 
 #[test]
 fn test_field_hardware_spec() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
@@ -73,7 +73,7 @@ fn test_field_hardware_spec() {
 
 #[test]
 fn test_field_hardware_specs() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     NewHardwareSpec {
@@ -186,7 +186,7 @@ fn test_field_hardware_specs() {
 
 #[test]
 fn test_field_hardware_spec_program_spec() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {

--- a/api/tests/test_query_node.rs
+++ b/api/tests/test_query_node.rs
@@ -13,7 +13,7 @@ mod utils;
 
 #[test]
 fn test_field_node() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let user_id = NewUser { username: "user1" }.create(conn).id;

--- a/api/tests/test_query_user.rs
+++ b/api/tests/test_query_user.rs
@@ -11,7 +11,7 @@ mod utils;
 
 #[test]
 fn test_field_user() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let user_id = NewUser { username: "user1" }.create(conn).id;

--- a/api/tests/test_update_hardware_spec.rs
+++ b/api/tests/test_update_hardware_spec.rs
@@ -40,7 +40,7 @@ static QUERY: &str = r#"
 /// Modify just a subset of fields, make sure the others keep their values
 #[test]
 fn test_update_hardware_spec_partial_modification() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -79,7 +79,7 @@ fn test_update_hardware_spec_partial_modification() {
 /// Modify all fields
 #[test]
 fn test_update_hardware_spec_full_modification() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -120,7 +120,7 @@ fn test_update_hardware_spec_full_modification() {
 /// Pass an invalid ID, get null back
 #[test]
 fn test_update_hardware_spec_invalid_id() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
 
     assert_eq!(
         runner.query(
@@ -144,7 +144,7 @@ fn test_update_hardware_spec_invalid_id() {
 /// [ERROR] Test that passing no modifications is an error
 #[test]
 fn test_update_hardware_spec_empty_modification() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -173,7 +173,7 @@ fn test_update_hardware_spec_empty_modification() {
 /// [ERROR] Test that using a duplicate name returns an error
 #[test]
 fn test_update_hardware_spec_duplicate() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     // We'll test collisions against this
@@ -210,7 +210,7 @@ fn test_update_hardware_spec_duplicate() {
 /// [ERROR] Test that passing invalid values gives an error
 #[test]
 fn test_update_hardware_spec_invalid_values() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 2",

--- a/api/tests/test_update_program_spec.rs
+++ b/api/tests/test_update_program_spec.rs
@@ -40,7 +40,7 @@ static QUERY: &str = r#"
 /// Partial modification, make sure unmodified fields keep their old value
 #[test]
 fn test_update_program_spec_partial_modification() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -86,7 +86,7 @@ fn test_update_program_spec_partial_modification() {
 /// Modify all fields
 #[test]
 fn test_update_program_spec_full_modification() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -137,7 +137,7 @@ fn test_update_program_spec_full_modification() {
 /// Pass an invalid ID, get null back
 #[test]
 fn test_update_program_spec_invalid_id() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
 
     assert_eq!(
         runner.query(
@@ -160,7 +160,7 @@ fn test_update_program_spec_invalid_id() {
 
 #[test]
 fn test_update_program_spec_empty_modification() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
@@ -203,7 +203,7 @@ fn test_update_program_spec_empty_modification() {
 
 #[test]
 fn test_update_program_spec_duplicate() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
@@ -247,7 +247,7 @@ fn test_update_program_spec_duplicate() {
 
 #[test]
 fn test_update_program_spec_invalid_values() {
-    let runner = QueryRunner::new().unwrap();
+    let runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
     let hw_spec = NewHardwareSpec {

--- a/frontend/src/components/hardware/HardwareSpecListItem.tsx
+++ b/frontend/src/components/hardware/HardwareSpecListItem.tsx
@@ -38,11 +38,6 @@ const HardwareSpecListItem: React.FC<{
           >
             <ListItemText
               primary={`${hardwareSpec.slug}/${programSpec.slug}`}
-              secondary={
-                programSpec.userPrograms.totalCount > 0
-                  ? `${programSpec.userPrograms.totalCount} solutions`
-                  : undefined
-              }
             />
           </ListItem>
         ))}
@@ -63,9 +58,6 @@ export default createFragmentContainer(HardwareSpecListItem, {
           node {
             id
             slug
-            userPrograms {
-              totalCount
-            }
           }
         }
       }


### PR DESCRIPTION
This adds the logged-in user to the graphql context, and updates all the user program API handlers to reference that user instead of the `tmp_user` hack. I had to add a bunch of tests to account for new edge cases that occur when the user isn't logged in, or tries to access another user's programs.

Currently this breaks some shit on the frontend if you're not logged in (cause it tries to fetch the user programs but that gives an error). I removed one of these cases but the others i left in place. I'm gonna work on that soon.