### PR TITLE
Disable TLS v1.0 and v1.1

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,7 +18,7 @@ http {
 
     ssl_certificate     /app/certs/${GDLK_HOSTNAME}/fullchain.pem;
     ssl_certificate_key /app/certs/${GDLK_HOSTNAME}/privkey.pem;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         HIGH:!aNULL:!MD5;
     ssl_session_cache   shared:SSL:10m;
     ssl_session_timeout 10m;


### PR DESCRIPTION
TLS 1.0 and 1.1. are insecure and deprecated. 1.3 is the new shit. I just made this exact change on my personal site and it worked so I didn't bother testing here. Worst case scenario, everything crashes and burns (f).