### PR TITLE
Use diesel_factories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +675,29 @@ dependencies = [
  "pq-sys 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "diesel-factories"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-factories-code-gen 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "diesel-factories-code-gen"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -881,6 +936,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-factories 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdlk 0.1.0",
  "juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1013,6 +1069,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "idna"
@@ -1518,6 +1579,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1528,6 +1597,14 @@ dependencies = [
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quote"
@@ -1802,6 +1879,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1825,6 +1907,16 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2039,6 +2131,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-width"
 version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2346,8 +2443,13 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum derive_more 0.99.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a806e96c59a76a5ba6e18735b6cf833344671e61e7863f2edb5c518ea2cac95c"
 "checksum diesel 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "33d7ca63eb2efea87a7f56a283acc49e2ce4b2bd54adf7465dc1d81fef13d8fc"
+"checksum diesel-factories 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1be529f4a6e6fdc57cde157478f30734106f070b58abbb91b3a461195a4866"
+"checksum diesel-factories-code-gen 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f71513283cf7d51795fe626155064eca48643f2f3e625bcbc960f19053f163d3"
 "checksum diesel_derives 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 "checksum digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
@@ -2383,6 +2485,7 @@ dependencies = [
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum if_chain 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
@@ -2441,8 +2544,10 @@ dependencies = [
 "checksum proc-macro-error-attr 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1497e40855348e4a8a40767d8e55174bce1e445a3ac9254ad44ad468ee0485af"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2477,9 +2582,11 @@ dependencies = [
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a1bcbed7d48956fcbb5d80c6b95aedb553513de0a1b451ea92679d999c010e98"
 "checksum structopt-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
+"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
@@ -2501,6 +2608,7 @@ dependencies = [
 "checksum unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -36,6 +36,7 @@ validator = "0.10.1"
 validator_derive = "0.10.1"
 
 [dev-dependencies]
+diesel-factories = "^1.0.1"
 maplit = "^1.0.0"
 
 [lib]

--- a/api/src/models/hardware_spec.rs
+++ b/api/src/models/hardware_spec.rs
@@ -1,4 +1,4 @@
-use crate::{models::Factory, schema::hardware_specs};
+use crate::schema::hardware_specs;
 use diesel::{
     prelude::*, query_builder::InsertStatement, Identifiable, Queryable,
 };
@@ -32,7 +32,7 @@ pub struct HardwareSpec {
 /// This can be constructed manually and inserted into the DB. These fields
 /// all correspond to [HardwareSpec](HardwareSpec), so look there for
 /// field-level documentation.
-#[derive(Debug, PartialEq, Insertable, Validate)]
+#[derive(Copy, Clone, Debug, Insertable, Validate)]
 #[table_name = "hardware_specs"]
 pub struct NewHardwareSpec<'a> {
     #[validate(length(min = 1))]
@@ -58,33 +58,8 @@ impl NewHardwareSpec<'_> {
         self.insert_into(hardware_specs::table)
     }
 }
-
-// This trait is only needed for tests
-impl Default for NewHardwareSpec<'_> {
-    fn default() -> Self {
-        Self {
-            name: "", // this is invalid, you'll have to override
-            num_registers: 1,
-            num_stacks: 0,
-            max_stack_length: 0,
-        }
-    }
-}
-
-// This trait is only needed for tests
-impl Factory for NewHardwareSpec<'_> {
-    type ReturnType = HardwareSpec;
-
-    fn create(self, conn: &PgConnection) -> HardwareSpec {
-        self.insert()
-            .returning(hardware_specs::all_columns)
-            .get_result(conn)
-            .unwrap()
-    }
-}
-
 /// A struct used to modify a row in the hardware_specs table.
-#[derive(Clone, Debug, PartialEq, Identifiable, AsChangeset, Validate)]
+#[derive(Copy, Clone, Debug, Identifiable, AsChangeset, Validate)]
 #[table_name = "hardware_specs"]
 pub struct ModifiedHardwareSpec<'a> {
     pub id: Uuid,

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -19,7 +19,6 @@ mod user_program;
 mod user_provider;
 mod user_role;
 
-use diesel::PgConnection;
 pub use hardware_spec::*;
 pub use permission::*;
 pub use program_spec::*;
@@ -29,13 +28,3 @@ pub use user::*;
 pub use user_program::*;
 pub use user_provider::*;
 pub use user_role::*;
-
-/// A trait that makes it easy to generate a row for a particular type. This
-/// should only be used for tests.
-pub trait Factory {
-    /// The type returned from an insert of this type.
-    type ReturnType;
-
-    /// Insert this object into the DB and return the full DB row.
-    fn create(self, conn: &PgConnection) -> Self::ReturnType;
-}

--- a/api/src/models/program_spec.rs
+++ b/api/src/models/program_spec.rs
@@ -1,7 +1,4 @@
-use crate::{
-    models::{Factory, HardwareSpec},
-    schema::program_specs,
-};
+use crate::{models::HardwareSpec, schema::program_specs};
 use diesel::{
     dsl, expression::bound::Bound, prelude::*, query_builder::InsertStatement,
     sql_types, Identifiable, Queryable,
@@ -55,7 +52,7 @@ impl ProgramSpec {
 /// This can be constructed manually and inserted into the DB. These fields
 /// all correspond to [ProgramSpec](ProgramSpec), so look there for
 /// field-level documentation.
-#[derive(Clone, Debug, Default, PartialEq, Insertable, Validate)]
+#[derive(Clone, Debug, Insertable, Validate)]
 #[table_name = "program_specs"]
 pub struct NewProgramSpec<'a> {
     pub hardware_spec_id: Uuid,
@@ -84,19 +81,7 @@ impl NewProgramSpec<'_> {
     }
 }
 
-// This trait is only needed for tests
-impl Factory for NewProgramSpec<'_> {
-    type ReturnType = ProgramSpec;
-
-    fn create(self, conn: &PgConnection) -> ProgramSpec {
-        self.insert()
-            .returning(program_specs::all_columns)
-            .get_result(conn)
-            .unwrap()
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Identifiable, AsChangeset, Validate)]
+#[derive(Clone, Debug, Identifiable, AsChangeset, Validate)]
 #[table_name = "program_specs"]
 pub struct ModifiedProgramSpec<'a> {
     pub id: Uuid,

--- a/api/src/models/user.rs
+++ b/api/src/models/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    models::{Factory, RoleType},
+    models::RoleType,
     schema::{roles, user_roles, users},
 };
 use diesel::{
@@ -59,7 +59,7 @@ impl User {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Insertable, Validate)]
+#[derive(Copy, Clone, Debug, Insertable, Validate)]
 #[table_name = "users"]
 pub struct NewUser<'a> {
     #[validate(length(min = 1, max = 20))]
@@ -73,17 +73,5 @@ impl NewUser<'_> {
     ) -> InsertStatement<users::table, <Self as Insertable<users::table>>::Values>
     {
         self.insert_into(users::table)
-    }
-}
-
-// This trait is only needed for tests
-impl Factory for NewUser<'_> {
-    type ReturnType = User;
-
-    fn create(self, conn: &PgConnection) -> User {
-        self.insert()
-            .returning(users::all_columns)
-            .get_result(conn)
-            .unwrap()
     }
 }

