### PR TITLE
Move request context into its own file

### DIFF
--- a/api/src/server/gql/internal.rs
+++ b/api/src/server/gql/internal.rs
@@ -2,9 +2,10 @@ use crate::{
     error::ResponseResult,
     server::gql::{
         hardware_spec::HardwareSpecNode, program_spec::ProgramSpecNode,
-        user::UserNode, user_program::UserProgramNode, Context, Cursor, Node,
+        user::UserNode, user_program::UserProgramNode, Cursor, Node,
     },
     util,
+    views::RequestContext,
 };
 use diesel::{OptionalExtension, PgConnection, QueryResult};
 use std::convert::TryFrom;
@@ -88,7 +89,7 @@ impl<N: NodeType> GenericEdge<N> {
 /// associated with a node type, and finds the row with the matching ID. Since
 /// we use UUIDs, this will never match more than one row across all the tables.
 pub fn get_by_id_from_all_types(
-    context: &Context,
+    context: &RequestContext,
     id: &juniper::ID,
 ) -> ResponseResult<Option<Node>> {
     let conn = context.db_conn();

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -4,13 +4,14 @@ use crate::{
     schema::user_programs,
     server::gql::{
         internal::{GenericEdge, NodeType},
-        ConnectionPageParams, Context, CopyUserProgramPayloadFields,
+        ConnectionPageParams, CopyUserProgramPayloadFields,
         CreateUserProgramPayloadFields, Cursor, DeleteUserProgramPayloadFields,
         PageInfo, ProgramSpecNode, UpdateUserProgramPayloadFields, UserNode,
         UserProgramConnectionFields, UserProgramEdgeFields,
         UserProgramNodeFields,
     },
     util::{self, Valid},
+    views::RequestContext,
 };
 use chrono::{offset::Utc, DateTime};
 use diesel::{dsl, PgConnection, QueryDsl, QueryResult, RunQueryDsl, Table};
@@ -41,41 +42,44 @@ impl NodeType for UserProgramNode {
 }
 
 impl UserProgramNodeFields for UserProgramNode {
-    fn field_id(&self, _executor: &juniper::Executor<'_, Context>) -> ID {
+    fn field_id(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> ID {
         util::uuid_to_gql_id(self.user_program.id)
     }
 
     fn field_file_name(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
     ) -> &String {
         &self.user_program.file_name
     }
 
     fn field_source_code(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
     ) -> &String {
         &self.user_program.source_code
     }
 
     fn field_created(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
     ) -> &DateTime<Utc> {
         &self.user_program.created
     }
 
     fn field_last_modified(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
     ) -> &DateTime<Utc> {
         &self.user_program.last_modified
     }
 
     fn field_user(
         &self,
-        executor: &juniper::Executor<'_, Context>,
+        executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserNode, Walked>,
     ) -> ResponseResult<UserNode> {
         Ok(UserNode::find(
@@ -87,7 +91,7 @@ impl UserProgramNodeFields for UserProgramNode {
 
     fn field_program_spec(
         &self,
-        executor: &juniper::Executor<'_, Context>,
+        executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramSpecNode, Walked>,
     ) -> ResponseResult<ProgramSpecNode> {
         Ok(ProgramSpecNode::find(
@@ -103,7 +107,7 @@ pub type UserProgramEdge = GenericEdge<UserProgramNode>;
 impl UserProgramEdgeFields for UserProgramEdge {
     fn field_node(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramNode, Walked>,
     ) -> &UserProgramNode {
         self.node()
@@ -111,7 +115,7 @@ impl UserProgramEdgeFields for UserProgramEdge {
 
     fn field_cursor(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
     ) -> &Cursor {
         self.cursor()
     }
@@ -138,7 +142,7 @@ impl UserProgramConnection {
         })
     }
 
-    fn get_total_count(&self, context: &Context) -> ResponseResult<i32> {
+    fn get_total_count(&self, context: &RequestContext) -> ResponseResult<i32> {
         match models::UserProgram::filter_by_user_and_program_spec(
             self.user_id,
             self.program_spec_id,
@@ -154,7 +158,7 @@ impl UserProgramConnection {
 
     fn get_edges(
         &self,
-        context: &Context,
+        context: &RequestContext,
     ) -> ResponseResult<Vec<UserProgramEdge>> {
         let offset = self.page_params.offset();
 
@@ -182,14 +186,14 @@ impl UserProgramConnection {
 impl UserProgramConnectionFields for UserProgramConnection {
     fn field_total_count(
         &self,
-        executor: &juniper::Executor<'_, Context>,
+        executor: &juniper::Executor<'_, RequestContext>,
     ) -> ResponseResult<i32> {
         self.get_total_count(executor.context())
     }
 
     fn field_page_info(
         &self,
-        executor: &juniper::Executor<'_, Context>,
+        executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, PageInfo, Walked>,
     ) -> ResponseResult<PageInfo> {
         Ok(PageInfo::from_page_params(
@@ -200,7 +204,7 @@ impl UserProgramConnectionFields for UserProgramConnection {
 
     fn field_edges(
         &self,
-        executor: &juniper::Executor<'_, Context>,
+        executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
     ) -> ResponseResult<Vec<UserProgramEdge>> {
         self.get_edges(executor.context())
@@ -214,7 +218,7 @@ pub struct CreateUserProgramPayload {
 impl CreateUserProgramPayloadFields for CreateUserProgramPayload {
     fn field_user_program_edge(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
     ) -> UserProgramEdge {
         GenericEdge::from_db_row(self.user_program.clone(), 0)
@@ -228,7 +232,7 @@ pub struct UpdateUserProgramPayload {
 impl UpdateUserProgramPayloadFields for UpdateUserProgramPayload {
     fn field_user_program_edge(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
     ) -> Option<UserProgramEdge> {
         self.user_program
@@ -246,7 +250,7 @@ pub struct CopyUserProgramPayload {
 impl CopyUserProgramPayloadFields for CopyUserProgramPayload {
     fn field_user_program_edge(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
     ) -> Option<UserProgramEdge> {
         self.user_program
@@ -262,7 +266,7 @@ pub struct DeleteUserProgramPayload {
 impl DeleteUserProgramPayloadFields for DeleteUserProgramPayload {
     fn field_deleted_id(
         &self,
-        _executor: &juniper::Executor<'_, Context>,
+        _executor: &juniper::Executor<'_, RequestContext>,
     ) -> Option<juniper::ID> {
         self.deleted_id.map(util::uuid_to_gql_id)
     }

--- a/api/src/views/context.rs
+++ b/api/src/views/context.rs
@@ -1,0 +1,208 @@
+//! This module holds contextual data that gets carried with each request. The
+//! top-level struct is [RequestContext].
+
+use crate::{
+    error::{ResponseError, ResponseResult},
+    models,
+    schema::{user_providers, users},
+    util::PooledConnection,
+};
+use diesel::{
+    NullableExpressionMethods, OptionalExtension, PgConnection, QueryDsl,
+    RunQueryDsl,
+};
+use uuid::Uuid;
+
+/// Information on the logged-in user.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AuthorizedUser {
+    pub id: Uuid,
+    pub username: String,
+}
+
+impl AuthorizedUser {
+    /// Convert this user into the user model struct.
+    pub fn into_model(self) -> models::User {
+        models::User {
+            id: self.id,
+            username: self.username,
+        }
+    }
+}
+
+/// A nested part of context, representing the authenticated user.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UserContext {
+    /// The ID of the user_provider that the user used to log in.
+    pub user_provider_id: Uuid,
+    /// Information on the requesting user. None if they are logged in but have
+    /// not set their username yet.
+    pub user: Option<AuthorizedUser>,
+}
+
+impl UserContext {
+    /// Load the user context from the database. The user_provider ID should
+    /// come from some authentication.
+    fn load_context(
+        conn: &PgConnection,
+        user_provider_id: Uuid,
+    ) -> ResponseResult<Option<Self>> {
+        // TODO after diesel 2.0, merge these two queries into one
+
+        // This is a double option for a reason - the outer option indicates
+        // if the user_providers row exists in the DB. The inner option
+        // indicates if the user_id column is populated in that row.
+        // The outer should usually be Some if we get this far, it only
+        // wouldn't be if that user_providers row has been deleted but the
+        // cookie hasn't expired yet.
+        // The inner should only be None if the user has logged in, but
+        // not set their username yet, so that a row in the users table
+        // hasn't been created yet.
+        let user_query_result: Option<(Option<Uuid>, Option<String>)> =
+            user_providers::table
+                .find(user_provider_id)
+                .left_join(users::table)
+                .select((
+                    users::columns::id.nullable(),
+                    users::columns::username.nullable(),
+                ))
+                .get_result(conn)
+                .optional()
+                .map_err(ResponseError::from)?;
+
+        let user_context = match user_query_result {
+            // The cookie is invalid, so user isn't logged in
+            None => None,
+            // If the inner value is none, then the user is logged in but
+            // not initialized
+            Some((None, None)) => Some(Self {
+                user_provider_id,
+                user: None,
+            }),
+            // User is logged in and initialized, return the full user data
+            Some((Some(user_id), Some(username))) => Some(Self {
+                user_provider_id,
+                user: Some(AuthorizedUser {
+                    id: user_id,
+                    username,
+                }),
+            }),
+            // The user ID and username should always be either both None or
+            // both Some, since they can both only be None when the left_join
+            // gives a null user. Both columns are NOT NULL so if the join
+            // matches something, then they should both be defined.
+            Some((None, Some(_))) | Some((Some(_), None)) => {
+                panic!("Unexpected query result: {:?}", user_query_result)
+            }
+        };
+
+        Ok(user_context)
+    }
+}
+
+/// The context that gets attached to every incoming request.
+pub struct RequestContext {
+    /// DB connection
+    pub db_conn: PooledConnection,
+    /// The authenticated user. None if the requesting user is not logged in.
+    pub user_context: Option<UserContext>,
+}
+
+impl RequestContext {
+    /// Load the context from the given request inputs.
+    pub fn load_context(
+        db_conn: PooledConnection,
+        user_provider_id: Option<Uuid>,
+    ) -> ResponseResult<Self> {
+        // Load user context for the given user_providers ID
+        let user_context: Option<UserContext> = match user_provider_id {
+            None => None,
+            Some(upid) => UserContext::load_context(&db_conn, upid)?,
+        };
+
+        Ok(Self {
+            db_conn,
+            user_context,
+        })
+    }
+
+    pub fn db_conn(&self) -> &PgConnection {
+        &self.db_conn
+    }
+
+    /// Get the ID of the authenticated user. If the user isn't authenticated,
+    /// or they ARE authenticated but haven't finished initializing their user
+    /// yet (to the point where a row in the `users` table has been created),
+    /// then return an error.
+    pub fn user(&self) -> Result<&AuthorizedUser, ResponseError> {
+        match &self.user_context {
+            Some(UserContext {
+                user: Some(user), ..
+            }) => Ok(&user),
+            _ => Err(ResponseError::Unauthenticated),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{models::Factory, util};
+
+    /// Test when the given user provider ID isn't in the DB
+    #[test]
+    fn test_user_load_context_invalid_user_provider() {
+        let pool = util::init_test_db_conn_pool().unwrap();
+        let ctx = UserContext::load_context(&pool.get().unwrap(), Uuid::nil());
+        assert_eq!(ctx.unwrap(), None);
+    }
+
+    /// Test when the user has a user_provider but the user hasn't been
+    /// initialized yet.
+    #[test]
+    fn test_user_load_context_uninitialized_user() {
+        let pool = util::init_test_db_conn_pool().unwrap();
+        let conn = &pool.get().unwrap();
+        let user_provider = models::NewUserProvider {
+            sub: "sub",
+            provider_name: "provider",
+            user_id: None,
+        }
+        .create(conn);
+
+        let ctx = UserContext::load_context(conn, user_provider.id);
+        assert_eq!(
+            ctx.unwrap(),
+            Some(UserContext {
+                user_provider_id: user_provider.id,
+                user: None
+            })
+        );
+    }
+
+    #[test]
+    fn test_user_load_context_initialized_user() {
+        let pool = util::init_test_db_conn_pool().unwrap();
+        let conn = &pool.get().unwrap();
+
+        let user = models::NewUser { username: "user1" }.create(conn);
+        let user_provider = models::NewUserProvider {
+            sub: "sub",
+            provider_name: "provider",
+            user_id: Some(user.id),
+        }
+        .create(conn);
+
+        let ctx = UserContext::load_context(conn, user_provider.id);
+        assert_eq!(
+            ctx.unwrap(),
+            Some(UserContext {
+                user_provider_id: user_provider.id,
+                user: Some(AuthorizedUser {
+                    id: user.id,
+                    username: user.username
+                })
+            })
+        );
+    }
+}

--- a/api/src/views/mod.rs
+++ b/api/src/views/mod.rs
@@ -2,12 +2,14 @@
 //! for fetching, mutations, etc. They're an abstraction layer between the
 //! models and the GQL responders.
 
+mod context;
 mod hardware_spec;
 mod program_spec;
 mod user;
 mod user_program;
 
 use crate::error::ResponseResult;
+pub use context::*;
 pub use hardware_spec::*;
 pub use program_spec::*;
 pub use user::*;

--- a/api/src/views/user.rs
+++ b/api/src/views/user.rs
@@ -2,18 +2,14 @@ use crate::{
     error::{DbErrorConverter, ResponseError, ResponseResult},
     models,
     schema::{user_providers, users},
-    server::UserContext,
-    views::View,
+    views::{RequestContext, UserContext, View},
 };
-use diesel::{
-    Connection, ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl,
-};
+use diesel::{Connection, ExpressionMethods, QueryDsl, RunQueryDsl};
 use validator::Validate;
 
 /// Initialize a new user.
 pub struct InitializeUserView<'a> {
-    pub conn: &'a PgConnection,
-    pub user_context: Option<UserContext>,
+    pub context: &'a RequestContext,
     pub username: &'a str,
 }
 
@@ -22,10 +18,11 @@ impl<'a> View for InitializeUserView<'a> {
 
     fn execute(&self) -> ResponseResult<Self::Output> {
         // The user should be logged in, but not had a User object created yet
-        match self.user_context {
+        match self.context.user_context {
             Some(UserContext {
                 user_provider_id, ..
             }) => {
+                let conn = self.context.db_conn();
                 let new_user = models::NewUser {
                     username: &self.username,
                 };
@@ -34,45 +31,41 @@ impl<'a> View for InitializeUserView<'a> {
                 // We need to insert the new user row, then update the
                 // user_provider to point at that row. We need a transaction to
                 // prevent race conditions.
-                self.conn
-                    .transaction::<models::User, ResponseError, _>(|| {
-                        let create_user_result: Result<models::User, _> =
-                            new_user
-                                .insert()
-                                .returning(users::all_columns)
-                                .get_result(self.conn);
+                conn.transaction::<models::User, ResponseError, _>(|| {
+                    let create_user_result: Result<models::User, _> = new_user
+                        .insert()
+                        .returning(users::all_columns)
+                        .get_result(conn);
 
-                        // Check if the username already exists
-                        let created_user = DbErrorConverter {
-                            unique_violation_to_exists: true,
-                            ..Default::default()
-                        }
-                        .convert(create_user_result)?;
+                    // Check if the username already exists
+                    let created_user = DbErrorConverter {
+                        unique_violation_to_exists: true,
+                        ..Default::default()
+                    }
+                    .convert(create_user_result)?;
 
-                        // We should update exactly 1 row. If not, then either
-                        // the referenced user_provider row is already linked to
-                        // a user, or it doesn't exist. In either case, just
-                        // return a NotFound error.
-                        let updated_rows = diesel::update(
-                            user_providers::table
-                                .find(user_provider_id)
-                                .filter(
-                                    user_providers::columns::user_id.is_null(),
-                                ),
-                        )
-                        .set(
-                            user_providers::columns::user_id
-                                .eq(Some(created_user.id)),
-                        )
-                        .execute(self.conn)?;
+                    // We should update exactly 1 row. If not, then either
+                    // the referenced user_provider row is already linked to
+                    // a user, or it doesn't exist. In either case, just
+                    // return a NotFound error.
+                    let updated_rows = diesel::update(
+                        user_providers::table
+                            .find(user_provider_id)
+                            .filter(user_providers::columns::user_id.is_null()),
+                    )
+                    .set(
+                        user_providers::columns::user_id
+                            .eq(Some(created_user.id)),
+                    )
+                    .execute(conn)?;
 
-                        if updated_rows == 0 {
-                            Err(ResponseError::NotFound)
-                        } else {
-                            Ok(created_user)
-                        }
-                    })
-                    .map_err(ResponseError::from)
+                    if updated_rows == 0 {
+                        Err(ResponseError::NotFound)
+                    } else {
+                        Ok(created_user)
+                    }
+                })
+                .map_err(ResponseError::from)
             }
             // Get up on outta here
             None => Err(ResponseError::Unauthenticated),

--- a/api/tests/test_copy_user_program.rs
+++ b/api/tests/test_copy_user_program.rs
@@ -1,12 +1,12 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{
     Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
 };
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
@@ -34,9 +34,9 @@ static QUERY: &str = r#"
 /// Successful copy
 #[test]
 fn test_copy_user_program_success() {
-    let mut runner = QueryRunner::new();
-    let user = runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     // Initialize data
     let program_spec_id = NewProgramSpec {
@@ -59,6 +59,7 @@ fn test_copy_user_program_success() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -91,8 +92,9 @@ fn test_copy_user_program_success() {
 /// Trying to copy a user_program that doesn't exist should return null.
 #[test]
 fn test_copy_user_program_invalid_id() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let runner = QueryRunner::new(context_builder);
 
     assert_eq!(
         runner.query(
@@ -115,8 +117,8 @@ fn test_copy_user_program_invalid_id() {
 /// Copying while not logged in returns an error.
 #[test]
 fn test_copy_user_program_not_logged_in() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     // Initialize data
     let user = NewUser { username: "user1" }.create(conn);
@@ -140,6 +142,7 @@ fn test_copy_user_program_not_logged_in() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -161,9 +164,9 @@ fn test_copy_user_program_not_logged_in() {
 /// You can't copy user_programs that don't belong to you.
 #[test]
 fn test_copy_user_program_wrong_owner() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     // Initialize data
     let other_user = NewUser { username: "user2" }.create(conn);
@@ -187,6 +190,7 @@ fn test_copy_user_program_wrong_owner() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,

--- a/api/tests/test_create_hardware_spec.rs
+++ b/api/tests/test_create_hardware_spec.rs
@@ -1,10 +1,10 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewHardwareSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
@@ -37,9 +37,9 @@ static QUERY: &str = r#"
 /// Test the standard success state of createHardwareSpec
 #[test]
 fn test_create_hardware_spec_success() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     // We'll test collisions against this
     NewHardwareSpec {
@@ -48,6 +48,7 @@ fn test_create_hardware_spec_success() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -80,9 +81,9 @@ fn test_create_hardware_spec_success() {
 /// [ERROR] Test createHardwareSpec when you try to use a pre-existing name
 #[test]
 fn test_create_hardware_spec_duplicate() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     // We'll test collisions against this
     NewHardwareSpec {
@@ -91,6 +92,7 @@ fn test_create_hardware_spec_duplicate() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -115,8 +117,9 @@ fn test_create_hardware_spec_duplicate() {
 /// [ERROR] Test createHardwareSpec when you pass invalid data
 #[test]
 fn test_create_hardware_spec_invalid_values() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let runner = QueryRunner::new(context_builder);
 
     assert_eq!(
         runner.query(
@@ -148,7 +151,8 @@ fn test_create_hardware_spec_invalid_values() {
 /// [ERROR] Test createHardwareSpec when you aren't logged in
 #[test]
 fn test_create_hardware_spec_not_logged_in() {
-    let runner = QueryRunner::new();
+    let context_builder = ContextBuilder::new();
+    let runner = QueryRunner::new(context_builder);
 
     assert_eq!(
         runner.query(

--- a/api/tests/test_create_program_spec.rs
+++ b/api/tests/test_create_program_spec.rs
@@ -1,10 +1,10 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
@@ -39,9 +39,10 @@ static QUERY: &str = r#"
 /// Create a program spec successfully
 #[test]
 fn test_create_program_spec_success() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -52,6 +53,7 @@ fn test_create_program_spec_success() {
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -85,8 +87,10 @@ fn test_create_program_spec_success() {
 /// [ERROR] References an invalid hardware spec
 #[test]
 fn test_create_program_spec_invalid_hw_spec() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let runner = QueryRunner::new(context_builder);
+
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
@@ -116,9 +120,9 @@ fn test_create_program_spec_invalid_hw_spec() {
 /// [ERROR] Program spec name is already taken
 #[test]
 fn test_create_program_spec_duplicate() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -137,6 +141,7 @@ fn test_create_program_spec_duplicate() {
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -162,9 +167,10 @@ fn test_create_program_spec_duplicate() {
 /// [ERROR] Values given are invalid
 #[test]
 fn test_create_program_spec_invalid_values() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -174,6 +180,7 @@ fn test_create_program_spec_invalid_values() {
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -203,8 +210,9 @@ fn test_create_program_spec_invalid_values() {
 /// [ERROR] You have to be logged in to do this
 #[test]
 fn test_create_program_spec_not_logged_in() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -214,6 +222,7 @@ fn test_create_program_spec_not_logged_in() {
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,

--- a/api/tests/test_query_auth_status.rs
+++ b/api/tests/test_query_auth_status.rs
@@ -1,9 +1,9 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewUser, NewUserProvider};
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
@@ -23,7 +23,8 @@ query AuthStatusQuery {
 /// Test when the user isn't authenticated at all
 #[test]
 fn test_field_auth_status_not_logged_in() {
-    let runner = QueryRunner::new();
+    let context_builder = ContextBuilder::new();
+    let runner = QueryRunner::new(context_builder);
 
     assert_eq!(
         runner.query(QUERY, hashmap! {}),
@@ -43,8 +44,9 @@ fn test_field_auth_status_not_logged_in() {
 /// Test when the user is logged in, but hasn't finished user setup yet
 #[test]
 fn test_field_auth_status_user_not_created() {
-    let mut runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
+
     let user_provider = NewUserProvider {
         sub: "asdf",
         provider_name: "provider",
@@ -52,8 +54,9 @@ fn test_field_auth_status_user_not_created() {
     }
     .create(conn);
     // user_provider is set, but not user
-    runner.set_user_provider(user_provider);
+    context_builder.set_user_provider(user_provider);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(QUERY, hashmap! {}),
         (
@@ -73,8 +76,9 @@ fn test_field_auth_status_user_not_created() {
 /// the most common auth status.
 #[test]
 fn test_field_auth_status_user_created() {
-    let mut runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
+
     let user = NewUser { username: "user1" }.create(conn);
     let user_provider = NewUserProvider {
         sub: "asdf",
@@ -83,8 +87,9 @@ fn test_field_auth_status_user_created() {
     }
     .create(conn);
     // user_provider is set, but not user
-    runner.set_user_provider(user_provider);
+    context_builder.set_user_provider(user_provider);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(QUERY, hashmap! {}),
         (

--- a/api/tests/test_query_hardware_spec.rs
+++ b/api/tests/test_query_hardware_spec.rs
@@ -1,17 +1,17 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
 #[test]
 fn test_field_hardware_spec() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -37,6 +37,7 @@ fn test_field_hardware_spec() {
         }
     "#;
 
+    let runner = QueryRunner::new(context_builder);
     // Known hardware spec
     assert_eq!(
         runner.query(
@@ -72,8 +73,8 @@ fn test_field_hardware_spec() {
 
 #[test]
 fn test_field_hardware_specs() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     NewHardwareSpec {
         name: "hw1",
@@ -110,6 +111,7 @@ fn test_field_hardware_specs() {
         }
     "#;
 
+    let runner = QueryRunner::new(context_builder);
     // Query all nodes
     assert_eq!(
         runner.query(query, hashmap! {}),
@@ -185,8 +187,8 @@ fn test_field_hardware_specs() {
 
 #[test]
 fn test_field_hardware_spec_program_spec() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -248,6 +250,7 @@ fn test_field_hardware_spec_program_spec() {
         }
     "#;
 
+    let runner = QueryRunner::new(context_builder);
     // Known program spec
     assert_eq!(
         runner.query(

--- a/api/tests/test_query_node.rs
+++ b/api/tests/test_query_node.rs
@@ -1,19 +1,19 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{
     self, Factory, NewHardwareSpec, NewProgramSpec, NewUser,
 };
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
 #[test]
 fn test_field_node() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     let user_id = NewUser { username: "user1" }.create(conn).id;
     let hardware_spec_id = NewHardwareSpec {
@@ -39,14 +39,15 @@ fn test_field_node() {
     .id;
 
     let query = r#"
-        query NodeQuery($nodeId: ID!) {
-            node(id: $nodeId) {
-                id
-            }
+    query NodeQuery($nodeId: ID!) {
+        node(id: $nodeId) {
+            id
         }
+    }
     "#;
 
     // Check a known UUID for each model type
+    let runner = QueryRunner::new(context_builder);
     for id in &[user_id, hardware_spec_id, program_spec_id, user_program_id] {
         assert_eq!(
             runner.query(

--- a/api/tests/test_query_program_spec.rs
+++ b/api/tests/test_query_program_spec.rs
@@ -1,17 +1,17 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{self, Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
 #[test]
 fn test_program_spec() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -44,6 +44,7 @@ fn test_program_spec() {
         }
     "#;
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             query,
@@ -73,9 +74,9 @@ fn test_program_spec() {
 
 #[test]
 fn test_program_spec_user_program() {
-    let mut runner = QueryRunner::new();
-    let user = runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -127,6 +128,7 @@ fn test_program_spec_user_program() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     let query = r#"
         query UserProgramQuery(
             $hwSlug: String!,
@@ -216,8 +218,8 @@ fn test_program_spec_user_program() {
 /// triggers an error.
 #[test]
 fn test_program_spec_user_program_not_logged_in() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     let hardware_spec_id = NewHardwareSpec {
         name: "hw1",
@@ -232,6 +234,7 @@ fn test_program_spec_user_program_not_logged_in() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     let query = r#"
         query UserProgramQuery(
             $hwSlug: String!,

--- a/api/tests/test_query_user.rs
+++ b/api/tests/test_query_user.rs
@@ -1,17 +1,17 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewUser};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
 #[test]
 fn test_field_user() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
 
     let user_id = NewUser { username: "user1" }.create(conn).id;
     let query = r#"
@@ -23,6 +23,7 @@ fn test_field_user() {
         }
     "#;
 
+    let runner = QueryRunner::new(context_builder);
     // Known user
     assert_eq!(
         runner.query(

--- a/api/tests/test_update_hardware_spec.rs
+++ b/api/tests/test_update_hardware_spec.rs
@@ -1,10 +1,10 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewHardwareSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
@@ -39,9 +39,9 @@ static QUERY: &str = r#"
 /// Modify just a subset of fields, make sure the others keep their values
 #[test]
 fn test_update_hardware_spec_partial_modification() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -49,6 +49,7 @@ fn test_update_hardware_spec_partial_modification() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -80,9 +81,9 @@ fn test_update_hardware_spec_partial_modification() {
 /// Modify all fields
 #[test]
 fn test_update_hardware_spec_full_modification() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -90,6 +91,7 @@ fn test_update_hardware_spec_full_modification() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -123,8 +125,9 @@ fn test_update_hardware_spec_full_modification() {
 /// Pass an invalid ID, get null back
 #[test]
 fn test_update_hardware_spec_invalid_id() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let runner = QueryRunner::new(context_builder);
 
     assert_eq!(
         runner.query(
@@ -148,9 +151,9 @@ fn test_update_hardware_spec_invalid_id() {
 /// [ERROR] Test that passing no modifications is an error
 #[test]
 fn test_update_hardware_spec_empty_modification() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -158,6 +161,7 @@ fn test_update_hardware_spec_empty_modification() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -179,9 +183,9 @@ fn test_update_hardware_spec_empty_modification() {
 /// [ERROR] Test that using a duplicate name returns an error
 #[test]
 fn test_update_hardware_spec_duplicate() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     // We'll test collisions against this
     NewHardwareSpec {
@@ -195,6 +199,7 @@ fn test_update_hardware_spec_duplicate() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -217,9 +222,9 @@ fn test_update_hardware_spec_duplicate() {
 /// [ERROR] Test that passing invalid values gives an error
 #[test]
 fn test_update_hardware_spec_invalid_values() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
@@ -227,6 +232,7 @@ fn test_update_hardware_spec_invalid_values() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -258,14 +264,16 @@ fn test_update_hardware_spec_invalid_values() {
 /// [ERROR] Test createHardwareSpec when you aren't logged in
 #[test]
 fn test_update_hardware_spec_not_logged_in() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 2",
         ..Default::default()
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,

--- a/api/tests/test_update_program_spec.rs
+++ b/api/tests/test_update_program_spec.rs
@@ -1,10 +1,10 @@
 #![deny(clippy::all)]
 
+use crate::utils::{ContextBuilder, QueryRunner};
 use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec};
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
-use utils::QueryRunner;
 
 mod utils;
 
@@ -39,9 +39,9 @@ static QUERY: &str = r#"
 /// Partial modification, make sure unmodified fields keep their old value
 #[test]
 fn test_update_program_spec_partial_modification() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -56,6 +56,7 @@ fn test_update_program_spec_partial_modification() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -87,9 +88,9 @@ fn test_update_program_spec_partial_modification() {
 /// Modify all fields
 #[test]
 fn test_update_program_spec_full_modification() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -107,6 +108,7 @@ fn test_update_program_spec_full_modification() {
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -140,8 +142,9 @@ fn test_update_program_spec_full_modification() {
 /// Pass an invalid ID, get null back
 #[test]
 fn test_update_program_spec_invalid_id() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let runner = QueryRunner::new(context_builder);
 
     assert_eq!(
         runner.query(
@@ -164,9 +167,9 @@ fn test_update_program_spec_invalid_id() {
 
 #[test]
 fn test_update_program_spec_empty_modification() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -188,6 +191,7 @@ fn test_update_program_spec_empty_modification() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -208,9 +212,9 @@ fn test_update_program_spec_empty_modification() {
 
 #[test]
 fn test_update_program_spec_duplicate() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -232,6 +236,7 @@ fn test_update_program_spec_duplicate() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -253,9 +258,9 @@ fn test_update_program_spec_duplicate() {
 
 #[test]
 fn test_update_program_spec_invalid_values() {
-    let mut runner = QueryRunner::new();
-    runner.log_in();
-    let conn = runner.db_conn();
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in();
+    let conn = context_builder.db_conn();
 
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
@@ -269,6 +274,7 @@ fn test_update_program_spec_invalid_values() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,
@@ -294,8 +300,9 @@ fn test_update_program_spec_invalid_values() {
 /// [ERROR] You have to be logged in to do this
 #[test]
 fn test_update_program_spec_not_logged_in() {
-    let runner = QueryRunner::new();
-    let conn = runner.db_conn();
+    let context_builder = ContextBuilder::new();
+    let conn = context_builder.db_conn();
+
     let hw_spec = NewHardwareSpec {
         name: "HW 1",
         ..Default::default()
@@ -308,6 +315,7 @@ fn test_update_program_spec_not_logged_in() {
     }
     .create(conn);
 
+    let runner = QueryRunner::new(context_builder);
     assert_eq!(
         runner.query(
             QUERY,


### PR DESCRIPTION
I reworked some of the request context stuff. Moved it into its own file cause the logic is getting bigger. I also reworked some of the test stuff to make user login easier. Gonna need this for my permissions PR. All the API functionality should be the same after this.