### PR TITLE
 setup custom ace mode to highlight comments

### DIFF
--- a/frontend/src/components/ide/CodeEditor.tsx
+++ b/frontend/src/components/ide/CodeEditor.tsx
@@ -2,9 +2,9 @@ import React, { useContext } from 'react';
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { IdeContext, gdlkSpanToAce } from 'state/ide';
-import AceEditor, { IAnnotation, IMarker } from 'react-ace';
-import 'ace-builds/src-noconflict/mode-plain_text';
+import AceEditor, { IAnnotation, IMarker, IEditorProps } from 'react-ace';
 import 'ace-builds/src-noconflict/theme-terminal';
+import GDLKMode from 'util/ace_mode';
 
 const useLocalStyles = makeStyles(({ palette }) => ({
   codeEditor: {
@@ -85,14 +85,20 @@ const CodeEditor: React.FC<{ className?: string }> = ({ className }) => {
       break;
   }
 
+  const onLoad = (editor: IEditorProps): void => {
+    const gdlkMode = new GDLKMode();
+    editor.getSession().setMode(gdlkMode);
+  };
+
   return (
     <div className={clsx(className, localClasses.codeEditor)}>
       <AceEditor
         name="gdlk-editor"
-        mode="plain_text"
+        mode="text"
         theme="terminal" // TODO use a better theme
         width="100%"
         height="100%"
+        onLoad={onLoad}
         value={sourceCode}
         annotations={annotations}
         markers={markers}

--- a/frontend/src/util/ace_mode.ts
+++ b/frontend/src/util/ace_mode.ts
@@ -1,0 +1,28 @@
+import { getAceInstance } from 'react-ace/lib/editorOptions';
+import 'ace-builds/src-noconflict/mode-plain_text';
+
+export class GDLKHighlightRules extends getAceInstance().acequire(
+  'ace/mode/text_highlight_rules'
+).TextHighlightRules {
+  constructor() {
+    super();
+    this.$rules = {
+      start: [
+        {
+          token: 'comment',
+          regex: ';.*$',
+        },
+      ],
+    };
+  }
+}
+
+export default class GDLKMode extends getAceInstance().acequire(
+  'ace/mode/plain_text'
+).Mode {
+  constructor() {
+    super();
+    this.HighlightRules = GDLKHighlightRules;
+    this.lineCommentStart = ';';
+  }
+}


### PR DESCRIPTION
Setup a custom ace mode to highlight comments and tell it what our comment char is to allow for `ctrl+\` to do block comments to close #114.

Its more jank then i would like but ace is a lil jank