--- a/api/src/models/user_program.rs
+++ b/api/src/models/user_program.rs
@@ -1,5 +1,5 @@
 use crate::{
-    models::{Factory, ProgramSpec, User},
+    models::{ProgramSpec, User},
     schema::user_programs,
 };
 use chrono::{offset::Utc, DateTime};
@@ -64,7 +64,7 @@ impl UserProgram {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Insertable, Validate)]
+#[derive(Copy, Clone, Debug, Insertable, Validate)]
 #[table_name = "user_programs"]
 pub struct NewUserProgram<'a> {
     pub user_id: Uuid,
@@ -83,18 +83,6 @@ impl NewUserProgram<'_> {
         <Self as Insertable<user_programs::table>>::Values,
     > {
         self.insert_into(user_programs::table)
-    }
-}
-
-// This trait is only needed for tests
-impl Factory for NewUserProgram<'_> {
-    type ReturnType = UserProgram;
-
-    fn create(self, conn: &PgConnection) -> UserProgram {
-        self.insert()
-            .returning(user_programs::all_columns)
-            .get_result(conn)
-            .unwrap()
     }
 }
 

--- a/api/src/models/user_provider.rs
+++ b/api/src/models/user_provider.rs
@@ -1,7 +1,4 @@
-use crate::{
-    models::{Factory, User},
-    schema::user_providers,
-};
+use crate::{models::User, schema::user_providers};
 use diesel::{prelude::*, query_builder::InsertStatement, Queryable};
 use uuid::Uuid;
 
