### PR TITLE
Add models and DB tables for permissions

### DIFF
--- a/api/migrations/2020-07-25-172603_add_permission_models/down.sql
+++ b/api/migrations/2020-07-25-172603_add_permission_models/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE role_permissions;
+DROP TABLE permissions;
+DROP TABLE user_roles;
+DROP TABLE roles;

--- a/api/migrations/2020-07-25-172603_add_permission_models/up.sql
+++ b/api/migrations/2020-07-25-172603_add_permission_models/up.sql
@@ -1,0 +1,44 @@
+CREATE TABLE roles (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    slug VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(slug) > 0),
+    name VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(name) > 0),
+    is_admin BOOLEAN NOT NULL DEFAULT FALSE -- admins implicitly get all permissions
+);
+-- autogenerate slug from name
+CREATE TRIGGER "t_roles_insert" BEFORE INSERT ON "roles"
+FOR EACH ROW EXECUTE PROCEDURE set_slug_from_name();
+
+CREATE TABLE user_roles (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    role_id UUID NOT NULL REFERENCES roles(id),
+    UNIQUE(user_id, role_id)
+);
+
+CREATE TABLE permissions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    slug VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(slug) > 0),
+    name VARCHAR(50) NOT NULL UNIQUE CHECK (char_length(name) > 0)
+);
+-- autogenerate slug from name
+CREATE TRIGGER "t_permissions_insert" BEFORE INSERT ON "permissions"
+FOR EACH ROW EXECUTE PROCEDURE set_slug_from_name();
+
+CREATE TABLE role_permissions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    role_id UUID NOT NULL REFERENCES roles(id),
+    permission_id UUID NOT NULL REFERENCES permissions(id),
+    UNIQUE(role_id, permission_id)
+);
+
+INSERT INTO roles (name, is_admin) VALUES
+    ('Admin', TRUE),
+    ('Spec Creator', FALSE);
+INSERT INTO permissions (name) VALUES
+    ('Create Specs'),
+    ('Modify All Specs'),
+    ('Delete All Specs'),
+    ('View All User Programs');
+INSERT INTO role_permissions (role_id, permission_id)
+    SELECT roles.id, permissions.id FROM roles, permissions
+    WHERE roles.name = 'Spec Creator' and permissions.name = 'Create Specs';

--- a/api/seeds/seed.sql
+++ b/api/seeds/seed.sql
@@ -1,6 +1,15 @@
+-- Users/roles
 WITH user_row AS (
     INSERT INTO users (username) VALUES ('user1') RETURNING id
 ),
