### PR TITLE
Add API abstraction layer

### DIFF
--- a/api/Makefile.toml
+++ b/api/Makefile.toml
@@ -91,6 +91,7 @@ dependencies = ["test-db-reset"]
 command = "cargo"
 args = [
     "test",
+    "--no-fail-fast",
     "${@}",
     "--",
     "--test-threads=1",

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -12,3 +12,4 @@ pub mod models;
 pub mod schema;
 pub mod server;
 pub mod util;
+pub mod views;

--- a/api/src/models/program_spec.rs
+++ b/api/src/models/program_spec.rs
@@ -65,6 +65,7 @@ pub struct NewProgramSpec<'a> {
 
     // IMPORTANT: If you update these validation values, make sure you update
     // ProgramSpec in the core crate as well!
+    // TODO once we remove validator, change these to slices
     #[validate(length(max = 256))]
     pub input: Vec<i32>,
     #[validate(length(max = 256))]
@@ -104,6 +105,7 @@ pub struct ModifiedProgramSpec<'a> {
     #[validate(length(min = 1))]
     pub name: Option<&'a str>,
     pub description: Option<&'a str>,
+    // TODO once we remove validator, change these to slices
     #[validate(length(max = 256))]
     pub input: Option<Vec<i32>>,
     #[validate(length(max = 256))]

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -1,9 +1,5 @@
 use crate::{
-    error::{DbErrorConverter, ResponseError, ResponseResult},
-    models,
-    schema::{
-        hardware_specs, program_specs, user_programs, user_providers, users,
-    },
+    error::ResponseResult,
     server::gql::{
         Context, CopyUserProgramInput, CopyUserProgramPayload,
         CreateHardwareSpecInput, CreateHardwareSpecPayload,
@@ -13,17 +9,13 @@ use crate::{
         InitializeUserPayload, MutationFields, UpdateHardwareSpecInput,
         UpdateHardwareSpecPayload, UpdateProgramSpecInput,
         UpdateProgramSpecPayload, UpdateUserProgramInput,
-        UpdateUserProgramPayload, UserContext,
+        UpdateUserProgramPayload,
     },
     util,
+    views::{self, View},
 };
-use diesel::{
-    Connection, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
-    RunQueryDsl, Table,
-};
+use diesel::PgConnection;
 use juniper_from_schema::{QueryTrail, Walked};
-use uuid::Uuid;
-use validator::Validate;
 
 /// The top-level mutation object.
 pub struct Mutation;
@@ -36,65 +28,13 @@ impl MutationFields for Mutation {
         input: InitializeUserInput,
     ) -> ResponseResult<InitializeUserPayload> {
         let context = executor.context();
-
-        // The user should be logged in, but not had a User object created yet
-        match context.user_context {
-            Some(UserContext {
-                user_provider_id, ..
-            }) => {
-                let conn = &context.get_db_conn()?;
-                let new_user = models::NewUser {
-                    username: &input.username,
-                };
-                new_user.validate()?;
-
-                // We need to insert the new user row, then update the
-                // user_provider to point at that row. We need a transaction to
-                // prevent race conditions.
-                let created_user = conn
-                    .transaction::<models::User, ResponseError, _>(|| {
-                        let create_user_result: Result<models::User, _> =
-                            new_user
-                                .insert()
-                                .returning(users::all_columns)
-                                .get_result(conn);
-
-                        // Check if the username already exists
-                        let created_user = DbErrorConverter {
-                            unique_violation_to_exists: true,
-                            ..Default::default()
-                        }
-                        .convert(create_user_result)?;
-
-                        // We should update exactly 1 row. If not, then either
-                        // the referenced user_provider row is already linked to
-                        // a user, or it doesn't exist. In either case, just
-                        // return a NotFound error.
-                        let updated_rows = diesel::update(
-                            user_providers::table
-                                .find(user_provider_id)
-                                .filter(
-                                    user_providers::columns::user_id.is_null(),
-                                ),
-                        )
-                        .set(
-                            user_providers::columns::user_id
-                                .eq(Some(created_user.id)),
-                        )
-                        .execute(conn)?;
-
-                        if updated_rows == 0 {
-                            Err(ResponseError::NotFound)
-                        } else {
-                            Ok(created_user)
-                        }
-                    })?;
-
-                Ok(InitializeUserPayload { user: created_user })
-            }
-            // Get up on outta here
-            None => Err(ResponseError::Unauthenticated),
-        }
+        let view = views::InitializeUserView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_context: context.user_context,
+            username: &input.username,
+        };
+        let created_user = view.execute()?;
+        Ok(InitializeUserPayload { user: created_user })
     }
 
     fn field_create_hardware_spec(
@@ -103,30 +43,16 @@ impl MutationFields for Mutation {
         _trail: &QueryTrail<'_, CreateHardwareSpecPayload, Walked>,
         input: CreateHardwareSpecInput,
     ) -> ResponseResult<CreateHardwareSpecPayload> {
-        let conn: &PgConnection =
-            &executor.context().get_db_conn()? as &PgConnection;
-
-        // User a helper type to do the insert
-        let new_hardware_spec = models::NewHardwareSpec {
+        let context = executor.context();
+        let view = views::CreateHardwareSpecView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
             name: &input.name,
             num_registers: input.num_registers,
             num_stacks: input.num_stacks,
             max_stack_length: input.max_stack_length,
         };
-        new_hardware_spec.validate()?;
-
-        // Insert the new row and return the whole row
-        let result: Result<models::HardwareSpec, _> = new_hardware_spec
-            .insert()
-            .returning(hardware_specs::table::all_columns())
-            .get_result(conn);
-
-        let hardware_spec: models::HardwareSpec = DbErrorConverter {
-            // HardwareSpec already exists with this name or slug
-            unique_violation_to_exists: true,
-            ..Default::default()
-        }
-        .convert(result)?;
+        let hardware_spec = view.execute()?;
 
         Ok(CreateHardwareSpecPayload { hardware_spec })
     }
@@ -137,41 +63,19 @@ impl MutationFields for Mutation {
         _trail: &QueryTrail<'_, UpdateHardwareSpecPayload, Walked>,
         input: UpdateHardwareSpecInput,
     ) -> ResponseResult<UpdateHardwareSpecPayload> {
-        let conn: &PgConnection =
-            &executor.context().get_db_conn()? as &PgConnection;
-
-        // User a helper type to do the insert
-        let modified_hardware_spec = models::ModifiedHardwareSpec {
+        let context = executor.context();
+        let view = views::UpdateHardwareSpecView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
             name: input.name.as_deref(),
             num_registers: input.num_registers,
             num_stacks: input.num_stacks,
             max_stack_length: input.max_stack_length,
         };
-        modified_hardware_spec.validate()?;
+        let hardware_spec = view.execute()?;
 
-        // Update the row, returning the new value. If the row doesn't exist,
-        // this will return None.
-        let result: Result<Option<models::HardwareSpec>, _> = diesel::update(
-            hardware_specs::table.find(modified_hardware_spec.id),
-        )
-        .set(modified_hardware_spec)
-        .returning(hardware_specs::table::all_columns())
-        .get_result(conn)
-        .optional();
-
-        let updated_row: Option<models::HardwareSpec> = DbErrorConverter {
-            // HardwareSpec already exists with this name or slug
-            unique_violation_to_exists: true,
-            // No update fields were given
-            query_builder_to_no_update: true,
-            ..Default::default()
-        }
-        .convert(result)?;
-
-        Ok(UpdateHardwareSpecPayload {
-            hardware_spec: updated_row,
-        })
+        Ok(UpdateHardwareSpecPayload { hardware_spec })
     }
 
     fn field_create_program_spec(
@@ -180,33 +84,17 @@ impl MutationFields for Mutation {
         _trail: &QueryTrail<'_, CreateProgramSpecPayload, Walked>,
         input: CreateProgramSpecInput,
     ) -> ResponseResult<CreateProgramSpecPayload> {
-        let conn: &PgConnection =
-            &executor.context().get_db_conn()? as &PgConnection;
-
-        // User a helper type to do the insert
-        let new_program_spec = models::NewProgramSpec {
+        let context = executor.context();
+        let view = views::CreateProgramSpecView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
             hardware_spec_id: util::gql_id_to_uuid(&input.hardware_spec_id),
             name: &input.name,
             description: &input.description,
-            input: input.input,
-            expected_output: input.expected_output,
+            input: &input.input,
+            expected_output: &input.expected_output,
         };
-        new_program_spec.validate()?;
-
-        // Insert the new row and return the whole row
-        let result: Result<models::ProgramSpec, _> = new_program_spec
-            .insert()
-            .returning(program_specs::table::all_columns())
-            .get_result(conn);
-
-        let program_spec: models::ProgramSpec = DbErrorConverter {
-            // Given hardware spec ID was invalid
-            fk_violation_to_not_found: true,
-            // ProgramSpec already exists with this name or slug
-            unique_violation_to_exists: true,
-            ..Default::default()
-        }
-        .convert(result)?;
+        let program_spec = view.execute()?;
 
         Ok(CreateProgramSpecPayload { program_spec })
     }
@@ -217,40 +105,19 @@ impl MutationFields for Mutation {
         _trail: &QueryTrail<'_, UpdateProgramSpecPayload, Walked>,
         input: UpdateProgramSpecInput,
     ) -> ResponseResult<UpdateProgramSpecPayload> {
-        let conn: &PgConnection =
-            &executor.context().get_db_conn()? as &PgConnection;
-
-        // Use a helper type to do the insert
-        let modified_program_spec = models::ModifiedProgramSpec {
+        let context = executor.context();
+        let view = views::UpdateProgramSpecView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
             name: input.name.as_deref(),
             description: input.description.as_deref(),
-            input: input.input,
-            expected_output: input.expected_output,
+            input: input.input.as_deref(),
+            expected_output: input.expected_output.as_deref(),
         };
-        modified_program_spec.validate()?;
+        let program_spec = view.execute()?;
 
-        // Update the row, returning the new value. If the row doesn't exist,
-        // this will return None.
-        let result: Result<Option<models::ProgramSpec>, _> =
-            diesel::update(program_specs::table.find(modified_program_spec.id))
-                .set(modified_program_spec)
-                .returning(program_specs::table::all_columns())
-                .get_result(conn)
-                .optional();
-
-        let updated_row: Option<models::ProgramSpec> = DbErrorConverter {
-            // ProgramSpec already exists with this name or slug
-            unique_violation_to_exists: true,
-            // No update fields were given
-            query_builder_to_no_update: true,
-            ..Default::default()
-        }
-        .convert(result)?;
-
-        Ok(UpdateProgramSpecPayload {
-            program_spec: updated_row,
-        })
+        Ok(UpdateProgramSpecPayload { program_spec })
     }
 
     fn field_create_user_program(
@@ -260,34 +127,15 @@ impl MutationFields for Mutation {
         input: CreateUserProgramInput,
     ) -> ResponseResult<CreateUserProgramPayload> {
         let context = executor.context();
-        let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
-        let user_id = context.user_id()?; // User needs to be logged in
-
-        // User a helper type to do the insert
-        let new_user_program = models::NewUserProgram {
-            user_id,
+        let view = views::CreateUserProgramView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
             program_spec_id: util::gql_id_to_uuid(&input.program_spec_id),
             file_name: &input.file_name,
             // If no source is provided, default to an empty string
             source_code: input.source_code.as_deref().unwrap_or(""),
         };
-        new_user_program.validate()?;
-
-        // Insert the new row and return the whole row
-        let result: Result<models::UserProgram, _> = new_user_program
-            .insert()
-            .returning(user_programs::table::all_columns())
-            .get_result(conn);
-
-        let user_program: models::UserProgram = DbErrorConverter {
-            // Given program spec ID was invalid. Note: this can also indicate
-            // an invalid user ID which would be a server-side bug, but fuck it
-            fk_violation_to_not_found: true,
-            // UserProgram already exists with this program spec/file name
-            unique_violation_to_exists: true,
-            ..Default::default()
-        }
-        .convert(result)?;
+        let user_program = view.execute()?;
 
         Ok(CreateUserProgramPayload { user_program })
     }
@@ -299,43 +147,16 @@ impl MutationFields for Mutation {
         input: UpdateUserProgramInput,
     ) -> ResponseResult<UpdateUserProgramPayload> {
         let context = executor.context();
-        let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
-        // User needs to be logged in to make changes. This also has to be
-        // their user_program.
-        let user_id = context.user_id()?;
-
-        // User a helper type to do the insert
-        let modified_user_program = models::ModifiedUserProgram {
+        let view = views::UpdateUserProgramView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
             file_name: input.file_name.as_deref(),
             source_code: input.source_code.as_deref(),
         };
-        modified_user_program.validate()?;
+        let user_program = view.execute()?;
 
-        // Update the row, returning the new value. If the row doesn't
-        // exist, this will return None.
-        let result: Result<Option<models::UserProgram>, _> =
-            diesel::update(models::UserProgram::find_for_user(
-                modified_user_program.id,
-                user_id,
-            ))
-            .set(modified_user_program)
-            .returning(user_programs::table::all_columns())
-            .get_result(conn)
-            .optional();
-
-        let updated_row: Option<models::UserProgram> = DbErrorConverter {
-            // UserProgram already exists with this program spec/file name
-            unique_violation_to_exists: true,
-            // No update fields were given
-            query_builder_to_no_update: true,
-            ..Default::default()
-        }
-        .convert(result)?;
-
-        Ok(UpdateUserProgramPayload {
-            user_program: updated_row,
-        })
+        Ok(UpdateUserProgramPayload { user_program })
     }
 
     fn field_copy_user_program(
@@ -345,41 +166,14 @@ impl MutationFields for Mutation {
         input: CopyUserProgramInput,
     ) -> ResponseResult<CopyUserProgramPayload> {
         let context = executor.context();
-        let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
-        // User needs to be logged in to make changes. This also has to be
-        // their user_program.
-        let user_id = context.user_id()?;
-
-        let existing_user_program: Option<models::UserProgram> =
-            models::UserProgram::find_for_user(
-                util::gql_id_to_uuid(&input.id),
-                user_id,
-            )
-            .get_result(conn)
-            .optional()?;
-
-        // If the requested user_program exists (for the given user), copy it
-        let inserted_row = match existing_user_program {
-            None => None,
-            Some(user_program) => {
-                Some(
-                    models::NewUserProgram {
-                        user_id,
-                        program_spec_id: user_program.program_spec_id,
-                        // Generate a new file name
-                        file_name: &format!("{} copy", &user_program.file_name),
-                        source_code: &user_program.source_code,
-                    }
-                    .insert()
-                    .returning(user_programs::all_columns)
-                    .get_result(conn)?,
-                )
-            }
+        let view = views::CopyUserProgramView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
+            id: util::gql_id_to_uuid(&input.id),
         };
+        let user_program = view.execute()?;
 
-        Ok(CopyUserProgramPayload {
-            user_program: inserted_row,
-        })
+        Ok(CopyUserProgramPayload { user_program })
     }
 
     fn field_delete_user_program(
@@ -389,18 +183,12 @@ impl MutationFields for Mutation {
         input: DeleteUserProgramInput,
     ) -> ResponseResult<DeleteUserProgramPayload> {
         let context = executor.context();
-        let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
-        // User needs to be logged in to make changes. This also has to be
-        // their user_program.
-        let user_id = context.user_id()?;
-
-        // Delete and get the ID back
-        let row_id = util::gql_id_to_uuid(&input.id);
-        let deleted_id: Option<Uuid> =
-            diesel::delete(models::UserProgram::find_for_user(row_id, user_id))
-                .returning(user_programs::columns::id)
-                .get_result(conn)
-                .optional()?;
+        let view = views::DeleteUserProgramView {
+            conn: &context.get_db_conn()? as &PgConnection,
+            user_id: context.user_id()?,
+            id: util::gql_id_to_uuid(&input.id),
+        };
+        let deleted_id = view.execute()?;
 
         Ok(DeleteUserProgramPayload { deleted_id })
     }

--- a/api/src/views/hardware_spec.rs
+++ b/api/src/views/hardware_spec.rs
@@ -1,0 +1,92 @@
+use crate::{
+    error::{DbErrorConverter, ResponseResult},
+    models,
+    schema::hardware_specs,
+    views::View,
+};
+use diesel::{OptionalExtension, PgConnection, QueryDsl, RunQueryDsl, Table};
+use uuid::Uuid;
+use validator::Validate;
+
+/// Create a new hardware spec
+pub struct CreateHardwareSpecView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub name: &'a str,
+    pub num_registers: i32,
+    pub num_stacks: i32,
+    pub max_stack_length: i32,
+}
+
+impl<'a> View for CreateHardwareSpecView<'a> {
+    type Output = models::HardwareSpec;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // User a helper type to do the insert
+        let new_hardware_spec = models::NewHardwareSpec {
+            name: self.name,
+            num_registers: self.num_registers,
+            num_stacks: self.num_stacks,
+            max_stack_length: self.max_stack_length,
+        };
+        new_hardware_spec.validate()?;
+
+        // Insert the new row and return the whole row
+        let result: Result<models::HardwareSpec, _> = new_hardware_spec
+            .insert()
+            .returning(hardware_specs::table::all_columns())
+            .get_result(self.conn);
+
+        DbErrorConverter {
+            // HardwareSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            ..Default::default()
+        }
+        .convert(result)
+    }
+}
+
+/// Modify an existing hardware spec
+pub struct UpdateHardwareSpecView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub id: Uuid,
+    pub name: Option<&'a str>,
+    pub num_registers: Option<i32>,
+    pub num_stacks: Option<i32>,
+    pub max_stack_length: Option<i32>,
+}
+
+impl<'a> View for UpdateHardwareSpecView<'a> {
+    type Output = Option<models::HardwareSpec>;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // User a helper type to do the insert
+        let modified_hardware_spec = models::ModifiedHardwareSpec {
+            id: self.id,
+            name: self.name,
+            num_registers: self.num_registers,
+            num_stacks: self.num_stacks,
+            max_stack_length: self.max_stack_length,
+        };
+        modified_hardware_spec.validate()?;
+
+        // Update the row, returning the new value. If the row doesn't exist,
+        // this will return None.
+        let result: Result<Option<models::HardwareSpec>, _> =
+            diesel::update(hardware_specs::table.find(self.id))
+                .set(modified_hardware_spec)
+                .returning(hardware_specs::table::all_columns())
+                .get_result(self.conn)
+                .optional();
+
+        DbErrorConverter {
+            // HardwareSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            // No update fields were given
+            query_builder_to_no_update: true,
+            ..Default::default()
+        }
+        .convert(result)
+    }
+}

--- a/api/src/views/mod.rs
+++ b/api/src/views/mod.rs
@@ -1,0 +1,24 @@
+//! Views are a layer on top of models that hold as much logic as possible
+//! for fetching, mutations, etc. They're an abstraction layer between the
+//! models and the GQL responders.
+
+mod hardware_spec;
+mod program_spec;
+mod user;
+mod user_program;
+
+use crate::error::ResponseResult;
+pub use hardware_spec::*;
+pub use program_spec::*;
+pub use user::*;
+pub use user_program::*;
+
+/// A `View` is a type that can perform some action which is called from the
+/// API. It could be a read or a write operation. The struct should hold
+/// whatever context is necessary to perform the operation, and it can be
+/// executed using [Self::execute].
+pub trait View {
+    type Output;
+
+    fn execute(&self) -> ResponseResult<Self::Output>;
+}

--- a/api/src/views/program_spec.rs
+++ b/api/src/views/program_spec.rs
@@ -1,0 +1,96 @@
+use crate::{
+    error::{DbErrorConverter, ResponseResult},
+    models,
+    schema::program_specs,
+    views::View,
+};
+use diesel::{OptionalExtension, PgConnection, QueryDsl, RunQueryDsl, Table};
+use uuid::Uuid;
+use validator::Validate;
+
+/// Create a new program spec
+pub struct CreateProgramSpecView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub hardware_spec_id: Uuid,
+    pub name: &'a str,
+    pub description: &'a str,
+    pub input: &'a [i32],
+    pub expected_output: &'a [i32],
+}
+
+impl<'a> View for CreateProgramSpecView<'a> {
+    type Output = models::ProgramSpec;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // User a helper type to do the insert
+        let new_program_spec = models::NewProgramSpec {
+            hardware_spec_id: self.hardware_spec_id,
+            name: self.name,
+            description: self.description,
+            input: self.input.into(),
+            expected_output: self.expected_output.into(),
+        };
+        new_program_spec.validate()?;
+
+        // Insert the new row and return the whole row
+        let result: Result<models::ProgramSpec, _> = new_program_spec
+            .insert()
+            .returning(program_specs::table::all_columns())
+            .get_result(self.conn);
+
+        DbErrorConverter {
+            // Given hardware spec ID was invalid
+            fk_violation_to_not_found: true,
+            // ProgramSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            ..Default::default()
+        }
+        .convert(result)
+    }
+}
+
+/// Modify an existing program spec
+pub struct UpdateProgramSpecView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub id: Uuid,
+    pub name: Option<&'a str>,
+    pub description: Option<&'a str>,
+    pub input: Option<&'a [i32]>,
+    pub expected_output: Option<&'a [i32]>,
+}
+
+impl<'a> View for UpdateProgramSpecView<'a> {
+    type Output = Option<models::ProgramSpec>;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // Use a helper type to do the insert
+        let modified_program_spec = models::ModifiedProgramSpec {
+            id: self.id,
+            name: self.name.as_deref(),
+            description: self.description.as_deref(),
+            input: self.input.map(Vec::from),
+            expected_output: self.expected_output.map(Vec::from),
+        };
+        modified_program_spec.validate()?;
+
+        // Update the row, returning the new value. If the row doesn't exist,
+        // this will return None.
+        let result: Result<Option<models::ProgramSpec>, _> =
+            diesel::update(program_specs::table.find(modified_program_spec.id))
+                .set(modified_program_spec)
+                .returning(program_specs::table::all_columns())
+                .get_result(self.conn)
+                .optional();
+
+        DbErrorConverter {
+            // ProgramSpec already exists with this name or slug
+            unique_violation_to_exists: true,
+            // No update fields were given
+            query_builder_to_no_update: true,
+            ..Default::default()
+        }
+        .convert(result)
+    }
+}