@@ -15,7 +12,7 @@ pub struct UserProvider {
     pub user_id: Option<Uuid>,
 }
 
-#[derive(Debug, Default, PartialEq, Insertable)]
+#[derive(Debug, Insertable)]
 #[table_name = "user_providers"]
 pub struct NewUserProvider<'a> {
     pub sub: &'a str,
@@ -32,17 +29,5 @@ impl NewUserProvider<'_> {
         <Self as Insertable<user_providers::table>>::Values,
     > {
         self.insert_into(user_providers::table)
-    }
-}
-
-// This trait is only needed for tests
-impl Factory for NewUserProvider<'_> {
-    type ReturnType = UserProvider;
-
-    fn create(self, conn: &PgConnection) -> UserProvider {
-        self.insert()
-            .returning(user_providers::all_columns)
-            .get_result(conn)
-            .unwrap()
     }
 }

--- a/api/src/models/user_role.rs
+++ b/api/src/models/user_role.rs
@@ -1,4 +1,4 @@
-use crate::{models::Factory, schema::user_roles};
+use crate::schema::user_roles;
 use diesel::{
     prelude::*, query_builder::InsertStatement, Identifiable, Queryable,
 };
@@ -12,7 +12,7 @@ pub struct UserRole {
     pub role_id: Uuid,
 }
 
