### PR TITLE
Add API and frontend prod images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Linting and Tests
+name: Lint, Test, and Build
 
 on:
   push:
@@ -91,25 +91,23 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-      - name: Docker login
-        run: docker login -u lucaspickering -p ${{ secrets.GITHUB_TOKEN }} docker.pkg.github.com
       - name: Build API image
         run: |-
           docker-compose pull api
           docker-compose build api
       - name: Test API
-        run: docker-compose run api ./docker/run_tests.sh
+        run: docker-compose run api cargo make -p docker test
       - name: Push API image
         if: github.ref == 'refs/heads/master'
-        run: docker-compose push api
+        run: |-
+          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker-compose push api
 
   test-frontend:
     name: "[FE] Test"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Docker login
-        run: docker login -u lucaspickering -p ${{ secrets.GITHUB_TOKEN }} docker.pkg.github.com
       - name: Build Frontend image
         run: |-
           docker-compose pull frontend
@@ -118,4 +116,41 @@ jobs:
         run: docker-compose run frontend ./docker/run_tests.sh
       - name: Push Frontend image
         if: github.ref == 'refs/heads/master'
-        run: docker-compose push frontend
+        run: |-
+          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker-compose push frontend
+
+  build-api-prd:
+    name: "[API] Build production image"
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    needs:
+      - lint
+      - test-core
+      - test-api
+    steps:
+      - uses: actions/checkout@master
+      - name: Build & push image
+        run: |
+          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker-compose pull api api-prd
+          docker-compose build api-prd
+          docker-compose push api-prd
+
+  build-frontend-prd:
+    name: "[FE] Build production image"
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    needs:
+      - lint
+      - test-core
+      - test-wasm
+      - test-frontend
+    steps:
+      - uses: actions/checkout@master
+      - name: Build & push image
+        run: |
+          docker-compose pull frontend frontend-prd
+          docker-compose build frontend-prd
+          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker-compose push frontend-prd

--- a/README.md
+++ b/README.md
@@ -45,18 +45,10 @@ cargo run -p gdlk_cli -- run --hardware hw.json --program prog.json -s prog.gdlk
 
 ### Running the Web Stack
 
-Unfortunately, until [this GitHub bug](https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782/page/2) is fixed, you'll have to login in to the GitHub docker registry in order to pull the images. [Go here to create a new token](https://github.com/settings/tokens), and give it these permissions:
-
-- `write:packages`
-- `read:packages`
-- `delete:packages`
-
-Then, in the repo root, run:
+In the repo root, run:
 
 ```sh
-cd api && cargo make secrets # Only needed on first execution
-cd ..
-docker login docker.pkg.github.com
+cd api && cargo make secrets && cd.. # Only needed on first execution
 # Enter your username and the new token as your password
 docker-compose up
 ```