--- a/api/src/views/user.rs
+++ b/api/src/views/user.rs
@@ -1,0 +1,81 @@
+use crate::{
+    error::{DbErrorConverter, ResponseError, ResponseResult},
+    models,
+    schema::{user_providers, users},
+    server::UserContext,
+    views::View,
+};
+use diesel::{
+    Connection, ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl,
+};
+use validator::Validate;
+
+/// Initialize a new user.
+pub struct InitializeUserView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_context: Option<UserContext>,
+    pub username: &'a str,
+}
+
+impl<'a> View for InitializeUserView<'a> {
+    type Output = models::User;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // The user should be logged in, but not had a User object created yet
+        match self.user_context {
+            Some(UserContext {
+                user_provider_id, ..
+            }) => {
+                let new_user = models::NewUser {
+                    username: &self.username,
+                };
+                new_user.validate()?;
+
+                // We need to insert the new user row, then update the
+                // user_provider to point at that row. We need a transaction to
+                // prevent race conditions.
+                self.conn
+                    .transaction::<models::User, ResponseError, _>(|| {
+                        let create_user_result: Result<models::User, _> =
+                            new_user
+                                .insert()
+                                .returning(users::all_columns)
+                                .get_result(self.conn);
+
+                        // Check if the username already exists
+                        let created_user = DbErrorConverter {
+                            unique_violation_to_exists: true,
+                            ..Default::default()
+                        }
+                        .convert(create_user_result)?;
+
+                        // We should update exactly 1 row. If not, then either
+                        // the referenced user_provider row is already linked to
+                        // a user, or it doesn't exist. In either case, just
+                        // return a NotFound error.
+                        let updated_rows = diesel::update(
+                            user_providers::table
+                                .find(user_provider_id)
+                                .filter(
+                                    user_providers::columns::user_id.is_null(),
+                                ),
+                        )
+                        .set(
+                            user_providers::columns::user_id
+                                .eq(Some(created_user.id)),
+                        )
+                        .execute(self.conn)?;
+
+                        if updated_rows == 0 {
+                            Err(ResponseError::NotFound)
+                        } else {
+                            Ok(created_user)
+                        }
+                    })
+                    .map_err(ResponseError::from)
+            }
+            // Get up on outta here
+            None => Err(ResponseError::Unauthenticated),
+        }
+    }
+}

