### PR TITLE
Improve cookie security

### DIFF
--- a/api/config/default.json
+++ b/api/config/default.json
@@ -1,7 +1,7 @@
 {
   "server_host": "0.0.0.0:8000",
   "open_id": {
-    "host_url": "http://localhost:3000",
+    "host_url": "https://localhost:3000",
     "providers": {
       "google": {
         "issuer_url": "https://accounts.google.com"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     tty: true # Colorize output
     environment:
       GDLK_API_HOST: http://api:8000
+      HTTPS: "true"
     volumes:
       - ./:/app:rw
       - frontend_core_build:/app/target

--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -209,7 +209,9 @@ const ProgramIde: React.FC<{
 
   // When either spec or the source changes, invalidate the compiled program
   useEffect(() => {
-    updateCompiledState(undefined);
+    // Do this as a post-effect so that it doesn't run on first render. That
+    // prevents us wiping out state right after we compile
+    return () => updateCompiledState(undefined);
   }, [wasmHardwareSpec, wasmProgramSpec, sourceCode, updateCompiledState]);
 
   const contextValue: IdeContextType = {


### PR DESCRIPTION
Made some cookie policy changes:
- Changed `Max-Age` to 24h (it was just `Session` before, so in a way this is less secure but I think 24h is still fine)
- Set `Secure: true`
  - This obv requires https to work, so I enabled it in dev. create-react-app has this built in, it just creates a self-signed cert. You'll have to use `https://localhost:3000` from now on
- Used the actual secret key for encryption (all zeroes isn't exactly secure)
- Set `SameSite: Lax`, which prevents CSRF attacks

I also fixed a random UI bug, where the IDE wouldn't show compilation results on the first render.