-#[derive(Debug, Default, PartialEq, Insertable)]
+#[derive(Debug, PartialEq, Insertable)]
 #[table_name = "user_roles"]
 pub struct NewUserRole {
     pub user_id: Uuid,
@@ -28,17 +28,5 @@ impl NewUserRole {
         <Self as Insertable<user_roles::table>>::Values,
     > {
         self.insert_into(user_roles::table)
-    }
-}
-
-// This trait is only needed for tests
-impl Factory for NewUserRole {
-    type ReturnType = UserRole;
-
-    fn create(self, conn: &PgConnection) -> UserRole {
-        self.insert()
-            .returning(user_roles::all_columns)
-            .get_result(conn)
-            .unwrap()
     }
 }

--- a/api/src/views/context.rs
+++ b/api/src/views/context.rs
@@ -201,7 +201,7 @@ impl RequestContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{models::Factory, util};
+    use crate::util;
     use maplit::hashset;
 
     /// Test when the given user provider ID isn't in the DB
@@ -218,12 +218,15 @@ mod tests {
     fn test_user_load_context_uninitialized_user() {
         let pool = util::init_test_db_conn_pool().unwrap();
         let conn = &pool.get().unwrap();
-        let user_provider = models::NewUserProvider {
+        let user_provider: models::UserProvider = models::NewUserProvider {
             sub: "sub",
             provider_name: "provider",
             user_id: None,
         }
-        .create(conn);
+        .insert()
+        .returning(user_providers::all_columns)
+        .get_result(conn)
+        .unwrap();
 
         let ctx = UserContext::load_context(conn, user_provider.id);
         assert_eq!(
@@ -240,13 +243,20 @@ mod tests {
         let pool = util::init_test_db_conn_pool().unwrap();
         let conn = &pool.get().unwrap();
 
-        let user = models::NewUser { username: "user1" }.create(conn);
-        let user_provider = models::NewUserProvider {
+        let user: models::User = models::NewUser { username: "user1" }
+            .insert()
+            .returning(users::all_columns)
+            .get_result(conn)
+            .unwrap();
+        let user_provider: models::UserProvider = models::NewUserProvider {
             sub: "sub",
             provider_name: "provider",
             user_id: Some(user.id),
         }
-        .create(conn);
+        .insert()
+        .returning(user_providers::all_columns)
+        .get_result(conn)
+        .unwrap();
         user.add_roles_x(conn, &[models::RoleType::SpecCreator])
             .unwrap();
 
@@ -270,13 +280,20 @@ mod tests {
         let pool = util::init_test_db_conn_pool().unwrap();
         let conn = &pool.get().unwrap();
 
-        let user = models::NewUser { username: "user1" }.create(conn);
-        let user_provider = models::NewUserProvider {
+        let user: models::User = models::NewUser { username: "user1" }
+            .insert()
+            .returning(users::all_columns)
+            .get_result(conn)
+            .unwrap();
+        let user_provider: models::UserProvider = models::NewUserProvider {
             sub: "sub",
             provider_name: "provider",
             user_id: Some(user.id),
         }
-        .create(conn);
+        .insert()
+        .returning(user_providers::all_columns)
+        .get_result(conn)
+        .unwrap();
         user.add_roles_x(
             conn,
             &[models::RoleType::SpecCreator, models::RoleType::Admin],

--- a/api/tests/test_copy_user_program.rs
+++ b/api/tests/test_copy_user_program.rs
@@ -1,9 +1,7 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{
-    Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
-};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -39,25 +37,17 @@ fn test_copy_user_program_success() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -121,26 +111,18 @@ fn test_copy_user_program_not_logged_in() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let user = UserFactory::default().username("user1").insert(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -169,26 +151,18 @@ fn test_copy_user_program_wrong_owner() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let other_user = NewUser { username: "user2" }.create(conn);
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: other_user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let other_user = UserFactory::default().username("user2").insert(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&other_user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(

--- a/api/tests/test_create_hardware_spec.rs
+++ b/api/tests/test_create_hardware_spec.rs
@@ -1,7 +1,10 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{Factory, NewHardwareSpec, RoleType};
+use crate::utils::{
+    factories::HardwareSpecFactory, ContextBuilder, QueryRunner,
+};
+use diesel_factories::Factory;
+use gdlk_api::models::RoleType;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -42,11 +45,7 @@ fn test_create_hardware_spec_success() {
     let conn = context_builder.db_conn();
 
     // We'll test collisions against this
-    NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    HardwareSpecFactory::default().name("HW 1").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -86,11 +85,7 @@ fn test_create_hardware_spec_duplicate() {
     let conn = context_builder.db_conn();
 
     // We'll test collisions against this
-    NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    HardwareSpecFactory::default().name("HW 1").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(

--- a/api/tests/test_create_program_spec.rs
+++ b/api/tests/test_create_program_spec.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec, RoleType};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
+use gdlk_api::models::RoleType;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -43,11 +44,7 @@ fn test_create_program_spec_success() {
     context_builder.log_in(&[RoleType::SpecCreator]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
 
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
@@ -124,18 +121,12 @@ fn test_create_program_spec_duplicate() {
     context_builder.log_in(&[RoleType::SpecCreator]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
     // We'll test collisions against this
-    NewProgramSpec {
-        name: "program 1",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    ProgramSpecFactory::default()
+        .name("program 1")
+        .hardware_spec(&hw_spec)
+        .insert(conn);
 
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
@@ -171,11 +162,7 @@ fn test_create_program_spec_invalid_values() {
     context_builder.log_in(&[RoleType::SpecCreator]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
@@ -213,11 +200,7 @@ fn test_create_program_spec_not_logged_in() {
     let context_builder = ContextBuilder::new();
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );
@@ -252,11 +235,7 @@ fn test_create_program_spec_permission_denied() {
     context_builder.log_in(&[]); // Insufficient permissions
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
     );

--- a/api/tests/test_query_auth_status.rs
+++ b/api/tests/test_query_auth_status.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{Factory, NewUser, NewUserProvider};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
 use maplit::hashmap;
 use serde_json::json;
 
@@ -47,12 +47,7 @@ fn test_field_auth_status_user_not_created() {
     let mut context_builder = ContextBuilder::new();
     let conn = context_builder.db_conn();
 
-    let user_provider = NewUserProvider {
-        sub: "asdf",
-        provider_name: "provider",
-        user_id: None,
-    }
-    .create(conn);
+    let user_provider = UserProviderFactory::default().insert(conn);
     // user_provider is set, but not user
     context_builder.set_user_provider(user_provider);
 
@@ -79,13 +74,10 @@ fn test_field_auth_status_user_created() {
     let mut context_builder = ContextBuilder::new();
     let conn = context_builder.db_conn();
 
-    let user = NewUser { username: "user1" }.create(conn);
-    let user_provider = NewUserProvider {
-        sub: "asdf",
-        provider_name: "provider",
-        user_id: Some(user.id),
-    }
-    .create(conn);
+    let user = UserFactory::default().username("user1").insert(conn);
+    let user_provider = UserProviderFactory::default()
+        .user(Some(&user))
+        .insert(conn);
     // user_provider is set, but not user
     context_builder.set_user_provider(user_provider);
 

--- a/api/tests/test_query_user.rs
+++ b/api/tests/test_query_user.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{Factory, NewUser};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -13,7 +13,7 @@ fn test_field_user() {
     let context_builder = ContextBuilder::new();
     let conn = context_builder.db_conn();
 
-    let user_id = NewUser { username: "user1" }.create(conn).id;
+    let user = UserFactory::default().username("user1").insert(conn);
     let query = r#"
         query UserQuery($username: String!) {
             user(username: $username) {
@@ -33,7 +33,7 @@ fn test_field_user() {
         (
             json!({
                 "user": {
-                    "id": (user_id.to_string()),
+                    "id": (user.id.to_string()),
                     "username": "user1"
                 }
             }),

--- a/api/tests/test_update_hardware_spec.rs
+++ b/api/tests/test_update_hardware_spec.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{Factory, NewHardwareSpec, RoleType};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
+use gdlk_api::models::RoleType;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -43,11 +44,7 @@ fn test_update_hardware_spec_partial_modification() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -85,11 +82,7 @@ fn test_update_hardware_spec_full_modification() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -155,11 +148,7 @@ fn test_update_hardware_spec_empty_modification() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -188,16 +177,8 @@ fn test_update_hardware_spec_duplicate() {
     let conn = context_builder.db_conn();
 
     // We'll test collisions against this
-    NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -226,11 +207,7 @@ fn test_update_hardware_spec_invalid_values() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -267,11 +244,7 @@ fn test_update_hardware_spec_not_logged_in() {
     let context_builder = ContextBuilder::new();
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -303,11 +276,7 @@ fn test_update_hardware_spec_permission_denied() {
     context_builder.log_in(&[]); // Insufficient permissions
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 2",
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 2").insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(

--- a/api/tests/test_update_program_spec.rs
+++ b/api/tests/test_update_program_spec.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{Factory, NewHardwareSpec, NewProgramSpec, RoleType};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
+use gdlk_api::models::RoleType;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -43,18 +44,13 @@ fn test_update_program_spec_partial_modification() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hardware_spec =
+        HardwareSpecFactory::default().name("HW 1").insert(conn);
     // This is the one we'll be modifying
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -92,17 +88,12 @@ fn test_update_program_spec_full_modification() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let hardware_spec =
+        HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
 
     let values_list: InputValue = InputValue::list(
         [1, 2, 3].iter().map(|v| InputValue::scalar(*v)).collect(),
@@ -171,25 +162,18 @@ fn test_update_program_spec_empty_modification() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hardware_spec =
+        HardwareSpecFactory::default().name("HW 1").insert(conn);
     // We'll test collisions against this
-    NewProgramSpec {
-        name: "Program 1",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    ProgramSpecFactory::default()
+        .name("Program 1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
     // This is the one we'll actually be modifying
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -216,25 +200,18 @@ fn test_update_program_spec_duplicate() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
+    let hardware_spec =
+        HardwareSpecFactory::default().name("HW 1").insert(conn);
     // We'll test collisions against this
-    NewProgramSpec {
-        name: "Program 1",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    ProgramSpecFactory::default()
+        .name("Program 1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
     // This is the one we'll actually be modifying
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -262,17 +239,12 @@ fn test_update_program_spec_invalid_values() {
     context_builder.log_in(&[RoleType::Admin]);
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let hardware_spec =
+        HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -303,17 +275,12 @@ fn test_update_program_spec_not_logged_in() {
     let context_builder = ContextBuilder::new();
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let hardware_spec =
+        HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -342,17 +309,11 @@ fn test_update_program_spec_permission_denied() {
     context_builder.log_in(&[]); // Insufficient permissions
     let conn = context_builder.db_conn();
 
-    let hw_spec = NewHardwareSpec {
-        name: "HW 1",
-        ..Default::default()
-    }
-    .create(conn);
-    let program_spec = NewProgramSpec {
-        name: "Program 2",
-        hardware_spec_id: hw_spec.id,
-        ..Default::default()
-    }
-    .create(conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("Program 2")
+        .hardware_spec(&hw_spec)
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(

--- a/api/tests/test_update_user_program.rs
+++ b/api/tests/test_update_user_program.rs
@@ -1,9 +1,7 @@
 #![deny(clippy::all)]
 
-use crate::utils::{ContextBuilder, QueryRunner};
-use gdlk_api::models::{
-    Factory, NewHardwareSpec, NewProgramSpec, NewUser, NewUserProgram,
-};
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
 use juniper::InputValue;
 use maplit::hashmap;
 use serde_json::json;
@@ -46,25 +44,17 @@ fn test_update_user_program_success() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -106,26 +96,18 @@ fn test_update_user_program_not_logged_in() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let user = NewUser { username: "user1" }.create(conn);
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let other_user = UserFactory::default().username("other").insert(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&other_user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -156,26 +138,18 @@ fn test_update_user_program_wrong_owner() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let owner = NewUser { username: "owner" }.create(conn);
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: owner.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let other_user = UserFactory::default().username("other").insert(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&other_user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -206,25 +180,17 @@ fn test_update_user_program_empty_modification() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -253,33 +219,24 @@ fn test_update_user_program_duplicate() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
     // Use this to test collisions
-    NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing2.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing2.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     assert_eq!(
@@ -310,25 +267,17 @@ fn test_update_user_program_invalid_values() {
     let conn = context_builder.db_conn();
 
     // Initialize data
-    let program_spec_id = NewProgramSpec {
-        name: "prog1",
-        hardware_spec_id: NewHardwareSpec {
-            name: "hw1",
-            ..Default::default()
-        }
-        .create(conn)
-        .id,
-        ..Default::default()
-    }
-    .create(conn)
-    .id;
-    let user_program = NewUserProgram {
-        user_id: user.id,
-        program_spec_id,
-        file_name: "existing.gdlk",
-        source_code: "READ RX0",
-    }
-    .create(conn);
+    let hardware_spec = HardwareSpecFactory::default().name("hw1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hardware_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("existing.gdlk")
+        .source_code("READ RX0")
+        .insert(conn);
 
     let runner = QueryRunner::new(context_builder);
     // Error - Known user program, but the target file name is invalid

--- a/api/tests/utils/factories.rs
+++ b/api/tests/utils/factories.rs
@@ -1,0 +1,80 @@
+//! Factory structs for generating test data of our models.
+
+use diesel_factories::{Association, Factory};
+use gdlk_api::models::{HardwareSpec, ProgramSpec, User};
+use uuid::Uuid;
+
+// TODO change all String to &str after https://github.com/davidpdrsn/diesel-factories/issues/21
+
+#[derive(Clone, Default, Factory)]
+#[factory(
+    model = "gdlk_api::models::User",
+    table = "gdlk_api::schema::users",
+    id = "Uuid"
+)]
+pub struct UserFactory {
+    pub username: String,
+}
+
+#[derive(Clone, Default, Factory)]
+#[factory(
+    model = "gdlk_api::models::UserProvider",
+    table = "gdlk_api::schema::user_providers",
+    id = "Uuid"
+)]
+pub struct UserProviderFactory<'a> {
+    pub sub: String,
+    pub provider_name: String,
+    pub user: Option<Association<'a, User, UserFactory>>,
+}
+
+#[derive(Clone, Factory)]
+#[factory(
+    model = "gdlk_api::models::HardwareSpec",
+    table = "gdlk_api::schema::hardware_specs",
+    id = "Uuid"
+)]
+pub struct HardwareSpecFactory {
+    pub name: String,
+    pub num_registers: i32,
+    pub num_stacks: i32,
+    pub max_stack_length: i32,
+}
+
+impl Default for HardwareSpecFactory {
+    fn default() -> Self {
+        Self {
+            name: "".into(),
+            num_registers: 1,
+            num_stacks: 0,
+            max_stack_length: 0,
+        }
+    }
+}
+
+#[derive(Clone, Default, Factory)]
+#[factory(
+    model = "gdlk_api::models::ProgramSpec",
+    table = "gdlk_api::schema::program_specs",
+    id = "Uuid"
+)]
+pub struct ProgramSpecFactory<'a> {
+    pub name: String,
+    pub description: String,
+    pub hardware_spec: Association<'a, HardwareSpec, HardwareSpecFactory>,
+    pub input: Vec<i32>,
+    pub expected_output: Vec<i32>,
+}
+
+#[derive(Clone, Default, Factory)]
+#[factory(
+    model = "gdlk_api::models::UserProgram",
+    table = "gdlk_api::schema::user_programs",
+    id = "Uuid"
+)]
+pub struct UserProgramFactory<'a> {
+    pub user: Association<'a, User, UserFactory>,
+    pub program_spec: Association<'a, ProgramSpec, ProgramSpecFactory<'a>>,
+    pub file_name: String,
+    pub source_code: String,
+}


### PR DESCRIPTION
I replaced our home-rolled `Factory` trait with this crate called [diesel_factories](https://docs.rs/diesel-factories/1.0.1/diesel_factories/) (which is by the same guy that made `juniper-from-schema`). It's pretty litty. Tbh this code shouldn't require much review, it's basically a situation of if it compiles and passes, it's working.

The one thing that's annoying here is that since the factory classes are defined in the util file for the integration tests (which are the tests that live in the separate `tests/` dir), we can't use them for unit tests in the main crate. We don't have many of these tests so for now we're just inserting stuff manually. Ideally we could move the factories into the crate but have them only exist for tests, but it doesn't look like there's a good way to do that. `cfg(test)`. We _could_ just have the factories exist in the API crate always, but i think that's pretty gnar and I don't wanna do it.