### PR TITLE
Add compile-time stat tracking on programs

### DIFF
--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -199,6 +199,7 @@ pub mod source {
 /// All types unique to the compiled AST live here.
 pub mod compiled {
     use super::*;
+    use crate::ProgramStats;
 
     /// An executable instruction. These are the instructions that machines
     /// actually execute.
@@ -220,6 +221,7 @@ pub mod compiled {
     #[derive(Clone, Debug, PartialEq)]
     pub struct Program<T> {
         pub instructions: Vec<Node<Instruction<T>, T>>,
+        pub stats: ProgramStats,
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -52,7 +52,7 @@ pub use machine::*;
 pub use models::*;
 pub use util::Span;
 
-use ast::compiled::Program;
+use crate::ast::compiled;
 use error::{CompileError, WithSource};
 use std::fmt::Debug;
 
@@ -77,7 +77,8 @@ impl Compiler<()> {
     pub fn compile(
         source: String,
         hardware_spec: HardwareSpec,
-    ) -> Result<Compiler<Program<Span>>, WithSource<CompileError>> {
+    ) -> Result<Compiler<compiled::Program<Span>>, WithSource<CompileError>>
+    {
         Ok(Self {
             source,
             hardware_spec,
@@ -93,9 +94,9 @@ impl Compiler<()> {
     }
 }
 
-impl Compiler<Program<Span>> {
+impl Compiler<compiled::Program<Span>> {
     /// Returns the AST for the compiled program.
-    pub fn program(&self) -> &Program<Span> {
+    pub fn program(&self) -> &compiled::Program<Span> {
         &self.ast
     }
 

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -361,6 +361,11 @@ impl Machine {
         }
     }
 
+    /// Get a reference to the program being executed.
+    pub fn program(&self) -> &Program<Span> {
+        &self.program
+    }
+
     /// Get the current input buffer.
     pub fn input(&self) -> &[LangValue] {
         self.input.as_slice()

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -6,6 +6,7 @@
 use crate::ast::wasm::StringArray;
 use crate::ast::{LangValue, RegisterRef, StackRef};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::{prelude::*, JsCast};
 
@@ -174,6 +175,21 @@ impl Default for ProgramSpec {
             expected_output: vec![],
         }
     }
+}
+
+/// A record of **static** statistics that can be gathered about a program. We
+/// collect these statistics at compile time. They can be used to rank programs,
+/// e.g. finding the minimal number of references need to solve a problem.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProgramStats {
+    /// All the registers that are referenced at least once by the program.
+    /// This will include registers even if they don't get used at runtime,
+    /// as we can't know at compile time which instructions will execute.
+    pub referenced_registers: HashSet<RegisterRef>,
+    /// All the stacks that are referenced at least once by the program.
+    /// This will include stacks even if they don't get used at runtime,
+    /// as we can't know at compile time which instructions will execute.
+    pub referenced_stacks: HashSet<StackRef>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Now we can track which registers and stacks a program references, at compile time. This will be used in the leaderboards pretty soon. Tracking this stuff requires traversing the entire AST. Instead of writing all new logic to do that traversal, I integrated it into the validation logic, which was easy enough. If we find ourselves including more non-validation logic into the validation step though, we may want to write a generic routine for traversing the AST, just to maintain separation of concerns. That way we can traverse the AST as many times as we want without having to keep re-writing the traversal logic.