### PR TITLE
Add copyUserProgram mutation (closes #109)

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -565,6 +565,17 @@ type Mutation {
   ): UpdateUserProgramPayload! @juniper(ownership: "owned")
 
   """
+  Copy a user program. It will be identical, except it will have a new name
+  generated based on the old name.
+  """
+  copyUserProgram(
+    """
+    All input fields.
+    """
+    input: CopyUserProgramInput!
+  ): CopyUserProgramPayload! @juniper(ownership: "owned")
+
+  """
   Delete a user program by ID.
   """
   deleteUserProgram(
@@ -800,13 +811,34 @@ type UpdateUserProgramPayload {
 }
 
 """
+Input to the `copyUserProgram` mutation.
+"""
+input CopyUserProgramInput {
+  """
+  The ID of the user program to copy.
+  """
+  id: ID!
+}
+
+"""
+Output from the `copyUserProgram` mutation.
+"""
+type CopyUserProgramPayload {
+  """
+  The new user program. `null` if the given ID did not match any user programs.
+  """
+  userProgramEdge: UserProgramEdge
+    @juniper(infallible: true, ownership: "owned")
+}
+
+"""
 Input to the `deleteUserProgram` mutation.
 """
 input DeleteUserProgramInput {
   """
   The ID of the user program to delete.
   """
-  userProgramId: ID!
+  id: ID!
 }
 
 """

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -4,10 +4,11 @@ use crate::{
     schema::user_programs,
     server::gql::{
         internal::{GenericEdge, NodeType},
-        ConnectionPageParams, Context, CreateUserProgramPayloadFields, Cursor,
-        DeleteUserProgramPayloadFields, PageInfo, ProgramSpecNode,
-        UpdateUserProgramPayloadFields, UserNode, UserProgramConnectionFields,
-        UserProgramEdgeFields, UserProgramNodeFields,
+        ConnectionPageParams, Context, CopyUserProgramPayloadFields,
+        CreateUserProgramPayloadFields, Cursor, DeleteUserProgramPayloadFields,
+        PageInfo, ProgramSpecNode, UpdateUserProgramPayloadFields, UserNode,
+        UserProgramConnectionFields, UserProgramEdgeFields,
+        UserProgramNodeFields,
     },
     util::{self, Valid},
 };
@@ -234,6 +235,22 @@ impl UpdateUserProgramPayloadFields for UpdateUserProgramPayload {
             .as_ref()
             // Since this wasn't queried as part of a set, we can use a
             // bullshit offset to generate the cursor
+            .map(|row| GenericEdge::from_db_row(row.clone(), 0))
+    }
+}
+
+pub struct CopyUserProgramPayload {
+    pub user_program: Option<models::UserProgram>,
+}
+
+impl CopyUserProgramPayloadFields for CopyUserProgramPayload {
+    fn field_user_program_edge(
+        &self,
+        _executor: &juniper::Executor<'_, Context>,
+        _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
+    ) -> Option<UserProgramEdge> {
+        self.user_program
+            .as_ref()
             .map(|row| GenericEdge::from_db_row(row.clone(), 0))
     }
 }

--- a/api/tests/test_copy_user_program.rs
+++ b/api/tests/test_copy_user_program.rs
@@ -1,0 +1,213 @@
+#![deny(clippy::all)]
+
+use diesel::PgConnection;
+use gdlk_api::models::{
+    Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
+};
+use juniper::InputValue;
+use maplit::hashmap;
+use serde_json::json;
+use utils::QueryRunner;
+
+mod utils;
+
+static QUERY: &str = r#"
+    mutation CopyUserProgramMutation($id: ID!) {
+        copyUserProgram(input: {
+            id: $id,
+        }) {
+            userProgramEdge {
+                node {
+                    fileName
+                    sourceCode
+                    user {
+                        username
+                    }
+                    programSpec {
+                        slug
+                    }
+                }
+            }
+        }
+    }
+"#;
+
+/// Successful copy
+#[test]
+fn test_copy_user_program_success() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    // Initialize data
+    let user = NewUser { username: "user1" }.create(conn);
+    let program_spec_id = NewProgramSpec {
+        name: "prog1",
+        hardware_spec_id: NewHardwareSpec {
+            name: "hw1",
+            ..Default::default()
+        }
+        .create(conn)
+        .id,
+        ..Default::default()
+    }
+    .create(conn)
+    .id;
+    let user_program = NewUserProgram {
+        user_id: user.id,
+        program_spec_id,
+        file_name: "existing.gdlk",
+        source_code: "READ RX0",
+    }
+    .create(conn);
+    runner.set_user(user); // Log in
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "copyUserProgram": {
+                    "userProgramEdge": {
+                        "node": {
+                            "fileName": "existing.gdlk copy",
+                            "sourceCode": "READ RX0",
+                            "user": {
+                                "username": "user1"
+                            },
+                            "programSpec": {
+                                "slug": "prog1"
+                            },
+                        }
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Trying to copy a user_program that doesn't exist should return null.
+#[test]
+fn test_copy_user_program_invalid_id() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    // Initialize data
+    let user = NewUser { username: "user1" }.create(conn);
+    runner.set_user(user); // Log in
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar("bogus"),
+            }
+        ),
+        (
+            json!({
+                "copyUserProgram": {
+                    "userProgramEdge": serde_json::Value::Null
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Copying while not logged in returns an error.
+#[test]
+fn test_copy_user_program_not_logged_in() {
+    let runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    // Initialize data
+    let user = NewUser { username: "user1" }.create(conn);
+    let program_spec_id = NewProgramSpec {
+        name: "prog1",
+        hardware_spec_id: NewHardwareSpec {
+            name: "hw1",
+            ..Default::default()
+        }
+        .create(conn)
+        .id,
+        ..Default::default()
+    }
+    .create(conn)
+    .id;
+    let user_program = NewUserProgram {
+        user_id: user.id,
+        program_spec_id,
+        file_name: "existing.gdlk",
+        source_code: "READ RX0",
+    }
+    .create(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            serde_json::Value::Null,
+            vec![json!({
+                "locations": [{"line": 3, "column": 9}],
+                "message": "Not logged in",
+                "path": ["copyUserProgram"],
+            })]
+        )
+    );
+}
+
+/// You can't copy user_programs that don't belong to you.
+#[test]
+fn test_copy_user_program_wrong_owner() {
+    let mut runner = QueryRunner::new();
+    let conn: &PgConnection = &runner.db_conn();
+
+    // Initialize data
+    let user = NewUser { username: "user1" }.create(conn);
+    let other_user = NewUser { username: "user2" }.create(conn);
+    let program_spec_id = NewProgramSpec {
+        name: "prog1",
+        hardware_spec_id: NewHardwareSpec {
+            name: "hw1",
+            ..Default::default()
+        }
+        .create(conn)
+        .id,
+        ..Default::default()
+    }
+    .create(conn)
+    .id;
+    let user_program = NewUserProgram {
+        user_id: other_user.id,
+        program_spec_id,
+        file_name: "existing.gdlk",
+        source_code: "READ RX0",
+    }
+    .create(conn);
+    runner.set_user(user); // Log in
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "copyUserProgram": {
+                    "userProgramEdge": serde_json::Value::Null
+                }
+            }),
+            vec![]
+        )
+    );
+}

--- a/api/tests/test_delete_user_program.rs
+++ b/api/tests/test_delete_user_program.rs
@@ -16,7 +16,7 @@ mod utils;
 
 static QUERY: &str = r#"
     mutation DeleteUserProgramMutation($id: ID!) {
-        deleteUserProgram(input: { userProgramId: $id }) {
+        deleteUserProgram(input: { id: $id }) {
             deletedId
         }
     }

--- a/frontend/src/components/userPrograms/CopyUserProgramButton.tsx
+++ b/frontend/src/components/userPrograms/CopyUserProgramButton.tsx
@@ -8,31 +8,16 @@ import { CopyUserProgramButton_userProgram } from './__generated__/CopyUserProgr
 import IconButton from 'components/common/IconButton';
 
 const updateUserProgramMutation = graphql`
-  mutation CopyUserProgramButton_Mutation(
-    $programSpecId: ID!
-    $fileName: String!
-    $sourceCode: String!
-  ) {
-    createUserProgram(
-      input: {
-        programSpecId: $programSpecId
-        fileName: $fileName
-        sourceCode: $sourceCode
-      }
-    ) {
+  mutation CopyUserProgramButton_Mutation($id: ID!) {
+    copyUserProgram(input: { id: $id }) {
       userProgramEdge {
         node {
           fileName
-          sourceCode
         }
       }
     }
   }
 `;
-
-function getNewFileName(fileName: string): string {
-  return `${fileName} copy`;
-}
 
 /**
  * A button that duplicates an existing user program.
@@ -56,9 +41,7 @@ const CopyUserProgramButton: React.FC<{
       onClick={() => {
         mutate({
           variables: {
-            programSpecId,
-            fileName: getNewFileName(userProgram.fileName),
-            sourceCode: userProgram.sourceCode,
+            id: userProgram.id,
           },
           configs: [
             // Update the list of programs in the parent after modification
@@ -86,8 +69,6 @@ export default createFragmentContainer(CopyUserProgramButton, {
   userProgram: graphql`
     fragment CopyUserProgramButton_userProgram on UserProgramNode {
       id
-      fileName
-      sourceCode
     }
   `,
 });

--- a/frontend/src/components/userPrograms/DeleteUserProgramButton.tsx
+++ b/frontend/src/components/userPrograms/DeleteUserProgramButton.tsx
@@ -7,8 +7,8 @@ import { DeleteUserProgramButton_Mutation } from './__generated__/DeleteUserProg
 import ConfirmationDialog from 'components/common/ConfirmationDialog';
 
 const deleteUserProgramMutation = graphql`
-  mutation DeleteUserProgramButton_Mutation($userProgramId: ID!) {
-    deleteUserProgram(input: { userProgramId: $userProgramId }) {
+  mutation DeleteUserProgramButton_Mutation($id: ID!) {
+    deleteUserProgram(input: { id: $id }) {
       deletedId
     }
   }
@@ -48,7 +48,7 @@ const DeleteUserProgramButton: React.FC<{
         confirmColor="secondary"
         onConfirm={() => {
           mutate({
-            variables: { userProgramId },
+            variables: { id: userProgramId },
             configs: [
               {
                 type: 'RANGE_DELETE',


### PR DESCRIPTION
Added `copyUserProgram` mutation, and used it in the UI. Previously we were manually copying by creating a new user program from the frontend with the same contents as the old one. By doing the copy on the server side now though, we dont have to load source code for all ther user programs, and it prevents out-of-sync bugs if you have multiple tabs open.