### PR TITLE
Make the webserver read its DB URL from the config object instead of from `DATABASE_URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,4 @@ This project is deployed through [Keskne](https://github.com/lucaspickering/kesk
 
 ### API Environment Variables
 
-There are a few environment variables that need to be set in production:
-
-```sh
-DATABASE_URL # This controls the diesel CLI
-GDLK_DATABASE_URL # This controls our web app
-GDLK_SERVER_HOST
-GDLK_SECRET_KEY
-GDLK_OPEN_ID__HOST_URL
-GDLK_OPEN_ID__PROVIDERS__GOOGLE__CLIENT_ID
-GDLK_OPEN_ID__PROVIDERS__GOOGLE__CLIENT_SECRET
-```
+There are a few environment variables that need to be set in production, which are listed in `api/docker/cmd.sh`.

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ This project is deployed through [Keskne](https://github.com/lucaspickering/kesk
 
 There are a few environment variables that need to be set in production:
 
-```
-DATABASE_URL
+```sh
+DATABASE_URL # This controls the diesel CLI
+GDLK_DATABASE_URL # This controls our web app
 GDLK_SERVER_HOST
 GDLK_SECRET_KEY
 GDLK_OPEN_ID__HOST_URL

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,6 @@ ENV DOCKERIZE_VERSION v0.6.1
 
 RUN apt-get update && \
     apt-get install -y \
-    curl \
     libpq-dev \
     libssl-dev \
     pkg-config \
@@ -13,13 +12,10 @@ RUN apt-get update && \
     && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSL https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    | tar xzv -C /usr/local/bin
-
 WORKDIR /app
 COPY rust-toolchain ./
-RUN cargo install cargo-make --version 0.31.0 && \
+RUN cargo install cargo-make --version 0.32.0 && \
     cargo install diesel_cli --version 1.4.1 --no-default-features --features=postgres && \
-    cargo install cargo-watch --version 7.4.1
+    cargo install cargo-watch --version 7.5.0
 
 WORKDIR /app/api

--- a/api/Makefile.toml
+++ b/api/Makefile.toml
@@ -9,7 +9,7 @@ TEST_DATABASE_URL = "postgres://root:root@localhost/gdlk_test?connect_timeout=10
 # This only controls the diesel CLI and GDLK in tests. When running the server,
 # it pulls from the config file instead.
 DATABASE_URL = "postgres://root:root@db/gdlk?connect_timeout=10"
-TEST_DATABASE_URL = "postgres://root:root@localhost/gdlk_test?connect_timeout=10"
+TEST_DATABASE_URL = "postgres://root:root@db/gdlk_test?connect_timeout=10"
 
 [tasks.db]
 # TODO - only install w/ postgres feature

--- a/api/Makefile.toml
+++ b/api/Makefile.toml
@@ -1,9 +1,15 @@
 # This is the default profile
 [env.development]
-DATABASE_URL = "postgres://root:root@localhost/gdlk"
+# This only controls the diesel CLI and GDLK in tests. When running the server,
+# it pulls from the config file instead.
+DATABASE_URL = "postgres://root:root@localhost/gdlk?connect_timeout=10"
+TEST_DATABASE_URL = "postgres://root:root@localhost/gdlk_test?connect_timeout=10"
 
 [env.docker]
-DATABASE_URL = "postgres://root:root@db/gdlk"
+# This only controls the diesel CLI and GDLK in tests. When running the server,
+# it pulls from the config file instead.
+DATABASE_URL = "postgres://root:root@db/gdlk?connect_timeout=10"
+TEST_DATABASE_URL = "postgres://root:root@localhost/gdlk_test?connect_timeout=10"
 
 [tasks.db]
 # TODO - only install w/ postgres feature
@@ -15,19 +21,12 @@ extend = "db"
 command = "diesel"
 args = ["${@}"]
 
-[tasks.wait-for-db]
-condition = { profiles = ["docker"] }
-command = "dockerize"
-args = ["-wait", "tcp://db:5432"]
-
 [tasks.db-setup]
 extend = "diesel"
-dependencies = ["wait-for-db"]
 args = ["db", "setup"]
 
 [tasks.db-reset]
 extend = "diesel"
-dependencies = ["wait-for-db"]
 args = ["db", "reset"]
 
 [tasks.migrations]
@@ -81,8 +80,7 @@ echo "You will need to set all OpenID client IDs and secrets manually."
 
 [tasks.test-db-reset]
 extend = "diesel"
-env = { DATABASE_URL = "${DATABASE_URL}_test" }
-dependencies = ["wait-for-db"]
+env = { DATABASE_URL = "${TEST_DATABASE_URL}" }
 # --locked-schema prevents changing schema.rs, which would trigger an API reload
 args = ["db", "reset", "--locked-schema"]
 

--- a/api/config/default.json
+++ b/api/config/default.json
@@ -1,4 +1,5 @@
 {
+  "database_url": "postgres://root:root@db/gdlk?connect_timeout=10",
   "server_host": "0.0.0.0:8000",
   "open_id": {
     "host_url": "https://localhost:3000",

--- a/api/docker/cmd.sh
+++ b/api/docker/cmd.sh
@@ -1,6 +1,25 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
-diesel migration run
-./gdlk_api
+# Env variables we expect as input:
+# - GDLK_DB_HOST
+# - GDLK_DB_NAME
+# - GDLK_ROOT_DB_USER
+# - GDLK_ROOT_DB_PASSWORD_FILE
+# - GDLK_APP_DB_USER
+# - GDLK_APP_DB_PASSWORD_FILE
+# - GDLK_SECRET_KEY_FILE
+# - GDLK_GOOGLE_CLIENT_ID_FILE
+# - GDLK_GOOGLE_CLIENT_SECRET_FILE
+
+# We use the DB superuser for migrations so that we can do extension and table alertations
+DATABASE_URL="postgres://${GDLK_ROOT_DB_USER}:$(cat $GDLK_ROOT_DB_PASSWORD_FILE)@${GDLK_DB_HOST}/${GDLK_DB_NAME}?connect_timeout=10" \
+    diesel migration run
+
+# We use an unprivileged user for the app cause security
+GDLK_DATABASE_URL="postgres://${GDLK_APP_DB_USER}:$(cat $GDLK_APP_DB_PASSWORD_FILE)@${GDLK_DB_HOST}/${GDLK_DB_NAME}?connect_timeout=10" \
+GDLK_SECRET_KEY=$(cat $GDLK_SECRET_KEY_FILE) \
+GDLK_OPEN_ID__PROVIDERS__GOOGLE__CLIENT_ID=$(cat $GDLK_GOOGLE_CLIENT_ID_FILE) \
+GDLK_OPEN_ID__PROVIDERS__GOOGLE__CLIENT_SECRET=$(cat $GDLK_GOOGLE_CLIENT_SECRET_FILE) \
+    ./gdlk_api

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-PREFIX=keskne_ source /app/load_secrets.sh
-export DATABASE_URL="postgres://${GDLK_DB_USER}:${GDLK_DB_PASSWORD}@${GDLK_DB_HOST}/${GDLK_DB_NAME}?connect_timeout=10"
-exec $@

--- a/api/prd.Dockerfile
+++ b/api/prd.Dockerfile
@@ -20,7 +20,5 @@ COPY --from=rust-builder /app/target/release/gdlk_api .
 ADD ./api/migrations ./migrations/
 ADD ./api/config/default.json ./config/
 ADD ./api/docker/ /app/
-ADD https://raw.githubusercontent.com/LucasPickering/keskne/master/revproxy/load_secrets.sh /app/
 
-ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["/app/cmd.sh"]

--- a/api/src/bin.rs
+++ b/api/src/bin.rs
@@ -1,5 +1,5 @@
 use failure::Fallible;
-use gdlk_api::{config::GdlkConfig, util};
+use gdlk_api::config::GdlkConfig;
 use log::{debug, info};
 
 fn run() -> Fallible<()> {
@@ -9,8 +9,7 @@ fn run() -> Fallible<()> {
     info!("Loaded config");
     debug!("{:#?}", &config);
 
-    let pool = util::init_db_conn_pool()?;
-    Ok(gdlk_api::server::run_server(config, pool)?)
+    Ok(gdlk_api::server::run_server(config)?)
 }
 
 fn main() {

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -26,6 +26,9 @@ pub struct OpenIdConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct GdlkConfig {
+    /// The URL of the DB that we connect to, as a Postgres URL.
+    /// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+    pub database_url: String,
     /// The hostname for the HTTP server to bind to.
     pub server_host: String,
     /// The secret key that's used to for authorization-related crypto stuff.

--- a/api/src/server/mod.rs
+++ b/api/src/server/mod.rs
@@ -90,8 +90,9 @@ async fn route_graphql(
 }
 
 #[actix_rt::main]
-pub async fn run_server(config: GdlkConfig, pool: Pool) -> io::Result<()> {
-    // Init GraphQL schema
+pub async fn run_server(config: GdlkConfig) -> io::Result<()> {
+    // Initialize env shit
+    let pool = util::init_db_conn_pool(&config.database_url).unwrap();
     let gql_schema = Arc::new(create_gql_schema());
     let client_map =
         web::Data::new(auth::build_client_map(&config.open_id).await);

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -41,8 +41,7 @@ impl<T: Validate> Deref for Valid<T> {
     }
 }
 
-pub fn init_db_conn_pool() -> Fallible<Pool> {
-    let database_url = std::env::var("DATABASE_URL")?;
+pub fn init_db_conn_pool(database_url: &str) -> Fallible<Pool> {
     let manager = ConnectionManager::new(database_url);
     let pool = r2d2::Pool::builder().build(manager)?;
     Ok(pool)

--- a/api/tests/utils/mod.rs
+++ b/api/tests/utils/mod.rs
@@ -38,8 +38,9 @@ pub struct QueryRunner {
 
 impl QueryRunner {
     pub fn new() -> Self {
+        let database_url = std::env::var("DATABASE_URL").unwrap();
         let context = Context {
-            pool: Arc::new(util::init_db_conn_pool().unwrap()),
+            pool: Arc::new(util::init_db_conn_pool(&database_url).unwrap()),
             user_context: None,
         };
         Self {


### PR DESCRIPTION
Diesel's CLI pulls its DB url from the env var `DATABASE_URL`, so we've been reading that for gdlk as well. But now in production we want the CLI and GDLK to use separate users, so this is a good opportunity to read it from the config instead for the API code. So the downside is that now we have to define the DB URL in multiple places in dev, but IMO it's more clear and the security buff in production is great too.

Also, I removed dockerize from the image in favor of just using `?connect_timeout=10`.

I was testing this with my deployment machine so this is actually already running in prod.