--- a/api/src/views/user_program.rs
+++ b/api/src/views/user_program.rs
@@ -1,0 +1,152 @@
+use crate::{
+    error::{DbErrorConverter, ResponseError, ResponseResult},
+    models,
+    schema::user_programs,
+    views::View,
+};
+use diesel::{OptionalExtension, PgConnection, RunQueryDsl, Table};
+use uuid::Uuid;
+use validator::Validate;
+
+/// Create a new user_program
+pub struct CreateUserProgramView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub program_spec_id: Uuid,
+    pub file_name: &'a str,
+    pub source_code: &'a str,
+}
+
+impl<'a> View for CreateUserProgramView<'a> {
+    type Output = models::UserProgram;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        let new_user_program = models::NewUserProgram {
+            user_id: self.user_id,
+            program_spec_id: self.program_spec_id,
+            file_name: self.file_name,
+            source_code: self.source_code,
+        };
+        new_user_program.validate()?;
+
+        // Insert the new row and return the whole row
+        let result: Result<models::UserProgram, _> = new_user_program
+            .insert()
+            .returning(user_programs::table::all_columns())
+            .get_result(self.conn);
+
+        DbErrorConverter {
+            // Given program spec ID was invalid. Note: this can also indicate
+            // an invalid user ID which would be a server-side bug, but fuck it
+            fk_violation_to_not_found: true,
+            // UserProgram already exists with this program spec/file name
+            unique_violation_to_exists: true,
+            ..Default::default()
+        }
+        .convert(result)
+    }
+}
+
+/// Update an existing user_program
+pub struct UpdateUserProgramView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub id: Uuid,
+    pub file_name: Option<&'a str>,
+    pub source_code: Option<&'a str>,
+}
+
+impl<'a> View for UpdateUserProgramView<'a> {
+    type Output = Option<models::UserProgram>;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        let modified_user_program = models::ModifiedUserProgram {
+            id: self.id,
+            file_name: self.file_name,
+            source_code: self.source_code,
+        };
+        modified_user_program.validate()?;
+
+        // Update the row, returning the new value. If the row doesn't
+        // exist, this will return None.
+        let result: Result<Option<models::UserProgram>, _> =
+            diesel::update(models::UserProgram::find_for_user(
+                modified_user_program.id,
+                self.user_id,
+            ))
+            .set(modified_user_program)
+            .returning(user_programs::table::all_columns())
+            .get_result(self.conn)
+            .optional();
+
+        DbErrorConverter {
+            // UserProgram already exists with this program spec/file name
+            unique_violation_to_exists: true,
+            // No update fields were given
+            query_builder_to_no_update: true,
+            ..Default::default()
+        }
+        .convert(result)
+    }
+}
+
+/// Duplicate an existing user_program
+pub struct CopyUserProgramView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub id: Uuid,
+}
+
+impl<'a> View for CopyUserProgramView<'a> {
+    type Output = Option<models::UserProgram>;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // The user has to own the user program to copy it
+        let existing_user_program: Option<models::UserProgram> =
+            models::UserProgram::find_for_user(self.id, self.user_id)
+                .get_result(self.conn)
+                .optional()?;
+
+        // If the requested user_program exists (for the given user), copy it
+        Ok(match existing_user_program {
+            None => None,
+            Some(user_program) => {
+                Some(
+                    models::NewUserProgram {
+                        user_id: self.user_id,
+                        program_spec_id: user_program.program_spec_id,
+                        // Generate a new file name
+                        file_name: &format!("{} copy", &user_program.file_name),
+                        source_code: &user_program.source_code,
+                    }
+                    .insert()
+                    .returning(user_programs::all_columns)
+                    .get_result(self.conn)?,
+                )
+            }
+        })
+    }
+}
+
+/// Delete an existing user_program
+pub struct DeleteUserProgramView<'a> {
+    pub conn: &'a PgConnection,
+    pub user_id: Uuid,
+    pub id: Uuid,
+}
+
+impl<'a> View for DeleteUserProgramView<'a> {
+    type Output = Option<Uuid>;
+
+    fn execute(&self) -> ResponseResult<Self::Output> {
+        // User has to own the program to delete it
+        diesel::delete(models::UserProgram::find_for_user(
+            self.id,
+            self.user_id,
+        ))
+        .returning(user_programs::columns::id)
+        .get_result(self.conn)
+        .optional()
+        .map_err(ResponseError::from)
+    }
+}

