### PR TITLE
Use names instead of slugs in the UI

### DIFF
--- a/frontend/src/components/hardware/HardwareSpecDetails.tsx
+++ b/frontend/src/components/hardware/HardwareSpecDetails.tsx
@@ -19,7 +19,7 @@ const HardwareSpecDetails: React.FC<{
   return (
     <Grid container>
       <Grid item xs={12}>
-        <Typography variant="h1">{hardwareSpec.slug}</Typography>
+        <Typography variant="h1">{hardwareSpec.name}</Typography>
       </Grid>
 
       <Grid item sm={4} xs={12}>
@@ -43,6 +43,7 @@ export default createFragmentContainer(HardwareSpecDetails, {
     fragment HardwareSpecDetails_hardwareSpec on HardwareSpecNode {
       id
       slug
+      name
       ...HardwareSpecSummary_hardwareSpec
       ...ProgramSpecListCard_hardwareSpec @arguments(count: 5)
     }

--- a/frontend/src/components/hardware/HardwareSpecListItem.tsx
+++ b/frontend/src/components/hardware/HardwareSpecListItem.tsx
@@ -25,7 +25,7 @@ const HardwareSpecListItem: React.FC<{
         component={UnstyledLink}
         to={`/hardware/${hardwareSpec.slug}`}
       >
-        <ListItemText primary={hardwareSpec.slug} />
+        <ListItemText primary={hardwareSpec.name} />
       </ListItem>
       <List dense disablePadding>
         {hardwareSpec.programSpecs.edges.map(({ node: programSpec }) => (
@@ -37,7 +37,7 @@ const HardwareSpecListItem: React.FC<{
             to={`/hardware/${hardwareSpec.slug}/puzzles/${programSpec.slug}`}
           >
             <ListItemText
-              primary={`${hardwareSpec.slug}/${programSpec.slug}`}
+              primary={`${hardwareSpec.name} / ${programSpec.name}`}
             />
           </ListItem>
         ))}
@@ -51,6 +51,7 @@ export default createFragmentContainer(HardwareSpecListItem, {
     fragment HardwareSpecListItem_hardwareSpec on HardwareSpecNode {
       id
       slug
+      name
       ...HardwareSpecSummary_hardwareSpec
       programSpecs(first: 5) {
         totalCount
@@ -58,6 +59,7 @@ export default createFragmentContainer(HardwareSpecListItem, {
           node {
             id
             slug
+            name
           }
         }
       }

--- a/frontend/src/components/hardware/ProgramSpecListCard.tsx
+++ b/frontend/src/components/hardware/ProgramSpecListCard.tsx
@@ -69,7 +69,7 @@ const ProgramSpecListRow = createFragmentContainer(
           </TableCell>
           <TableCell>
             <Link to={`${url}/puzzles/${programSpec.slug}`}>
-              {programSpec.slug}
+              {programSpec.name}
             </Link>
           </TableCell>
 
@@ -95,6 +95,7 @@ const ProgramSpecListRow = createFragmentContainer(
     programSpec: graphql`
       fragment ProgramSpecListCard_programSpec on ProgramSpecNode {
         slug
+        name
         description
         userPrograms @include(if: $loggedIn) {
           totalCount

--- a/frontend/src/components/programs/ProgramSpecDetails.tsx
+++ b/frontend/src/components/programs/ProgramSpecDetails.tsx
@@ -11,7 +11,6 @@ import {
 } from '@material-ui/core';
 import UserProgramsCard from '../userPrograms/UserProgramsCard';
 import HardwareSpecSummary from 'components/hardware/HardwareSpecSummary';
-import SimpleTable from 'components/common/SimpleTable';
 import Link from 'components/common/Link';
 import { UserContext } from 'state/user';
 
@@ -44,10 +43,10 @@ const ProgramSpecDetails: React.FC<{
       <Grid item xs={12}>
         <Typography variant="h1">
           <Link to={`/hardware/${programSpec.hardwareSpec.slug}`}>
-            {programSpec.hardwareSpec.slug}
+            {programSpec.hardwareSpec.name}
           </Link>
           {' / '}
-          {programSpec.slug}
+          {programSpec.name}
         </Typography>
       </Grid>
 
@@ -62,20 +61,6 @@ const ProgramSpecDetails: React.FC<{
             <div className={localClasses.specSection}>
               <Typography variant="h2">Hardware Spec</Typography>
               <HardwareSpecSummary hardwareSpec={programSpec.hardwareSpec} />
-            </div>
-
-            <div className={localClasses.specSection}>
-              <Typography variant="h2">Details</Typography>
-
-              <SimpleTable
-                data={[
-                  { label: 'Input', value: programSpec.input.join(' ') },
-                  {
-                    label: 'Expected Output',
-                    value: programSpec.expectedOutput.join(' '),
-                  },
-                ]}
-              />
             </div>
           </CardContent>
         </Card>
@@ -95,11 +80,11 @@ export default createFragmentContainer(ProgramSpecDetails, {
     fragment ProgramSpecDetails_programSpec on ProgramSpecNode {
       id
       slug
+      name
       description
-      input
-      expectedOutput
       hardwareSpec {
         slug
+        name
         ...HardwareSpecSummary_hardwareSpec
       }
       # Requesting user programs while not logged in causes an error


### PR DESCRIPTION
Little UI cleanup. Also removed the input/expected output from the program spec details page, cause it isn't really helpful and didn't fit anyway.