### PR TITLE
Add authStatus field to API

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -38,6 +38,11 @@ type Query {
   ): Node @juniper(ownership: "owned")
 
   """
+  Data related to the currently logged-in user.
+  """
+  authStatus: AuthStatus! @juniper(infallible: true, ownership: "owned")
+
+  """
   Get a single user by their username.
   """
   user(
@@ -151,6 +156,27 @@ type UserNode implements Node {
   the user and others.
   """
   username: String! @juniper(infallible: true)
+}
+
+"""
+A wrapper for data related to the current user's authentication.
+"""
+type AuthStatus {
+  """
+  Is this user currently logged in?
+  """
+  authenticated: Boolean! @juniper(infallible: true, ownership: "owned")
+
+  """
+  Is the user logged in AND have they created a username for themself?
+  """
+  userCreated: Boolean! @juniper(infallible: true, ownership: "owned")
+
+  """
+  The full user object for the authenticated user. This will be populated
+  iff `userCreated` is `true`.
+  """
+  user: UserNode @juniper(ownership: "owned")
 }
 
 # ===== HARDWARE SPEC =====

--- a/api/src/server/auth.rs
+++ b/api/src/server/auth.rs
@@ -198,12 +198,15 @@ pub async fn route_login(
         None => {
             // user_provider not found (first login) so make the row
             // then init the user
-            let user_provider: UserProvider =
-                NewUserProvider { sub, provider_name }
-                    .insert()
-                    .returning(user_providers::all_columns)
-                    .get_result(conn)
-                    .unwrap();
+            let user_provider: UserProvider = NewUserProvider {
+                sub,
+                provider_name,
+                user_id: None,
+            }
+            .insert()
+            .returning(user_providers::all_columns)
+            .get_result(conn)
+            .unwrap();
 
             // Create a new User object, then set the auth cookie
             init_user(&user_provider, userinfo, conn)?;

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -189,11 +189,11 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<CreateUserProgramPayload> {
         let context = executor.context();
         let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
-        let user = context.user()?;
+        let user_id = context.user_id()?; // User needs to be logged in
 
         // User a helper type to do the insert
         let new_user_program = models::NewUserProgram {
-            user_id: user.id,
+            user_id,
             program_spec_id: util::gql_id_to_uuid(&input.program_spec_id),
             file_name: &input.file_name,
             // If no source is provided, default to an empty string
@@ -230,7 +230,7 @@ impl MutationFields for Mutation {
         let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
         // User needs to be logged in to make changes. This also has to be
         // their user_program.
-        let user = context.user()?;
+        let user_id = context.user_id()?;
 
         // User a helper type to do the insert
         let modified_user_program = models::ModifiedUserProgram {
@@ -247,7 +247,7 @@ impl MutationFields for Mutation {
                 .find(modified_user_program.id)
                 // Extra filter to make sure the requesting user is the owner of
                 // the row.
-                .filter(user_programs::columns::user_id.eq(user.id)),
+                .filter(user_programs::columns::user_id.eq(user_id)),
         )
         .set(modified_user_program)
         .returning(user_programs::table::all_columns())
@@ -278,7 +278,7 @@ impl MutationFields for Mutation {
         let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
         // User needs to be logged in to make changes. This also has to be
         // their user_program.
-        let user = context.user()?;
+        let user_id = context.user_id()?;
 
         // Delete and get the ID back
         let row_id = util::gql_id_to_uuid(&input.user_program_id);
@@ -287,7 +287,7 @@ impl MutationFields for Mutation {
                 .find(row_id)
                 // Extra filter to make sure the requesting user is the owner of
                 // the row.
-                .filter(user_programs::columns::user_id.eq(user.id)),
+                .filter(user_programs::columns::user_id.eq(user_id)),
         )
         .returning(user_programs::columns::id)
         .get_result(conn)

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -112,10 +112,10 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
     ) -> ResponseResult<Option<UserProgramNode>> {
         let context = executor.context();
         let conn = &context.get_db_conn()? as &PgConnection;
-        let user = context.user()?;
+        let user_id = context.user_id()?;
 
         Ok(models::UserProgram::filter_by_user_and_program_spec(
-            user.id,
+            user_id,
             self.program_spec.id,
         )
         .filter(user_programs::dsl::file_name.eq(&file_name))
@@ -132,9 +132,8 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         first: Option<i32>,
         after: Option<Cursor>,
     ) -> ResponseResult<UserProgramConnection> {
-        let user = executor.context().user()?;
-
-        UserProgramConnection::new(user.id, self.program_spec.id, first, after)
+        let user_id = executor.context().user_id()?;
+        UserProgramConnection::new(user_id, self.program_spec.id, first, after)
     }
 }
 

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -1,11 +1,15 @@
 use crate::{
+    error::{ResponseError, ResponseResult},
     models,
     schema::users,
-    server::gql::{internal::NodeType, Context, UserNodeFields},
+    server::gql::{
+        internal::NodeType, AuthStatusFields, Context, UserNodeFields,
+    },
     util,
 };
 use diesel::{PgConnection, QueryDsl, QueryResult, RunQueryDsl};
 use juniper::ID;
+use juniper_from_schema::{QueryTrail, Walked};
 use uuid::Uuid;
 
 #[derive(Clone, Debug)]
@@ -37,5 +41,46 @@ impl UserNodeFields for UserNode {
         _executor: &juniper::Executor<'_, Context>,
     ) -> &String {
         &self.user.username
+    }
+}
+
+/// A simple wrapper for a few fields that pertain to the requesting user's
+/// authentication status.
+pub struct AuthStatus();
+
+impl AuthStatusFields for AuthStatus {
+    fn field_authenticated(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+    ) -> bool {
+        executor.context().user_context.is_some()
+    }
+
+    fn field_user_created(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+    ) -> bool {
+        executor.context().user_id().is_ok()
+    }
+
+    fn field_user(
+        &self,
+        executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserNode, Walked>,
+    ) -> ResponseResult<Option<UserNode>> {
+        let context = executor.context();
+
+        match executor.context().user_id() {
+            Ok(user_id) => {
+                let user: models::User = users::table
+                    .find(user_id)
+                    .get_result(&context.get_db_conn()?)?;
+                Ok(Some(user.into()))
+            }
+            // User isn't authed or hasn't finished setup
+            Err(ResponseError::Unauthenticated) => Ok(None),
+            // This shouldn't be possible
+            Err(err) => Err(err),
+        }
     }
 }

--- a/api/tests/test_query_auth_status.rs
+++ b/api/tests/test_query_auth_status.rs
@@ -1,0 +1,105 @@
+#![deny(clippy::all)]
+
+use diesel::PgConnection;
+use gdlk_api::models::{Factory, NewUser, NewUserProvider};
+use maplit::hashmap;
+use serde_json::json;
+use utils::QueryRunner;
+
+mod utils;
+
+const QUERY: &str = r#"
+query AuthStatusQuery {
+    authStatus {
+        authenticated
+        userCreated
+        user {
+            id
+            username
+        }
+    }
+}
+"#;
+
+/// Test when the user isn't authenticated at all
+#[test]
+fn test_field_auth_status_not_logged_in() {
+    let runner = QueryRunner::new();
+
+    assert_eq!(
+        runner.query(QUERY, hashmap! {}),
+        (
+            json!({
+                "authStatus": {
+                    "authenticated": false,
+                    "userCreated": false,
+                    "user": serde_json::Value::Null,
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Test when the user is logged in, but hasn't finished user setup yet
+#[test]
+fn test_field_auth_status_user_not_created() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+    let user_provider = NewUserProvider {
+        sub: "asdf",
+        provider_name: "provider",
+        user_id: None,
+    }
+    .create(conn);
+    // user_provider is set, but not user
+    runner.set_user_provider(user_provider);
+
+    assert_eq!(
+        runner.query(QUERY, hashmap! {}),
+        (
+            json!({
+                "authStatus": {
+                    "authenticated": true,
+                    "userCreated": false,
+                    "user": serde_json::Value::Null,
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Test when the user is logged in and has created their user. This should be
+/// the most common auth status.
+#[test]
+fn test_field_auth_status_user_created() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+    let user = NewUser { username: "user1" }.create(conn);
+    let user_provider = NewUserProvider {
+        sub: "asdf",
+        provider_name: "provider",
+        user_id: Some(user.id),
+    }
+    .create(conn);
+    // user_provider is set, but not user
+    runner.set_user_provider(user_provider);
+
+    assert_eq!(
+        runner.query(QUERY, hashmap! {}),
+        (
+            json!({
+                "authStatus": {
+                    "authenticated": true,
+                    "userCreated": true,
+                    "user": {
+                        "id": user.id.to_string(),
+                        "username": "user1",
+                    },
+                }
+            }),
+            vec![]
+        )
+    );
+}


### PR DESCRIPTION
Adds a new top-level field to the API called `authStatus` that exposes data for the current user. The frontend can use this to decide whether to show log in vs log out button, the set username page, etc. I had to make some changes to how the user is stored in the GQL context for this. I realized we don't actually need the full user object in most cases, so now we're not running a query for the user on each request anymore. #performance