--- a/api/tests/test_copy_user_program.rs
+++ b/api/tests/test_copy_user_program.rs
@@ -39,7 +39,7 @@ fn test_copy_user_program_success() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -59,7 +59,6 @@ fn test_copy_user_program_success() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(
@@ -94,11 +93,7 @@ fn test_copy_user_program_success() {
 #[test]
 fn test_copy_user_program_invalid_id() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
-    // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
-    runner.set_user(user); // Log in
+    runner.log_in();
 
     assert_eq!(
         runner.query(
@@ -171,7 +166,7 @@ fn test_copy_user_program_wrong_owner() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
+    runner.log_in();
     let other_user = NewUser { username: "user2" }.create(conn);
     let program_spec_id = NewProgramSpec {
         name: "prog1",
@@ -192,7 +187,6 @@ fn test_copy_user_program_wrong_owner() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(

--- a/api/tests/test_create_user_program.rs
+++ b/api/tests/test_create_user_program.rs
@@ -44,7 +44,7 @@ fn test_create_user_program_success() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
+    runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -57,7 +57,6 @@ fn test_create_user_program_success() {
     }
     .create(conn)
     .id;
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(
@@ -111,7 +110,7 @@ fn test_create_user_program_repeat_name() {
 
     // Create a user_program for user1
     let user1 = NewUser { username: "user1" }.create(conn);
-    runner.set_user(user1);
+    runner.set_user(&user1);
     assert_eq!(
         runner.query(
             QUERY,
@@ -143,7 +142,7 @@ fn test_create_user_program_repeat_name() {
 
     // Create a user_program with the same name for user2
     let user2 = NewUser { username: "user2" }.create(conn);
-    runner.set_user(user2);
+    runner.set_user(&user2);
     assert_eq!(
         runner.query(
             QUERY,
@@ -180,7 +179,7 @@ fn test_create_user_program_duplicate() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -202,8 +201,6 @@ fn test_create_user_program_duplicate() {
         source_code: "READ RX0",
     }
     .create(conn);
-
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(
@@ -230,7 +227,7 @@ fn test_create_user_program_invalid_program_spec() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
+    runner.log_in();
     NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -242,7 +239,6 @@ fn test_create_user_program_invalid_program_spec() {
         ..Default::default()
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     // Error - Unknown user+program spec combo
     assert_eq!(
@@ -270,7 +266,7 @@ fn test_create_user_program_invalid_values() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
+    runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -283,7 +279,6 @@ fn test_create_user_program_invalid_values() {
     }
     .create(conn)
     .id;
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(

--- a/api/tests/test_delete_user_program.rs
+++ b/api/tests/test_delete_user_program.rs
@@ -27,7 +27,7 @@ fn test_delete_user_program_success() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let user_program_id = NewUserProgram {
         user_id: user.id,
         program_spec_id: NewProgramSpec {
@@ -47,7 +47,6 @@ fn test_delete_user_program_success() {
     }
     .create(conn)
     .id;
-    runner.set_user(user); // Log in
 
     // Known row
     assert_eq!(
@@ -144,9 +143,11 @@ fn test_delete_user_program_not_logged_in() {
 fn test_delete_user_program_wrong_owner() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
+    runner.log_in();
 
+    let owner = NewUser { username: "user2" }.create(conn);
     let user_program_id = NewUserProgram {
-        user_id: NewUser { username: "user1" }.create(conn).id,
+        user_id: owner.id,
         program_spec_id: NewProgramSpec {
             name: "prog1",
             hardware_spec_id: NewHardwareSpec {
@@ -164,8 +165,6 @@ fn test_delete_user_program_wrong_owner() {
     }
     .create(conn)
     .id;
-    let not_owner = NewUser { username: "user2" }.create(conn);
-    runner.set_user(not_owner); // Log in as someone else
 
     // It should pretend like the user_program doesn't exist
     assert_eq!(

--- a/api/tests/test_query_program_spec.rs
+++ b/api/tests/test_query_program_spec.rs
@@ -1,9 +1,7 @@
 #![deny(clippy::all)]
 
 use diesel::PgConnection;
-use gdlk_api::models::{
-    self, Factory, NewHardwareSpec, NewProgramSpec, NewUser,
-};
+use gdlk_api::models::{self, Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -79,7 +77,7 @@ fn test_program_spec_user_program() {
     let mut runner = QueryRunner::new();
     let conn: &PgConnection = &runner.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
         ..Default::default()
@@ -129,7 +127,6 @@ fn test_program_spec_user_program() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     let query = r#"
         query UserProgramQuery(

--- a/api/tests/test_update_user_program.rs
+++ b/api/tests/test_update_user_program.rs
@@ -46,7 +46,7 @@ fn test_update_user_program_success() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -66,7 +66,6 @@ fn test_update_user_program_success() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(
@@ -155,7 +154,7 @@ fn test_update_user_program_wrong_owner() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let owner = NewUser { username: "user1" }.create(conn);
+    let owner = NewUser { username: "owner" }.create(conn);
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -175,8 +174,7 @@ fn test_update_user_program_wrong_owner() {
         source_code: "READ RX0",
     }
     .create(conn);
-    let not_owner = NewUser { username: "user2" }.create(conn);
-    runner.set_user(not_owner); // Log in as someone other than the owner
+    runner.log_in(); // Log in as someone other than the owner
 
     assert_eq!(
         runner.query(
@@ -205,7 +203,7 @@ fn test_update_user_program_empty_modification() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -225,7 +223,6 @@ fn test_update_user_program_empty_modification() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(
@@ -252,7 +249,7 @@ fn test_update_user_program_duplicate() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -280,7 +277,6 @@ fn test_update_user_program_duplicate() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     assert_eq!(
         runner.query(
@@ -309,7 +305,7 @@ fn test_update_user_program_invalid_values() {
     let conn: &PgConnection = &runner.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
+    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -329,7 +325,6 @@ fn test_update_user_program_invalid_values() {
         source_code: "READ RX0",
     }
     .create(conn);
-    runner.set_user(user); // Log in
 
     // Error - Known user program, but the target file name is invalid
     assert_eq!(


### PR DESCRIPTION
This adds another layer between the models and the GQL resolvers, called views (name open to changes). Right now I only implemented them for mutations. The big gain here is that it will make it much easier and more central once we implement permissions. I need to figure out a way to make this easy to use with read operations too so that we don't duplicate too much code between models. For now though we just won't implement custom permissions for read ops.

As part of this I added a check to the hw and program spec mutations that require you to be logged in to run them.