### PR TITLE
Improve error handling in API, replace failure with anyhow/thiserror in core+cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,10 +861,10 @@ dependencies = [
 name = "gdlk"
 version = "0.1.0"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom_locate 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -896,7 +901,7 @@ dependencies = [
 name = "gdlk_cli"
 version = "0.1.0"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdlk 0.1.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2305,6 +2310,7 @@ dependencies = [
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-GDLK is a programming language, as well as a game based on solving puzzles with the language. There is no usable product _yet_, but it's coming soon™!
+GDLK is a programming language, as well as a game based on solving puzzles with the language. We have a basic playable version available at [gdlk.lucaspickering.me](https://gdlk.lucaspickering.me). Feedback is appreciated!
 
 ### What does GDLK stand for?
 
@@ -101,6 +101,7 @@ DEBUG=1 cargo make test
 We use nightly Rust. Here's a list of reasons why. If this list every gets empty, we should switch to stable.
 
 - Rust features
+  - [backtrace](https://github.com/rust-lang/rust/issues/53487)
   - [or_patterns](https://github.com/rust-lang/rust/issues/54883)
 - Rustfmt
   - [merge_imports](https://github.com/rust-lang/rustfmt/issues/3362)

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -7,19 +7,19 @@ use actix_web::{
 };
 use diesel::result::DatabaseErrorKind;
 use juniper::{DefaultScalarValue, FieldError, IntoFieldError};
-use log::error;
+use log::{error, log, Level};
 use openidconnect::{core::CoreErrorResponseType, StandardErrorResponse};
-use std::{array::TryFromSliceError, fmt::Debug};
+use std::{
+    array::TryFromSliceError, backtrace::Backtrace, error::Error, fmt::Debug,
+};
 use thiserror::Error;
 use validator::{ValidationError, ValidationErrors, ValidationErrorsKind};
 
 pub type ResponseResult<T> = Result<T, ResponseError>;
 
-/// An error that can occur while handling an HTTP request. These errors should
-/// all at least somewhat meaningful to the user.
+/// TODO
 #[derive(Debug, Error)]
-pub enum ResponseError {
-    // ===== Client errors =====
+pub enum ClientError {
     /// User tried to tried to reference a non-existent resource. Be careful
     /// with this! This should NOT be to respond to queries where the missing
     /// resource was directly queried. E.g. if querying hardware specs by slug,
@@ -29,25 +29,39 @@ pub enum ResponseError {
     /// row and specifying a FK to a related row. If that FK is invalid, that
     /// would be a good time to return this variant.
     #[error("Not found")]
-    NotFound,
+    NotFound {
+        /// The diesel error that triggered this, used just for debugging.
+        /// Should be provided whenever possible.
+        source: Option<diesel::result::Error>,
+    },
 
     /// User tried to use some unique identifier that already exists. This
     /// could occur during a create, rename, etc.
     #[error("This resource already exists")]
-    AlreadyExists,
+    AlreadyExists {
+        /// The diesel error that triggered this, used just for debugging
+        source: diesel::result::Error,
+    },
 
     /// User tried to perform an update mutation, but didn't given any values
     /// to change.
     #[error("No fields were given to update")]
-    NoUpdate,
+    NoUpdate {
+        /// The diesel error that triggered this, used just for debugging
+        source: diesel::result::Error,
+    },
 
     /// Action cannot be performed because the user is not authenticated.
     #[error("Not logged in")]
     Unauthenticated,
 
-    /// User submitted invalid/incorrect credentials for auth
-    #[error("Invalid credentials")]
-    InvalidCredentials,
+    /// CSRF failure during auth
+    #[error("CSRF token was not provided or did not match the expected value")]
+    CsrfError,
+
+    /// Claims returned from the OpenID provider are invalid in some way
+    #[error("Claims verification failure: {0}")]
+    ClaimsVerificationError(#[from] openidconnect::ClaimsVerificationError),
 
     /// Wrapper for a serde_json error.
     #[error("Serialization/deserialization error: {}", 0)]
@@ -55,11 +69,11 @@ pub enum ResponseError {
 
     /// Wrapper for validator's error type
     #[error("Validator error: {}", 0)]
-    ValidationErrors(#[from] validator::ValidationErrors),
+    ValidationErrors(#[from] ValidationErrors),
 
     /// Wrapper for an OpenID token error, which can occur while validating a
     /// token submitted by a user.
-    #[error("{}", 0)]
+    #[error("{0}")]
     RequestTokenError(
         #[from]
         openidconnect::RequestTokenError<
@@ -67,25 +81,124 @@ pub enum ResponseError {
             StandardErrorResponse<CoreErrorResponseType>,
         >,
     ),
+}
 
-    // ===== Server Errors =====
+/// TODO
+#[derive(Debug, Error)]
+pub enum ServerError {
     /// Wrapper for R2D2's error type
-    #[error("Database error: {}", 0)]
+    #[error("Database error: {0}")]
     R2d2Error(#[from] r2d2::Error),
 
     /// Wrapper for Diesel's error type
-    #[error("Database error: {}", 0)]
+    #[error("Database error: {0}")]
     DieselError(#[from] diesel::result::Error),
+
+    /// When we do token exchange with an OpenID provider, we always expect to
+    /// get an `id_token` field back in the response. If we don't for some
+    /// reason (either we fucked up or the provider fucked up), use this error.
+    #[error("id_token field was not in OpenID response")]
+    MissingIdToken,
+}
+
+/// An error that can occur while handling an HTTP request. These errors should
+/// all at least somewhat meaningful to the user.
+#[derive(Debug, Error)]
+pub enum ResponseError {
+    #[error("{source}")]
+    Client {
+        source: ClientError,
+        backtrace: Backtrace,
+    },
+    #[error("{source}")]
+    Server {
+        source: ServerError,
+        backtrace: Backtrace,
+    },
+}
+
+impl ResponseError {
+    /// TODO
+    pub fn from_client_error<T: Into<ClientError>>(source: T) -> Self {
+        let e: ClientError = source.into();
+        e.into()
+    }
+
+    /// TODO
+    pub fn from_server_error<T: Into<ServerError>>(source: T) -> Self {
+        let e: ServerError = source.into();
+        e.into()
+    }
+
+    /// Log this error to the server output. Server errors use the `error` log
+    /// level, while client errors use `debug`.
+    pub fn log(&self) {
+        let log_level = match self {
+            ResponseError::Client { .. } => Level::Debug,
+            ResponseError::Server { .. } => Level::Error,
+        };
+
+        // Print both the Display and the Debug version, for completeness
+        log!(
+            log_level,
+            "Response Error: {}\n{:#?}\n{}",
+            self,
+            // ResponseError's type enforces that source and backtrace are
+            // always present
+            self.source().unwrap(),
+            self.backtrace().expect("No backtrace available :(")
+        );
+    }
+}
+
+// These two implementations are the only way that `ResponseError`s should be
+// created, to ensure they get the backtrace.
+impl From<ClientError> for ResponseError {
+    fn from(source: ClientError) -> Self {
+        Self::Client {
+            source,
+            backtrace: Backtrace::capture(),
+        }
+    }
+}
+impl From<ServerError> for ResponseError {
+    fn from(source: ServerError) -> Self {
+        Self::Server {
+            source,
+            backtrace: Backtrace::capture(),
+        }
+    }
+}
+
+// Implementations for some COMMON and UNAMBIGUOUS error conversions. If an
+// error type could concievably be both a client and a server error, then we
+// shouldn't implement these conversions, to prevent accidental mis-conversions.
+impl From<ValidationErrors> for ResponseError {
+    fn from(source: ValidationErrors) -> Self {
+        let e: ClientError = source.into();
+        e.into()
+    }
+}
+impl From<diesel::result::Error> for ResponseError {
+    fn from(source: diesel::result::Error) -> Self {
+        let e: ServerError = source.into();
+        e.into()
+    }
 }
 
 // Juniper error
 impl IntoFieldError for ResponseError {
     fn into_field_error(self) -> FieldError {
+        // Temporary method to log errors
+        // TODO https://github.com/LucasPickering/gdlk/issues/125
+        self.log();
+
         match self {
-            ResponseError::ValidationErrors(errors) => {
-                validation_to_field_error(errors)
-            }
-            error => FieldError::new(error.to_string(), juniper::Value::Null),
+            ResponseError::Client {
+                source: ClientError::ValidationErrors(errors),
+                ..
+            } => validation_to_field_error(errors),
+            _ => FieldError::new(self.to_string(), juniper::Value::Null),
         }
     }
 }
@@ -93,13 +206,36 @@ impl IntoFieldError for ResponseError {
 // Actix error
 impl actix_web::ResponseError for ResponseError {
     fn error_response(&self) -> HttpResponse {
+        // Temporary method to log errors
+        // TODO https://github.com/LucasPickering/gdlk/issues/125
+        self.log();
+
         match self {
-            // 401
-            Self::InvalidCredentials => HttpResponse::Unauthorized().into(),
-            // 409
-            Self::AlreadyExists => HttpResponse::Conflict().into(),
-            // Everything else becomes a 500
-            _ => HttpResponse::InternalServerError().into(),
+            Self::Client { source, .. } => {
+                match source {
+                    // 401
+                    ClientError::CsrfError
+                    | ClientError::ClaimsVerificationError(_) => {
+                        HttpResponse::Unauthorized().into()
+                    }
+                    // 409
+                    ClientError::AlreadyExists { .. } => {
+                        HttpResponse::Conflict().into()
+                    }
+                    // Everything else becomes a 400
+                    _ => HttpResponse::BadRequest().into(),
+                }
+            }
+            Self::Server { source, .. } => {
+                match source {
+                    // 503
+                    ServerError::R2d2Error(_) => {
+                        HttpResponse::ServiceUnavailable().into()
+                    }
+                    // Everything else becomes a 500
+                    _ => HttpResponse::InternalServerError().into(),
+                }
+            }
         }
     }
 }
@@ -149,12 +285,12 @@ fn validation_to_field_error(errors: ValidationErrors) -> FieldError {
 pub enum ActixClientError {
     /// A wrapper for [actix_web::client::SendRequestError]. This type doesn't
     /// implement `Error` so we have to convert it to a string first.
-    #[error("{}", 0)]
+    #[error("{0}")]
     SendRequestError(String),
 
     /// A wrapper for [actix_web::client::PayloadError]. This type doesn't
     /// implement `Error` so we have to convert it to a string first.
-    #[error("{}", 0)]
+    #[error("{0}")]
     PayloadError(String),
 }
 
@@ -174,12 +310,12 @@ impl From<PayloadError> for ActixClientError {
 #[derive(Debug, Error)]
 pub enum IntDecodeError {
     /// An error that occurs if a given string isn't valid base64.
-    #[error("{}", 0)]
+    #[error("{0}")]
     Base64Error(#[from] base64::DecodeError),
 
     /// An error that occurs if the string was decoded into bytes, but the
     /// bytes can't be properly fit into the desired int size (e.g. 4 bytes).
-    #[error("{}", 0)]
+    #[error("{0}")]
     TryFromSliceError(#[from] TryFromSliceError),
 }
 
@@ -217,40 +353,41 @@ impl DbErrorConverter {
         self,
         result: Result<T, diesel::result::Error>,
     ) -> Result<T, ResponseError> {
-        match result {
-            Ok(val) => Ok(val),
+        result.map_err(|error| {
+            match error {
+                // FK is invalid
+                diesel::result::Error::DatabaseError(
+                    DatabaseErrorKind::ForeignKeyViolation,
+                    _,
+                ) if self.fk_violation_to_not_found => ClientError::NotFound {
+                    source: Some(error),
+                }
+                .into(),
 
-            // FK is invalid
-            Err(diesel::result::Error::DatabaseError(
-                DatabaseErrorKind::ForeignKeyViolation,
-                _,
-            )) if self.fk_violation_to_not_found => {
-                Err(ResponseError::NotFound)
+                // Object already exists
+                diesel::result::Error::DatabaseError(
+                    DatabaseErrorKind::UniqueViolation,
+                    _,
+                ) if self.unique_violation_to_exists => {
+                    ClientError::AlreadyExists { source: error }.into()
+                }
+
+                // User didn't specify any fields to update
+                diesel::result::Error::QueryBuilderError(ref msg)
+                    if self.query_builder_to_no_update
+                    // Currently this is the only way a QueryBuilderError can occur,
+                    // but diesel could change that so keep this check to be safe
+                        && msg.to_string().contains("no changes to save") =>
+                {
+                    ClientError::NoUpdate { source: error }.into()
+                }
+
+                // Add more conversions here
+
+                // Fall back to the built in converion from ResponseError
+                _ => error.into(),
             }
-
-            // Object already exists
-            Err(diesel::result::Error::DatabaseError(
-                DatabaseErrorKind::UniqueViolation,
-                _,
-            )) if self.unique_violation_to_exists => {
-                Err(ResponseError::AlreadyExists)
-            }
-
-            // User didn't specify any fields to update
-            Err(diesel::result::Error::QueryBuilderError(msg))
-                if self.query_builder_to_no_update
-                // Currently this is the only way a QueryBuilderError can occur,
-                // but diesel could change that so keep this check to be safe
-                    && msg.to_string().contains("no changes to save") =>
-            {
-                Err(ResponseError::NoUpdate)
-            }
-
-            // Add more conversions here
-
-            // Fall back to the built in converion from ResponseError
-            Err(err) => Err(err.into()),
-        }
+        })
     }
 }
 
@@ -349,15 +486,14 @@ mod tests {
                 .convert::<()>(Err(make_fk_violation_error()))
                 .unwrap_err()
                 .to_string(),
-            ResponseError::DieselError(make_fk_violation_error()).to_string()
+            ServerError::DieselError(make_fk_violation_error()).to_string()
         );
         assert_eq!(
             converter
                 .convert::<()>(Err(make_unique_violation_error()))
                 .unwrap_err()
                 .to_string(),
-            ResponseError::DieselError(make_unique_violation_error())
-                .to_string()
+            ServerError::DieselError(make_unique_violation_error()).to_string()
         );
     }
 
@@ -374,7 +510,7 @@ mod tests {
             )))
             .unwrap_err()
             .to_string(),
-            ResponseError::NotFound.to_string()
+            "Not found"
         );
     }
 
@@ -391,7 +527,7 @@ mod tests {
             )))
             .unwrap_err()
             .to_string(),
-            ResponseError::AlreadyExists.to_string()
+            "This resource already exists"
         );
     }
 
@@ -410,7 +546,7 @@ mod tests {
             )))
             .unwrap_err()
             .to_string(),
-            ResponseError::NoUpdate.to_string()
+            "No fields were given to update"
         );
     }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![feature(backtrace)]
 
 // Diesel hasn't fully moved to Rust 2018 yet so we need this
 #[macro_use]

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ResponseError, ResponseResult},
+    error::{ClientError, ResponseError, ResponseResult},
     models,
     schema::users,
     server::gql::{
@@ -96,7 +96,10 @@ impl AuthStatusFields for AuthStatus {
         match executor.context().user() {
             Ok(user) => Ok(Some(user.clone().into_model().into())),
             // User isn't authed or hasn't finished setup
-            Err(ResponseError::Unauthenticated) => Ok(None),
+            Err(ResponseError::Client {
+                source: ClientError::Unauthenticated,
+                ..
+            }) => Ok(None),
             // This shouldn't be possible
             Err(err) => Err(err),
         }

--- a/api/src/server/mod.rs
+++ b/api/src/server/mod.rs
@@ -37,7 +37,7 @@ async fn route_graphql(
     // Auth cookie holds a user provider ID - if populated, parse it
     let user_provider_id = identity.identity().map(|id| util::parse_uuid(&id));
     let context = RequestContext::load_context(
-        pool.get().map_err(ResponseError::from)?,
+        pool.get().map_err(ResponseError::from_server_error)?,
         user_provider_id,
     )?;
     let response = web::block(move || {

--- a/api/src/views/user.rs
+++ b/api/src/views/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{DbErrorConverter, ResponseError, ResponseResult},
+    error::{ClientError, DbErrorConverter, ResponseError, ResponseResult},
     models,
     schema::{user_providers, users},
     views::{RequestContext, UserContext, View},
@@ -60,15 +60,14 @@ impl<'a> View for InitializeUserView<'a> {
                     .execute(conn)?;
 
                     if updated_rows == 0 {
-                        Err(ResponseError::NotFound)
+                        Err(ClientError::NotFound { source: None }.into())
                     } else {
                         Ok(created_user)
                     }
                 })
-                .map_err(ResponseError::from)
             }
             // Get up on outta here
-            None => Err(ResponseError::Unauthenticated),
+            None => Err(ClientError::Unauthenticated.into()),
         }
     }
 }

--- a/api/src/views/user_program.rs
+++ b/api/src/views/user_program.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{DbErrorConverter, ResponseError, ResponseResult},
+    error::{DbErrorConverter, ResponseResult},
     models,
     schema::user_programs,
     views::View,
@@ -140,13 +140,12 @@ impl<'a> View for DeleteUserProgramView<'a> {
 
     fn execute(&self) -> ResponseResult<Self::Output> {
         // User has to own the program to delete it
-        diesel::delete(models::UserProgram::find_for_user(
+        Ok(diesel::delete(models::UserProgram::find_for_user(
             self.id,
             self.user_id,
         ))
         .returning(user_programs::columns::id)
         .get_result(self.conn)
-        .optional()
-        .map_err(ResponseError::from)
+        .optional()?)
     }
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 description = "Small CLI utility for compiling and running GDLK programs"
 
 [dependencies]
-failure = "0.1"
+anyhow = "1.0"
 gdlk = { path = "../core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,10 +14,10 @@ description = "Implementation of the GDLK language."
 wasm = ["wasm-bindgen"]
 
 [dependencies]
-failure = "0.1"
 nom = "5.1.1"
 nom_locate = "2.0"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 
 [dependencies.wasm-bindgen]
 version = "0.2.58"


### PR DESCRIPTION
In the last PR I replaced `failure` with `thiserror`. `failure` is deprecated, and there's two crates now that replace it: `thiserror` and `anyhow`. `thiserror` is used for creating custom error types (which is what we do in the API and core crates), and `anyhow` is useful for making a generic "idgaf what the error type is" error, similar to `Fallible`. We're just using `anyhow` in the CLI crate.

As part of this I also split the `ResponseError` type into two separate sub-types: Client errors (basically 4xx errors) and Server errors (basically 5xx). When you convert an error into `ResponseError`, you'll have to specify whether you want it to be a client or a server error. I think this is good cause it makes it harder to misclassify stuff.

I also made the errors carry a backtrace, so now when we have server errors in production, it should log a backtrace with it for #debugging.