@@ -115,3 +107,20 @@ We use nightly Rust. Here's a list of reasons why. If this list every gets empty
   - [wrap_comments](https://github.com/rust-lang/rustfmt/issues/3347)
 
 [Here's a helpful site for finding new nightly versions](https://rust-lang.github.io/rustup-components-history/).
+
+## Deployment
+
+This project is deployed through [Keskne](https://github.com/lucaspickering/keskne). Two different production images are built automatically on each merge to master: one for the API, and one for static assets. Then those get deployed.
+
+### API Environment Variables
+
+There are a few environment variables that need to be set in production:
+
+```
+DATABASE_URL
+GDLK_SERVER_HOST
+GDLK_SECRET_KEY
+GDLK_OPEN_ID__HOST_URL
+GDLK_OPEN_ID__PROVIDERS__GOOGLE__CLIENT_ID
+GDLK_OPEN_ID__PROVIDERS__GOOGLE__CLIENT_SECRET
+```

--- a/api/docker/cmd.sh
+++ b/api/docker/cmd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+diesel migration run
+./gdlk_api

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+PREFIX=keskne_ source /app/load_secrets.sh
+export DATABASE_URL="postgres://${GDLK_DB_USER}:${GDLK_DB_PASSWORD}@${GDLK_DB_HOST}/${GDLK_DB_NAME}?connect_timeout=10"
+exec $@

--- a/api/docker/run_tests.sh
+++ b/api/docker/run_tests.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-cargo make -p docker seed
-cargo make -p docker test

--- a/api/prd.Dockerfile
+++ b/api/prd.Dockerfile
@@ -1,0 +1,26 @@
+# Build the server distributable
+FROM gcr.io/gdlkit/gdlk-api:latest as rust-builder
+# We need core/, api/, and a bunch of other files, so just copy everything in
+COPY . /app
+RUN cargo build --release
+
+# Build our actual image
+FROM debian:buster-slim
+WORKDIR /app/api
+RUN apt-get update && \
+    apt-get install -y \
+    ca-certificates \
+    libssl1.1 \
+    libpq5 \
+    && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=rust-builder /usr/local/cargo/bin/diesel /usr/local/bin/
+COPY --from=rust-builder /app/target/release/gdlk_api .
+
+ADD ./api/migrations ./migrations/
+ADD ./api/config/default.json ./config/
+ADD ./api/docker/ /app/
+ADD https://raw.githubusercontent.com/LucasPickering/keskne/master/revproxy/load_secrets.sh /app/
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["/app/cmd.sh"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,8 +12,8 @@ services:
       context: .
       dockerfile: ./api/Dockerfile
       cache_from:
-        - docker.pkg.github.com/lucaspickering/gdlk/gdlk-api:${DOCKER_TAG}
-    image: docker.pkg.github.com/lucaspickering/gdlk/gdlk-api:${DOCKER_TAG}
+        - gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
+    image: gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
     volumes:
       - ./:/app:rw
     depends_on:
@@ -27,7 +27,23 @@ services:
       context: .
       dockerfile: ./frontend/Dockerfile
       cache_from:
-        - docker.pkg.github.com/lucaspickering/gdlk/gdlk-frontend:${DOCKER_TAG}
-    image: docker.pkg.github.com/lucaspickering/gdlk/gdlk-frontend:${DOCKER_TAG}
+        - gcr.io/gdlkit/gdlk-frontend:${DOCKER_TAG}
+    image: gcr.io/gdlkit/gdlk-frontend:${DOCKER_TAG}
     volumes:
       - ./:/app:rw
+
+  api-prd:
+    build:
+      context: .
+      dockerfile: ./api/prd.Dockerfile
+      cache_from:
+        - gcr.io/gdlkit/gdlk-api-prd:${DOCKER_TAG}
+    image: gcr.io/gdlkit/gdlk-api-prd:${DOCKER_TAG}
+
+  frontend-prd:
+    build:
+      context: .
+      dockerfile: ./frontend/prd.Dockerfile
+      cache_from:
+        - gcr.io/gdlkit/gdlk-frontend-prd:${DOCKER_TAG}
+    image: gcr.io/gdlkit/gdlk-frontend-prd:${DOCKER_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "5432:5432"
 
   api:
-    image: docker.pkg.github.com/lucaspickering/gdlk/gdlk-api:${DOCKER_TAG}
+    image: gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
     command: cargo make -p docker start
     tty: true # Colorize output
     volumes:
@@ -35,7 +35,7 @@ services:
       - "8000:8000"
 
   frontend:
-    image: docker.pkg.github.com/lucaspickering/gdlk/gdlk-frontend:${DOCKER_TAG}
+    image: gcr.io/gdlkit/gdlk-frontend:${DOCKER_TAG}
     command: ./docker/run_frontend.sh
     init: true # Needed to kill the relay compiler background process
     tty: true # Colorize output

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
+    "prebuild": "npm run relay",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",

--- a/frontend/prd.Dockerfile
+++ b/frontend/prd.Dockerfile
@@ -1,0 +1,10 @@
+# Build the frontend static assets
+FROM gcr.io/gdlkit/gdlk-frontend:latest as frontend-builder
+COPY . /app
+ENV NODE_ENV production
+RUN npm run build
+
+# Put all the static assets in an image
+FROM alpine:latest
+WORKDIR /app/static
+COPY --from=frontend-builder /app/frontend/build .


### PR DESCRIPTION
Adds two new images that we can use to distribute the app. One for the API, which is just the built executable with a few runtime dependencies, and one for the frontend, which is just some static assets.

Also switched from the shitty github container registry to google cloud, which means we can now pull images without logging in.