### PR TITLE
Add initializeUser mutation

### DIFF
--- a/api/migrations/2020-05-30-210421_init_models/down.sql
+++ b/api/migrations/2020-05-30-210421_init_models/down.sql
@@ -1,3 +1,4 @@
+DROP TABLE user_providers;
 DROP TABLE user_programs;
 DROP TABLE users;
 DROP TABLE program_specs;

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -159,6 +159,20 @@ type UserNode implements Node {
 }
 
 """
+Edge for UserNode.
+"""
+type UserEdge implements Edge {
+  """
+  The related node.
+  """
+  node: UserNode! @juniper(infallible: true)
+  """
+  Identifier for this edge.
+  """
+  cursor: Cursor! @juniper(infallible: true)
+}
+
+"""
 A wrapper for data related to the current user's authentication.
 """
 type AuthStatus {
@@ -474,6 +488,17 @@ The root mutation. Some general notes about mutations:
 """
 type Mutation {
   """
+  Perform first-time setup for a user. This needs to be run after first log in
+  for a user. This can only be run once (subsequent calls will return an error).
+  """
+  initializeUser(
+    """
+    All input fields
+    """
+    input: InitializeUserInput!
+  ): InitializeUserPayload! @juniper(ownership: "owned")
+
+  """
   Create a new hardware spec. An error is returned if the given name is
   already taken, or if the slug derived from that name is already taken.
   """
@@ -548,6 +573,26 @@ type Mutation {
     """
     input: DeleteUserProgramInput!
   ): DeleteUserProgramPayload! @juniper(ownership: "owned")