+user_role_row AS (
+    INSERT INTO user_roles (user_id, role_id)
+        SELECT user_row.id, roles.id
+        FROM user_row, roles WHERE roles.name = 'admin'
+        RETURNING id
+),
+
+-- Hw specs
 hw_spec_rows AS (
     INSERT INTO hardware_specs (name, num_registers, num_stacks, max_stack_length)
         VALUES ('K100', 1, 0, 0), ('K210', 2, 1, 10), ('K320', 3, 2, 32)

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -10,17 +10,25 @@
 //!   implement the [Factory] trait.
 
 mod hardware_spec;
+mod permission;
 mod program_spec;
+mod role;
+mod role_permission;
 mod user;
 mod user_program;
 mod user_provider;
+mod user_role;
 
 use diesel::PgConnection;
 pub use hardware_spec::*;
+pub use permission::*;
 pub use program_spec::*;
+pub use role::*;
+pub use role_permission::*;
 pub use user::*;
 pub use user_program::*;
 pub use user_provider::*;
+pub use user_role::*;
 
 /// A trait that makes it easy to generate a row for a particular type. This
 /// should only be used for tests.

--- a/api/src/models/permission.rs
+++ b/api/src/models/permission.rs
@@ -1,0 +1,125 @@
+use crate::{
+    error::{ResponseError, ServerError},
+    schema::permissions,
+};
+use diesel::{Identifiable, Queryable};
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// A mapping of all variants to the corresponding name used in the DB
+const NAME_MAPPING: &[(PermissionType, &str)] = &[
+    (PermissionType::CreateSpecs, "Create Specs"),
+    (PermissionType::ModifyAllSpecs, "Modify All Specs"),
+    (PermissionType::DeleteAllSpecs, "Delete All Specs"),
+    (
+        PermissionType::ViewAllUserPrograms,
+        "View All User Programs",
+    ),
+];
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum PermissionType {
+    /// User can create new hardware and program specs
+    CreateSpecs,
+
+    /// User can modify all existing hardware and program specs, regardless of
+    /// whether or not they are the owner.
+    ModifyAllSpecs,
+
+    /// User can delete all existing hardware and program specs, regardless of
+    /// whether or not they are the owner.
+    DeleteAllSpecs,
+
+    /// User can view all existing user programs, not just their own.
+    ViewAllUserPrograms,
+}
+
+impl PermissionType {
+    pub fn to_str(self) -> &'static str {
+        for (permission_type, name) in NAME_MAPPING {
+            if self == *permission_type {
+                return name;
+            }
+        }
+        panic!("Missing name for permission type: {:?}", self);
+    }
+}
+
+impl FromStr for PermissionType {
+    type Err = ResponseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        for (permission_type, name) in NAME_MAPPING {
+            if s == *name {
+                return Ok(*permission_type);
+            }
+        }
+
+        // Unknown value
+        Err(ServerError::InvalidDbValue {
+            column: Box::new(permissions::columns::name),
+            value: s.into(),
+        }
+        .into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
+#[table_name = "permissions"]
+pub struct Permission {
+    pub id: Uuid,
+    pub slug: String,
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util;
+    use diesel::{QueryDsl, RunQueryDsl};
+
+    /// Test that the list of permission types we define here in code matches
+    /// the list of types that exist in the DB. All permissions are created by
+    /// migrations, so we don't need to seed any data here.
+    #[test]
+    fn test_all_permission_types() {
+        let pool = util::init_test_db_conn_pool().unwrap();
+        let conn = &pool.get().unwrap();
+        let all_permissions: Vec<Permission> = permissions::table
+            .select(permissions::all_columns)
+            // sort so we can do stable comparisons later
+            .order_by(permissions::columns::name)
+            .get_results(conn)
+            .unwrap();
+
+        // Test that all names can be deserialized correctly
+        for permission in all_permissions.iter() {
+            if let Err(err) = permission.name.parse::<PermissionType>() {
+                panic!(
+                    "Unable to parse permission name: {}\n{}",
+                    permission.name, err
+                );
+            }
+        }
+
+        let queried_names: Vec<&str> = all_permissions
+            .iter()
+            .map(|permission| permission.name.as_str())
+            .collect();
+
+        // Test that all names can be serialized correctly
+        let mut serialized_names: Vec<&str> = NAME_MAPPING
+            .iter()
+            .map(|(permission_type, _)| permission_type.to_str())
+            .collect();
+        serialized_names.sort();
+
+        // Make sure the list of serialized names matches all the names we
+        // pulled from the DB. This makes sure we don't have any extraneous
+        // variants defined in code.
+        assert_eq!(
+            queried_names, serialized_names,
+            "Serialized permission types did not match names from the DB"
+        );
+    }
+}

--- a/api/src/models/role.rs
+++ b/api/src/models/role.rs
@@ -1,0 +1,116 @@
+use crate::{
+    error::{ResponseError, ResponseResult, ServerError},
+    schema::roles,
+};
+use diesel::{Identifiable, Queryable};
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// A mapping of all variants to the corresponding name used in the DB
+const NAME_MAPPING: &[(RoleType, &str)] = &[
+    (RoleType::Admin, "Admin"),
+    (RoleType::SpecCreator, "Spec Creator"),
+];
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum RoleType {
+    /// These users can perform any action.
+    Admin,
+
+    /// These users can create specs. Once we start attaching the creator to
+    /// each spec then we can allow these users to modify their own specs, but
+    /// for now they can only create them.
+    SpecCreator,
+}
+
+impl RoleType {
+    pub fn to_str(self) -> &'static str {
+        for (role_type, name) in NAME_MAPPING {
+            if self == *role_type {
+                return name;
+            }
+        }
+        panic!("Missing name for role type: {:?}", self);
+    }
+}
+
+impl FromStr for RoleType {
+    type Err = ResponseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        for (role_type, name) in NAME_MAPPING {
+            if s == *name {
+                return Ok(*role_type);
+            }
+        }
+
+        // Unknown value
+        Err(ServerError::InvalidDbValue {
+            column: Box::new(roles::columns::name),
+            value: s.into(),
+        }
+        .into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
+#[table_name = "roles"]
+pub struct Role {
+    pub id: Uuid,
+    pub slug: String,
+    pub name: String,
+    pub is_admin: bool,
+}
+
+impl Role {
+    pub fn role_type(&self) -> ResponseResult<RoleType> {
+        self.name.parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util;
+    use diesel::{QueryDsl, RunQueryDsl};
+
+    /// Test that the list of role types we define here in code matches
+    /// the list of types that exist in the DB. All roles are created by
+    /// migrations, so we don't need to seed any data here.
+    #[test]
+    fn test_all_role_types() {
+        let pool = util::init_test_db_conn_pool().unwrap();
+        let conn = &pool.get().unwrap();
+        let all_roles: Vec<Role> = roles::table
+            .select(roles::all_columns)
+            // sort so we can do stable comparisons later
+            .order_by(roles::columns::name)
+            .get_results(conn)
+            .unwrap();
+
+        // Test that all names can be deserialized correctly
+        for role in all_roles.iter() {
+            if let Err(err) = role.name.parse::<RoleType>() {
+                panic!("Unable to parse role name: {}\n{}", role.name, err);
+            }
+        }
+
+        let queried_names: Vec<&str> =
+            all_roles.iter().map(|role| role.name.as_str()).collect();
+
+        // Test that all names can be serialized correctly
+        let mut serialized_names: Vec<&str> = NAME_MAPPING
+            .iter()
+            .map(|(role_type, _)| role_type.to_str())
+            .collect();
+        serialized_names.sort();
+
+        // Make sure the list of serialized names matches all the names we
+        // pulled from the DB. This makes sure we don't have any extraneous
+        // variants defined in code.
+        assert_eq!(
+            queried_names, serialized_names,
+            "Serialized role types did not match names from the DB"
+        );
+    }
+}

--- a/api/src/models/role_permission.rs
+++ b/api/src/models/role_permission.rs
@@ -1,0 +1,11 @@
+use crate::schema::role_permissions;
+use diesel::{Identifiable, Queryable};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
+#[table_name = "role_permissions"]
+pub struct RolePermission {
+    pub id: Uuid,
+    pub role_id: Uuid,
+    pub permissions_id: Uuid,
+}

--- a/api/src/models/user.rs
+++ b/api/src/models/user.rs
@@ -1,14 +1,17 @@
-use crate::{models::Factory, schema::users};
+use crate::{
+    models::{Factory, RoleType},
+    schema::{roles, user_roles, users},
+};
 use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
-    sql_types::Text, Identifiable, Queryable,
+    sql_types, Identifiable, Queryable,
 };
 use uuid::Uuid;
 use validator::Validate;
 
 /// Expression to filter users by username
 pub type WithUsername<'a> =
-    dsl::Eq<users::columns::username, Bound<Text, &'a str>>;
+    dsl::Eq<users::columns::username, Bound<sql_types::Text, &'a str>>;
 
 #[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
 #[table_name = "users"]
@@ -28,6 +31,31 @@ impl User {
         username: &str,
     ) -> dsl::Filter<users::table, WithUsername<'_>> {
         users::table.filter(Self::with_username(username))
+    }
+
+    /// Build and execute query to grant each of the given roles to the user.
+    pub fn add_roles_x(
+        &self,
+        conn: &PgConnection,
+        roles: &[RoleType],
+    ) -> Result<usize, diesel::result::Error> {
+        // Map the role types to strings. No need to collect this iter, just
+        // pass it along directly
+        let role_names = roles.iter().map(|role_type| role_type.to_str());
+        diesel::insert_into(user_roles::table)
+            .values(
+                roles::table
+                    .select((
+                        self.id.into_sql::<sql_types::Uuid>(),
+                        roles::columns::id,
+                    ))
+                    .filter(roles::columns::name.eq_any(role_names)),
+            )
+            .into_columns((
+                user_roles::columns::user_id,
+                user_roles::columns::role_id,
+            ))
+            .execute(conn)
     }
 }
 

--- a/api/src/models/user_role.rs
+++ b/api/src/models/user_role.rs
@@ -1,0 +1,44 @@
+use crate::{models::Factory, schema::user_roles};
+use diesel::{
+    prelude::*, query_builder::InsertStatement, Identifiable, Queryable,
+};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
+#[table_name = "user_roles"]
+pub struct UserRole {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub role_id: Uuid,
+}
+
+#[derive(Debug, Default, PartialEq, Insertable)]
+#[table_name = "user_roles"]
+pub struct NewUserRole {
+    pub user_id: Uuid,
+    pub role_id: Uuid,
+}
+
+impl NewUserRole {
+    /// Insert this object into the `user_roles` DB table.
+    pub fn insert(
+        self,
+    ) -> InsertStatement<
+        user_roles::table,
+        <Self as Insertable<user_roles::table>>::Values,
+    > {
+        self.insert_into(user_roles::table)
+    }
+}
+
+// This trait is only needed for tests
+impl Factory for NewUserRole {
+    type ReturnType = UserRole;
+
+    fn create(self, conn: &PgConnection) -> UserRole {
+        self.insert()
+            .returning(user_roles::all_columns)
+            .get_result(conn)
+            .unwrap()
+    }
+}

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -10,6 +10,14 @@ table! {
 }
 
 table! {
+    permissions (id) {
+        id -> Uuid,
+        slug -> Varchar,
+        name -> Varchar,
+    }
+}
+
+table! {
     program_specs (id) {
         id -> Uuid,
         slug -> Varchar,
@@ -18,6 +26,23 @@ table! {
         hardware_spec_id -> Uuid,
         input -> Array<Int4>,
         expected_output -> Array<Int4>,
+    }
+}
+
+table! {
+    role_permissions (id) {
+        id -> Uuid,
+        role_id -> Uuid,
+        permission_id -> Uuid,
+    }
+}
+
+table! {
+    roles (id) {
+        id -> Uuid,
+        slug -> Varchar,
+        name -> Varchar,
+        is_admin -> Bool,
     }
 }
 
@@ -43,6 +68,14 @@ table! {
 }
 
 table! {
+    user_roles (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        role_id -> Uuid,
+    }
+}
+
+table! {
     users (id) {
         id -> Uuid,
         username -> Varchar,
@@ -50,14 +83,22 @@ table! {
 }
 
 joinable!(program_specs -> hardware_specs (hardware_spec_id));
+joinable!(role_permissions -> permissions (permission_id));
+joinable!(role_permissions -> roles (role_id));
 joinable!(user_programs -> program_specs (program_spec_id));
 joinable!(user_programs -> users (user_id));
 joinable!(user_providers -> users (user_id));
+joinable!(user_roles -> roles (role_id));
+joinable!(user_roles -> users (user_id));
 
 allow_tables_to_appear_in_same_query!(
     hardware_specs,
+    permissions,
     program_specs,
+    role_permissions,
+    roles,
     user_programs,
     user_providers,
+    user_roles,
     users,
 );


### PR DESCRIPTION
This is half of the previous PR, just the DB stuff and the diesel models. I scrapped the custom pg enum because I think it will be too annoying to maintain (apparently removing values from an enum is really annoying, which we may want to do). This also prevents having to do some annoying diesel stuff to Rust types for the custom enums, which I think will make it all easier to understand. There is a little bit of manual conversion we have to do now between strings and our `PermissionType` enum, but I don't think it's going to be any problem and I included tests to make sure the enums always stay up to date.