### PR TITLE
Use DB transactions during testing instead of manually wiping all tables

### DIFF
--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -91,9 +91,7 @@ impl HardwareSpecNodeFields for HardwareSpecNode {
         Ok(
             models::ProgramSpec::filter_by_hardware_spec(self.hardware_spec.id)
                 .filter(program_specs::dsl::slug.eq(&slug))
-                .get_result::<models::ProgramSpec>(
-                    &executor.context().get_db_conn()?,
-                )
+                .get_result::<models::ProgramSpec>(executor.context().db_conn())
                 .optional()?
                 .map(ProgramSpecNode::from),
         )
@@ -147,7 +145,7 @@ impl HardwareSpecConnection {
     fn get_total_count(&self, context: &Context) -> ResponseResult<i32> {
         match hardware_specs::table
             .select(dsl::count_star())
-            .get_result::<i64>(&context.get_db_conn()?)
+            .get_result::<i64>(context.db_conn())
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
             Ok(count) => Ok(count.try_into().unwrap()),
@@ -170,7 +168,7 @@ impl HardwareSpecConnection {
         }
 
         let rows: Vec<models::HardwareSpec> =
-            query.get_results(&context.get_db_conn()?)?;
+            query.get_results(context.db_conn())?;
 
         Ok(HardwareSpecEdge::from_db_rows(rows, offset))
     }

--- a/api/src/server/gql/internal.rs
+++ b/api/src/server/gql/internal.rs
@@ -91,7 +91,7 @@ pub fn get_by_id_from_all_types(
     context: &Context,
     id: &juniper::ID,
 ) -> ResponseResult<Option<Node>> {
-    let conn: &PgConnection = &context.get_db_conn()? as &PgConnection;
+    let conn = context.db_conn();
     let uuid_id = util::gql_id_to_uuid(id);
 
     // Do one query per node type to fine the node with this ID

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -14,7 +14,6 @@ use crate::{
     util,
     views::{self, View},
 };
-use diesel::PgConnection;
 use juniper_from_schema::{QueryTrail, Walked};
 
 /// The top-level mutation object.
@@ -29,7 +28,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<InitializeUserPayload> {
         let context = executor.context();
         let view = views::InitializeUserView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_context: context.user_context,
             username: &input.username,
         };
@@ -45,7 +44,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<CreateHardwareSpecPayload> {
         let context = executor.context();
         let view = views::CreateHardwareSpecView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             name: &input.name,
             num_registers: input.num_registers,
@@ -65,7 +64,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<UpdateHardwareSpecPayload> {
         let context = executor.context();
         let view = views::UpdateHardwareSpecView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
             name: input.name.as_deref(),
@@ -86,7 +85,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<CreateProgramSpecPayload> {
         let context = executor.context();
         let view = views::CreateProgramSpecView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             hardware_spec_id: util::gql_id_to_uuid(&input.hardware_spec_id),
             name: &input.name,
@@ -107,7 +106,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<UpdateProgramSpecPayload> {
         let context = executor.context();
         let view = views::UpdateProgramSpecView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
             name: input.name.as_deref(),
@@ -128,7 +127,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<CreateUserProgramPayload> {
         let context = executor.context();
         let view = views::CreateUserProgramView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             program_spec_id: util::gql_id_to_uuid(&input.program_spec_id),
             file_name: &input.file_name,
@@ -148,7 +147,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<UpdateUserProgramPayload> {
         let context = executor.context();
         let view = views::UpdateUserProgramView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
             file_name: input.file_name.as_deref(),
@@ -167,7 +166,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<CopyUserProgramPayload> {
         let context = executor.context();
         let view = views::CopyUserProgramView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
         };
@@ -184,7 +183,7 @@ impl MutationFields for Mutation {
     ) -> ResponseResult<DeleteUserProgramPayload> {
         let context = executor.context();
         let view = views::DeleteUserProgramView {
-            conn: &context.get_db_conn()? as &PgConnection,
+            conn: context.db_conn(),
             user_id: context.user_id()?,
             id: util::gql_id_to_uuid(&input.id),
         };

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -98,7 +98,7 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         _trail: &QueryTrail<'_, HardwareSpecNode, Walked>,
     ) -> ResponseResult<HardwareSpecNode> {
         Ok(HardwareSpecNode::find(
-            &executor.context().get_db_conn()? as &PgConnection,
+            &executor.context().db_conn(),
             self.program_spec.hardware_spec_id,
         )?
         .into())
@@ -111,7 +111,6 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         file_name: String,
     ) -> ResponseResult<Option<UserProgramNode>> {
         let context = executor.context();
-        let conn = &context.get_db_conn()? as &PgConnection;
         let user_id = context.user_id()?;
 
         Ok(models::UserProgram::filter_by_user_and_program_spec(
@@ -120,7 +119,7 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         )
         .filter(user_programs::dsl::file_name.eq(&file_name))
         .select(user_programs::table::all_columns())
-        .get_result::<models::UserProgram>(conn)
+        .get_result::<models::UserProgram>(context.db_conn())
         .optional()?
         .map(UserProgramNode::from))
     }
@@ -180,7 +179,7 @@ impl ProgramSpecConnection {
                 self.hardware_spec_id,
             ))
             .select(dsl::count_star())
-            .get_result::<i64>(&context.get_db_conn()?)
+            .get_result::<i64>(context.db_conn())
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
             Ok(count) => Ok(count.try_into().unwrap()),
@@ -208,7 +207,7 @@ impl ProgramSpecConnection {
         }
 
         let rows: Vec<models::ProgramSpec> =
-            query.get_results(&context.get_db_conn()?)?;
+            query.get_results(context.db_conn())?;
 
         Ok(ProgramSpecEdge::from_db_rows(rows, offset))
     }

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -93,9 +93,8 @@ impl AuthStatusFields for AuthStatus {
 
         match executor.context().user_id() {
             Ok(user_id) => {
-                let user: models::User = users::table
-                    .find(user_id)
-                    .get_result(&context.get_db_conn()?)?;
+                let user: models::User =
+                    users::table.find(user_id).get_result(context.db_conn())?;
                 Ok(Some(user.into()))
             }
             // User isn't authed or hasn't finished setup

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -79,7 +79,7 @@ impl UserProgramNodeFields for UserProgramNode {
         _trail: &QueryTrail<'_, UserNode, Walked>,
     ) -> ResponseResult<UserNode> {
         Ok(UserNode::find(
-            &executor.context().get_db_conn()? as &PgConnection,
+            executor.context().db_conn(),
             self.user_program.user_id,
         )?
         .into())
@@ -91,7 +91,7 @@ impl UserProgramNodeFields for UserProgramNode {
         _trail: &QueryTrail<'_, ProgramSpecNode, Walked>,
     ) -> ResponseResult<ProgramSpecNode> {
         Ok(ProgramSpecNode::find(
-            &executor.context().get_db_conn()? as &PgConnection,
+            executor.context().db_conn(),
             self.user_program.program_spec_id,
         )?
         .into())
@@ -144,7 +144,7 @@ impl UserProgramConnection {
             self.program_spec_id,
         )
         .select(dsl::count_star())
-        .get_result::<i64>(&context.get_db_conn()?)
+        .get_result::<i64>(context.db_conn())
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
             Ok(count) => Ok(count.try_into().unwrap()),
@@ -173,7 +173,7 @@ impl UserProgramConnection {
         }
 
         let rows: Vec<models::UserProgram> =
-            query.get_results(&context.get_db_conn()?)?;
+            query.get_results(context.db_conn())?;
 
         Ok(UserProgramEdge::from_db_rows(rows, offset))
     }

--- a/api/src/server/mod.rs
+++ b/api/src/server/mod.rs
@@ -73,14 +73,12 @@ async fn route_graphql(
         }
     };
 
+    let context = Context {
+        db_conn: pool.get().map_err(ResponseError::from)?,
+        user_context,
+    };
     let response = web::block(move || {
-        let res = data.execute(
-            &gql_schema,
-            &Context {
-                pool: pool.into_inner(),
-                user_context,
-            },
-        );
+        let res = data.execute(&gql_schema, &context);
         Ok::<_, serde_json::error::Error>(serde_json::to_string(&res)?)
     })
     .await?;

--- a/api/src/util.rs
+++ b/api/src/util.rs
@@ -2,8 +2,8 @@
 
 #[cfg(test)]
 pub use self::tests::*;
-use diesel::{r2d2::ConnectionManager, PgConnection};
-use failure::Fallible;
+use diesel::{r2d2::ConnectionManager, Connection, PgConnection};
+use r2d2::CustomizeConnection;
 use std::ops::Deref;
 use uuid::Uuid;
 use validator::{Validate, ValidationErrors};
@@ -41,10 +41,42 @@ impl<T: Validate> Deref for Valid<T> {
     }
 }
 
-pub fn init_db_conn_pool(database_url: &str) -> Fallible<Pool> {
+/// A DB connection customizer that wraps each connection in a transaction
+/// before returning it. This should be used in all unit tests to prevent
+/// make changes to the DB.
+#[derive(Copy, Clone, Debug)]
+struct TestConnectionCustomizer;
+
+impl CustomizeConnection<PgConnection, diesel::r2d2::Error>
+    for TestConnectionCustomizer
+{
+    fn on_acquire(
+        &self,
+        conn: &mut PgConnection,
+    ) -> Result<(), diesel::r2d2::Error> {
+        conn.begin_test_transaction()
+            .map_err(diesel::r2d2::Error::QueryError)?;
+        Ok(())
+    }
+
+    fn on_release(&self, _conn: PgConnection) {}
+}
+
+/// Initialize a new DB connection pool, for use in the webserver.
+pub fn init_db_conn_pool(database_url: &str) -> Result<Pool, r2d2::Error> {
     let manager = ConnectionManager::new(database_url);
-    let pool = r2d2::Pool::builder().build(manager)?;
-    Ok(pool)
+    r2d2::Pool::builder().build(manager)
+}
+
+/// Initialize a new DB connection pool for use in tests. Reads the DB URL from
+/// the environment. Also, all connections are wrapped in a test transaction
+/// to prevent making modifications to the DB.
+pub fn init_test_db_conn_pool() -> Result<Pool, r2d2::Error> {
+    let database_url = std::env::var("DATABASE_URL").unwrap();
+    let manager = ConnectionManager::new(database_url);
+    r2d2::Pool::builder()
+        .connection_customizer(Box::new(TestConnectionCustomizer))
+        .build(manager)
 }
 
 /// Converts a UUID to a Juniper (GraphQL) ID.

--- a/api/tests/test_copy_user_program.rs
+++ b/api/tests/test_copy_user_program.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{
     Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
 };
@@ -36,10 +35,10 @@ static QUERY: &str = r#"
 #[test]
 fn test_copy_user_program_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let user = runner.log_in();
+    let conn = runner.db_conn();
 
     // Initialize data
-    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -117,7 +116,7 @@ fn test_copy_user_program_invalid_id() {
 #[test]
 fn test_copy_user_program_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     // Initialize data
     let user = NewUser { username: "user1" }.create(conn);
@@ -163,10 +162,10 @@ fn test_copy_user_program_not_logged_in() {
 #[test]
 fn test_copy_user_program_wrong_owner() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    runner.log_in();
+    let conn = runner.db_conn();
 
     // Initialize data
-    runner.log_in();
     let other_user = NewUser { username: "user2" }.create(conn);
     let program_spec_id = NewProgramSpec {
         name: "prog1",

--- a/api/tests/test_create_hardware_spec.rs
+++ b/api/tests/test_create_hardware_spec.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewHardwareSpec};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -39,8 +38,8 @@ static QUERY: &str = r#"
 #[test]
 fn test_create_hardware_spec_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     // We'll test collisions against this
     NewHardwareSpec {
@@ -82,8 +81,8 @@ fn test_create_hardware_spec_success() {
 #[test]
 fn test_create_hardware_spec_duplicate() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     // We'll test collisions against this
     NewHardwareSpec {

--- a/api/tests/test_create_program_spec.rs
+++ b/api/tests/test_create_program_spec.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -41,8 +40,8 @@ static QUERY: &str = r#"
 #[test]
 fn test_create_program_spec_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -118,8 +117,8 @@ fn test_create_program_spec_invalid_hw_spec() {
 #[test]
 fn test_create_program_spec_duplicate() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -164,8 +163,8 @@ fn test_create_program_spec_duplicate() {
 #[test]
 fn test_create_program_spec_invalid_values() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -205,7 +204,7 @@ fn test_create_program_spec_invalid_values() {
 #[test]
 fn test_create_program_spec_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()

--- a/api/tests/test_create_user_program.rs
+++ b/api/tests/test_create_user_program.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{
     Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
 };
@@ -42,9 +41,9 @@ static QUERY: &str = r#"
 #[test]
 fn test_create_user_program_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     runner.log_in();
+    let conn = runner.db_conn();
+
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -93,7 +92,7 @@ fn test_create_user_program_success() {
 #[test]
 fn test_create_user_program_repeat_name() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let program_spec_id = NewProgramSpec {
         name: "prog1",
@@ -109,7 +108,7 @@ fn test_create_user_program_repeat_name() {
     .id;
 
     // Create a user_program for user1
-    let user1 = NewUser { username: "user1" }.create(conn);
+    let user1 = NewUser { username: "user1" }.create(runner.db_conn());
     runner.set_user(&user1);
     assert_eq!(
         runner.query(
@@ -141,7 +140,7 @@ fn test_create_user_program_repeat_name() {
     );
 
     // Create a user_program with the same name for user2
-    let user2 = NewUser { username: "user2" }.create(conn);
+    let user2 = NewUser { username: "user2" }.create(runner.db_conn());
     runner.set_user(&user2);
     assert_eq!(
         runner.query(
@@ -177,9 +176,9 @@ fn test_create_user_program_repeat_name() {
 #[test]
 fn test_create_user_program_duplicate() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     let user = runner.log_in();
+    let conn = runner.db_conn();
+
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -225,9 +224,9 @@ fn test_create_user_program_duplicate() {
 #[test]
 fn test_create_user_program_invalid_program_spec() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     runner.log_in();
+    let conn = runner.db_conn();
+
     NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -264,9 +263,9 @@ fn test_create_user_program_invalid_program_spec() {
 #[test]
 fn test_create_user_program_invalid_values() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     runner.log_in();
+    let conn = runner.db_conn();
+
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {

--- a/api/tests/test_delete_user_program.rs
+++ b/api/tests/test_delete_user_program.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use diesel::{OptionalExtension, PgConnection, QueryDsl, RunQueryDsl};
+use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
 use gdlk_api::{
     models::{
         self, Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
@@ -25,9 +25,9 @@ static QUERY: &str = r#"
 #[test]
 fn test_delete_user_program_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     let user = runner.log_in();
+    let conn = runner.db_conn();
+
     let user_program_id = NewUserProgram {
         user_id: user.id,
         program_spec_id: NewProgramSpec {
@@ -98,7 +98,7 @@ fn test_delete_user_program_success() {
 #[test]
 fn test_delete_user_program_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let user_program_id = NewUserProgram {
         user_id: NewUser { username: "user1" }.create(conn).id,
@@ -142,8 +142,8 @@ fn test_delete_user_program_not_logged_in() {
 #[test]
 fn test_delete_user_program_wrong_owner() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     let owner = NewUser { username: "user2" }.create(conn);
     let user_program_id = NewUserProgram {

--- a/api/tests/test_initialize_user.rs
+++ b/api/tests/test_initialize_user.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use diesel::{dsl, PgConnection, QueryDsl, RunQueryDsl};
+use diesel::{dsl, QueryDsl, RunQueryDsl};
 use gdlk_api::{
     models::{Factory, NewUser, NewUserProvider},
     schema::users,
@@ -32,7 +32,7 @@ static QUERY: &str = r#"
 #[test]
 fn test_initialize_user_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let user_provider = NewUserProvider {
         sub: "sub",
@@ -91,7 +91,7 @@ fn test_initialize_user_not_logged_in() {
 #[test]
 fn test_initialize_user_duplicate_username() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     NewUser { username: "user1" }.create(conn);
     let user_provider = NewUserProvider {
@@ -124,7 +124,7 @@ fn test_initialize_user_duplicate_username() {
 #[test]
 fn test_initialize_user_invalid_username() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let user_provider = NewUserProvider {
         sub: "sub",
@@ -184,7 +184,7 @@ fn test_initialize_user_invalid_username() {
 #[test]
 fn test_initialize_user_already_initialized() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let user = NewUser { username: "user1" }.create(conn);
     let user_provider = NewUserProvider {
@@ -219,7 +219,7 @@ fn test_initialize_user_already_initialized() {
     assert_eq!(
         users::table
             .select(dsl::count_star())
-            .get_result::<i64>(conn)
+            .get_result::<i64>(runner.db_conn())
             .unwrap(),
         1
     );

--- a/api/tests/test_query_auth_status.rs
+++ b/api/tests/test_query_auth_status.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewUser, NewUserProvider};
 use maplit::hashmap;
 use serde_json::json;
@@ -45,7 +44,7 @@ fn test_field_auth_status_not_logged_in() {
 #[test]
 fn test_field_auth_status_user_not_created() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
     let user_provider = NewUserProvider {
         sub: "asdf",
         provider_name: "provider",
@@ -75,7 +74,7 @@ fn test_field_auth_status_user_not_created() {
 #[test]
 fn test_field_auth_status_user_created() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
     let user = NewUser { username: "user1" }.create(conn);
     let user_provider = NewUserProvider {
         sub: "asdf",

--- a/api/tests/test_query_hardware_spec.rs
+++ b/api/tests/test_query_hardware_spec.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -12,7 +11,7 @@ mod utils;
 #[test]
 fn test_field_hardware_spec() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -74,7 +73,7 @@ fn test_field_hardware_spec() {
 #[test]
 fn test_field_hardware_specs() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     NewHardwareSpec {
         name: "hw1",
@@ -187,7 +186,7 @@ fn test_field_hardware_specs() {
 #[test]
 fn test_field_hardware_spec_program_spec() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",

--- a/api/tests/test_query_node.rs
+++ b/api/tests/test_query_node.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{
     self, Factory, NewHardwareSpec, NewProgramSpec, NewUser,
 };
@@ -14,7 +13,7 @@ mod utils;
 #[test]
 fn test_field_node() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let user_id = NewUser { username: "user1" }.create(conn).id;
     let hardware_spec_id = NewHardwareSpec {

--- a/api/tests/test_query_program_spec.rs
+++ b/api/tests/test_query_program_spec.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{self, Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -12,7 +11,7 @@ mod utils;
 #[test]
 fn test_program_spec() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -75,9 +74,9 @@ fn test_program_spec() {
 #[test]
 fn test_program_spec_user_program() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     let user = runner.log_in();
+    let conn = runner.db_conn();
+
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
         ..Default::default()
@@ -218,7 +217,7 @@ fn test_program_spec_user_program() {
 #[test]
 fn test_program_spec_user_program_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",

--- a/api/tests/test_query_user.rs
+++ b/api/tests/test_query_user.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewUser};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -12,7 +11,7 @@ mod utils;
 #[test]
 fn test_field_user() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     let user_id = NewUser { username: "user1" }.create(conn).id;
     let query = r#"

--- a/api/tests/test_update_hardware_spec.rs
+++ b/api/tests/test_update_hardware_spec.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewHardwareSpec};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -41,9 +40,9 @@ static QUERY: &str = r#"
 #[test]
 fn test_update_hardware_spec_partial_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     runner.log_in();
+    let conn = runner.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
         ..Default::default()
@@ -82,8 +81,8 @@ fn test_update_hardware_spec_partial_modification() {
 #[test]
 fn test_update_hardware_spec_full_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -150,8 +149,8 @@ fn test_update_hardware_spec_invalid_id() {
 #[test]
 fn test_update_hardware_spec_empty_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -181,8 +180,8 @@ fn test_update_hardware_spec_empty_modification() {
 #[test]
 fn test_update_hardware_spec_duplicate() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     // We'll test collisions against this
     NewHardwareSpec {
@@ -219,8 +218,8 @@ fn test_update_hardware_spec_duplicate() {
 #[test]
 fn test_update_hardware_spec_invalid_values() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -260,7 +259,7 @@ fn test_update_hardware_spec_invalid_values() {
 #[test]
 fn test_update_hardware_spec_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
         ..Default::default()

--- a/api/tests/test_update_program_spec.rs
+++ b/api/tests/test_update_program_spec.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
@@ -41,9 +40,9 @@ static QUERY: &str = r#"
 #[test]
 fn test_update_program_spec_partial_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     runner.log_in();
+    let conn = runner.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -89,9 +88,9 @@ fn test_update_program_spec_partial_modification() {
 #[test]
 fn test_update_program_spec_full_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
-
     runner.log_in();
+    let conn = runner.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -166,8 +165,9 @@ fn test_update_program_spec_invalid_id() {
 #[test]
 fn test_update_program_spec_empty_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -209,8 +209,9 @@ fn test_update_program_spec_empty_modification() {
 #[test]
 fn test_update_program_spec_duplicate() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -253,8 +254,8 @@ fn test_update_program_spec_duplicate() {
 #[test]
 fn test_update_program_spec_invalid_values() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
     runner.log_in();
+    let conn = runner.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -294,7 +295,7 @@ fn test_update_program_spec_invalid_values() {
 #[test]
 fn test_update_program_spec_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()

--- a/api/tests/test_update_user_program.rs
+++ b/api/tests/test_update_user_program.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-use diesel::PgConnection;
 use gdlk_api::models::{
     Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
 };
@@ -43,10 +42,10 @@ static QUERY: &str = r#"
 #[test]
 fn test_update_user_program_success() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let user = runner.log_in();
+    let conn = runner.db_conn();
 
     // Initialize data
-    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -103,7 +102,7 @@ fn test_update_user_program_success() {
 #[test]
 fn test_update_user_program_not_logged_in() {
     let runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     // Initialize data
     let user = NewUser { username: "user1" }.create(conn);
@@ -151,7 +150,7 @@ fn test_update_user_program_not_logged_in() {
 #[test]
 fn test_update_user_program_wrong_owner() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let conn = runner.db_conn();
 
     // Initialize data
     let owner = NewUser { username: "owner" }.create(conn);
@@ -200,10 +199,10 @@ fn test_update_user_program_wrong_owner() {
 #[test]
 fn test_update_user_program_empty_modification() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let user = runner.log_in();
+    let conn = runner.db_conn();
 
     // Initialize data
-    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -246,10 +245,10 @@ fn test_update_user_program_empty_modification() {
 #[test]
 fn test_update_user_program_duplicate() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let user = runner.log_in();
+    let conn = runner.db_conn();
 
     // Initialize data
-    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {
@@ -302,10 +301,10 @@ fn test_update_user_program_duplicate() {
 #[test]
 fn test_update_user_program_invalid_values() {
     let mut runner = QueryRunner::new();
-    let conn: &PgConnection = &runner.db_conn();
+    let user = runner.log_in();
+    let conn = runner.db_conn();
 
     // Initialize data
-    let user = runner.log_in();
     let program_spec_id = NewProgramSpec {
         name: "prog1",
         hardware_spec_id: NewHardwareSpec {


### PR DESCRIPTION
Right now, we have a macro that wipes all tables after each test to remove any changes that might've been made. This is annoying tho cause we have to update the macro every time we add a new table. I'm changing it to instead start a new transaction on the DB for each test, then it just never gets committed so that the changes don't apply to the table. I was hoping this would allow us to parallelize the tests, but I got a deadlock error when I did so that is gonna have to wait still.

In order to do this, I had to change the GQL context to hold a single connection instead of the whole pool (cause the transaction is only attached to a single connection). After thinking about it more tho, I think this is way better anyway. Previously, we were often opening multiple connections while serving one HTTP request, which doesn't make sense. We won't be making any parallel queries so we're just wasting time by getting a new connection from the pool more than once.

Also this makes the code to actually get a connection a bit cleaner, so we don't need `as &PgConnection` anymore.