+}
+
+"""
+Input to the `initializeUser` mutation.
+"""
+input InitializeUserInput {
+  """
+  New username to set. Must be non-empty and globally unique.
+  """
+  username: String!
+}
+
+"""
+Output from the `initializeUser` mutation.
+"""
+type InitializeUserPayload {
+  """
+  The initialized user.
+  """
+  userEdge: UserEdge! @juniper(infallible: true, ownership: "owned")
 }
 
 """

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -224,7 +224,7 @@ impl DbErrorConverter {
             Err(diesel::result::Error::QueryBuilderError(msg))
                 if self.query_builder_to_no_update
                 // Currently this is the only way a QueryBuilderError can occur,
-                // but diesel could change that so keep this error to be safe
+                // but diesel could change that so keep this check to be safe
                     && msg.to_string().contains("no changes to save") =>
             {
                 Err(ResponseError::NoUpdate)

--- a/api/src/models/user.rs
+++ b/api/src/models/user.rs
@@ -4,6 +4,7 @@ use diesel::{
     sql_types::Text, Identifiable, Queryable,
 };
 use uuid::Uuid;
+use validator::Validate;
 
 /// Expression to filter users by username
 pub type WithUsername<'a> =
@@ -30,9 +31,10 @@ impl User {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Insertable)]
+#[derive(Debug, Default, PartialEq, Insertable, Validate)]
 #[table_name = "users"]
 pub struct NewUser<'a> {
+    #[validate(length(min = 1))]
     pub username: &'a str,
 }
 

--- a/api/src/models/user.rs
+++ b/api/src/models/user.rs
@@ -34,7 +34,7 @@ impl User {
 #[derive(Debug, Default, PartialEq, Insertable, Validate)]
 #[table_name = "users"]
 pub struct NewUser<'a> {
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 20))]
     pub username: &'a str,
 }
 

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -31,6 +31,7 @@ mod user_program;
 graphql_schema_from_file!("schema.graphql", error_type: ResponseError);
 
 /// A nested part of context, representing the authenticated user.
+#[derive(Copy, Clone, Debug)]
 pub struct UserContext {
     /// The ID of the user_provider that the user used to log in.
     pub user_provider_id: Uuid,

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -3,7 +3,9 @@ use crate::{
     models,
     schema::users,
     server::gql::{
-        internal::NodeType, AuthStatusFields, Context, UserNodeFields,
+        internal::{GenericEdge, NodeType},
+        AuthStatusFields, Context, Cursor, InitializeUserPayloadFields,
+        UserEdgeFields, UserNodeFields,
     },
     util,
 };
@@ -41,6 +43,25 @@ impl UserNodeFields for UserNode {
         _executor: &juniper::Executor<'_, Context>,
     ) -> &String {
         &self.user.username
+    }
+}
+
+pub type UserEdge = GenericEdge<UserNode>;
+
+impl UserEdgeFields for UserEdge {
+    fn field_node(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserNode, Walked>,
+    ) -> &UserNode {
+        self.node()
+    }
+
+    fn field_cursor(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+    ) -> &Cursor {
+        self.cursor()
     }
 }
 
@@ -82,5 +103,19 @@ impl AuthStatusFields for AuthStatus {
             // This shouldn't be possible
             Err(err) => Err(err),
         }
+    }
+}
+
+pub struct InitializeUserPayload {
+    pub user: models::User,
+}
+
+impl InitializeUserPayloadFields for InitializeUserPayload {
+    fn field_user_edge(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserEdge, Walked>,
+    ) -> UserEdge {
+        GenericEdge::from_db_row(self.user.clone(), 0)
     }
 }

--- a/api/tests/test_initialize_user.rs
+++ b/api/tests/test_initialize_user.rs
@@ -149,7 +149,29 @@ fn test_initialize_user_invalid_username() {
                 "path": ["initializeUser"],
                 "extensions": {
                     "username": [
-                        {"min": "1", "value": "\"\""},
+                        {"min": "1", "value": "\"\"", "max": "20"},
+                    ]
+                },
+            })]
+        )
+    );
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                // Length limit is 20 chars
+                "username" => InputValue::scalar("012345678901234567890"),
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                "message": "Input validation error(s)",
+                "locations": [{"line": 5, "column": 9}],
+                "path": ["initializeUser"],
+                "extensions": {
+                    "username": [
+                        {"min": "1", "value": "\"012345678901234567890\"", "max": "20"},
                     ]
                 },
             })]

--- a/api/tests/test_initialize_user.rs
+++ b/api/tests/test_initialize_user.rs
@@ -1,0 +1,204 @@
+#![deny(clippy::all)]
+
+use diesel::{dsl, PgConnection, QueryDsl, RunQueryDsl};
+use gdlk_api::{
+    models::{Factory, NewUser, NewUserProvider},
+    schema::users,
+};
+use juniper::InputValue;
+use maplit::hashmap;
+use serde_json::json;
+use utils::QueryRunner;
+
+mod utils;
+
+static QUERY: &str = r#"
+    mutation InitializeUserMutation(
+        $username: String!,
+    ) {
+        initializeUser(input: {
+            username: $username
+        }) {
+            userEdge {
+                node {
+                    username
+                }
+            }
+        }
+    }
+"#;
+
+/// Initialize a user successfully
+#[test]
+fn test_initialize_user_success() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    let user_provider = NewUserProvider {
+        sub: "sub",
+        provider_name: "provider",
+        user_id: None,
+    }
+    .create(conn);
+    runner.set_user_provider(user_provider);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "username" => InputValue::scalar("user1"),
+            }
+        ),
+        (
+            json!({
+                "initializeUser": {
+                    "userEdge": {
+                        "node": {
+                            "username": "user1"
+                        }
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Try to initialize a user while not logged in.
+#[test]
+fn test_initialize_user_not_logged_in() {
+    let runner = QueryRunner::new();
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "username" => InputValue::scalar("user1"),
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                "message": "Not logged in",
+                "locations": [{"line": 5, "column": 9}],
+                "path": ["initializeUser"],
+            })]
+        )
+    );
+}
+
+/// Setting a username that's already taken should return an error.
+#[test]
+fn test_initialize_user_duplicate_username() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    NewUser { username: "user1" }.create(conn);
+    let user_provider = NewUserProvider {
+        sub: "sub",
+        provider_name: "provider",
+        user_id: None,
+    }
+    .create(conn);
+    runner.set_user_provider(user_provider);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "username" => InputValue::scalar("user1"), // Already taken
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                "message": "This resource already exists",
+                "locations": [{"line": 5, "column": 9}],
+                "path": ["initializeUser"],
+            })]
+        )
+    );
+}
+
+/// Setting a username that doesn't pass validation should return an error
+#[test]
+fn test_initialize_user_invalid_username() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    let user_provider = NewUserProvider {
+        sub: "sub",
+        provider_name: "provider",
+        user_id: None,
+    }
+    .create(conn);
+    runner.set_user_provider(user_provider);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "username" => InputValue::scalar(""), // Invalid username
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                "message": "Input validation error(s)",
+                "locations": [{"line": 5, "column": 9}],
+                "path": ["initializeUser"],
+                "extensions": {
+                    "username": [
+                        {"min": "1", "value": "\"\""},
+                    ]
+                },
+            })]
+        )
+    );
+}
+
+/// Trying to initialize a user that's already been initialized should return
+/// an error.
+#[test]
+fn test_initialize_user_already_initialized() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    let user = NewUser { username: "user1" }.create(conn);
+    let user_provider = NewUserProvider {
+        sub: "sub",
+        provider_name: "provider",
+        user_id: Some(user.id),
+    }
+    .create(conn);
+    runner.set_user_provider(user_provider);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "username" => InputValue::scalar("user2"),
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                // This is a shitty error message, but fuck it. This shouldn't
+                // be possible to hit from the UI anyway
+                "message": "Not found",
+                "locations": [{"line": 5, "column": 9}],
+                "path": ["initializeUser"],
+            })]
+        )
+    );
+
+    // Make sure there's still only one user in the DB, to ensure that the
+    // user creation got rolled back
+    assert_eq!(
+        users::table
+            .select(dsl::count_star())
+            .get_result::<i64>(conn)
+            .unwrap(),
+        1
+    );
+}

--- a/api/tests/test_query_auth_status.rs
+++ b/api/tests/test_query_auth_status.rs
@@ -8,7 +8,7 @@ use utils::QueryRunner;
 
 mod utils;
 
-const QUERY: &str = r#"
+static QUERY: &str = r#"
 query AuthStatusQuery {
     authStatus {
         authenticated

--- a/api/tests/utils/mod.rs
+++ b/api/tests/utils/mod.rs
@@ -119,10 +119,10 @@ impl Drop for QueryRunner {
         let conn = self.context.get_db_conn().unwrap();
         delete_tables!(
             &conn,
+            models::UserProvider,
             models::UserProgram,
             models::ProgramSpec,
             models::HardwareSpec,
-            models::UserProvider,
             models::User,
             // Any new table needs to be added here!
         );


### PR DESCRIPTION
Adds a new mutation called `initializeUser` that lets you set your username for the first time. I thought about just making this a generic `setUsername` mutation so that we can let people change their usernames in the future, but I figured at some point we may need extra data in `initializeUser` beyond just the username. We can add a separate `setUsername` later, and the logic for it should be simpler anyway.