### PR TITLE
Change lang value to i32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
-    "api",
-    "cli",
-    "core",
-    "wasm",
+  "api",
+  "cli",
+  "core",
+  "wasm",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
-name = "gdlk_api"
-version = "0.1.0"
-license = "MIT"
-repository = "https://github.com/LucasPickering/gdlk"
 authors = [
-    "John Reilly Murray <johnreillymurray@gmail.com>",
-    "Lucas Pickering <lucas@lucaspickering.me>",
+  "John Reilly Murray <johnreillymurray@gmail.com>",
+  "Lucas Pickering <lucas@lucaspickering.me>",
 ]
-edition = "2018"
 description = "HTTP API to run the entire GDLK site."
+edition = "2018"
+license = "MIT"
+name = "gdlk_api"
+repository = "https://github.com/LucasPickering/gdlk"
+version = "0.1.0"
 
 [dependencies]
 actix = "0.9"
 actix-identity = "0.2.1"
-actix-web = { version = "2.0", features = ["openssl"] }
-actix-web-actors = "2.0"
 actix-rt = "1.0"
+actix-web = {version = "2.0", features = ["openssl"]}
+actix-web-actors = "2.0"
 base64 = "^0.12.0"
 chrono = "0.4"
-config = { version = "0.10", default-features = false, features = ["json"] }
-diesel = { version = "^1.4.3", default-features = false, features = ["chrono", "postgres", "r2d2", "uuidv07"] }
+config = {version = "0.10", default-features = false, features = ["json"]}
+diesel = {version = "^1.4.3", default-features = false, features = ["chrono", "postgres", "r2d2", "uuidv07"]}
 env_logger = "0.7"
-gdlk = { path = "../core" }
-juniper = { version = "0.14.2", default-features = false, features = ["chrono"] }
+gdlk = {path = "../core"}
+juniper = {version = "0.14.2", default-features = false, features = ["chrono"]}
 # juniper-from-schema = "0.5.2"
-juniper-from-schema = { git = "https://github.com/LucasPickering/juniper-from-schema", branch = "fragment-bug-workaround" }
+juniper-from-schema = {git = "https://github.com/LucasPickering/juniper-from-schema", branch = "fragment-bug-workaround"}
 log = "^0.4.8"
-openidconnect = { git = "https://github.com/ramosbugs/openidconnect-rs", branch = "main", default-features = false }
+openidconnect = {git = "https://github.com/ramosbugs/openidconnect-rs", branch = "main", default-features = false}
 r2d2 = "0.8"
-serde = { version = "1.0", features = ["derive"] }
+serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0"
 uuid = "^0.7.0"

--- a/api/migrations/2020-05-30-210421_init_models/up.sql
+++ b/api/migrations/2020-05-30-210421_init_models/up.sql
@@ -16,7 +16,6 @@ CREATE TABLE program_specs (
     name VARCHAR(50) NOT NULL CHECK (char_length(name) > 0),
     description TEXT NOT NULL,
     hardware_spec_id UUID NOT NULL REFERENCES hardware_specs(id),
-    -- TODO add constraint to make sure all values in range
     input INT[] NOT NULL CHECK (array_length(input, 1) <= 256),
     expected_output INT[] NOT NULL CHECK (array_length(input, 1) <= 256),
     UNIQUE(slug, hardware_spec_id),

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "gdlk_cli"
-version = "0.1.0"
-license = "MIT"
-repository = "https://github.com/LucasPickering/gdlk"
 authors = [
-    "John Reilly Murray <johnreillymurray@gmail.com>",
-    "Lucas Pickering <lucas@lucaspickering.me>",
+  "John Reilly Murray <johnreillymurray@gmail.com>",
+  "Lucas Pickering <lucas@lucaspickering.me>",
 ]
-edition = "2018"
 description = "Small CLI utility for compiling and running GDLK programs"
+edition = "2018"
+license = "MIT"
+name = "gdlk_cli"
+repository = "https://github.com/LucasPickering/gdlk"
+version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0"
-gdlk = { path = "../core" }
-serde = { version = "1.0", features = ["derive"] }
+gdlk = {path = "../core"}
+serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 structopt = "0.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "gdlk"
-version = "0.1.0"
-license = "MIT"
-repository = "https://github.com/LucasPickering/gdlk"
 authors = [
-    "John Reilly Murray <johnreillymurray@gmail.com>",
-    "Lucas Pickering <lucas@lucaspickering.me>",
+  "John Reilly Murray <johnreillymurray@gmail.com>",
+  "Lucas Pickering <lucas@lucaspickering.me>",
 ]
-edition = "2018"
 description = "Implementation of the GDLK language."
+edition = "2018"
+license = "MIT"
+name = "gdlk"
+repository = "https://github.com/LucasPickering/gdlk"
+version = "0.1.0"
 
 [features]
 wasm = ["wasm-bindgen"]
@@ -16,10 +16,10 @@ wasm = ["wasm-bindgen"]
 [dependencies]
 nom = "5.1.1"
 nom_locate = "2.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = {version = "1.0", features = ["derive"]}
 thiserror = "1.0"
 
 [dependencies.wasm-bindgen]
-version = "0.2.58"
 features = ["serde-serialize"]
 optional = true
+version = "0.2.58"

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -13,7 +13,7 @@ use crate::{
 use std::fmt::{self, Display, Formatter};
 
 /// The type of every value in our language.
-pub type LangValue = i16;
+pub type LangValue = i32;
 
 /// A symbol used to identify a certain user register.
 pub type UserRegisterId = usize;

--- a/core/src/parse.rs
+++ b/core/src/parse.rs
@@ -724,14 +724,14 @@ mod tests {
                         Node(
                             ValueSource::Const(Node(
                                 LangValue::max_value(),
-                                span(1, 9, 1, 14)
+                                span(1, 9, 1, 19)
                             )),
-                            span(1, 9, 1, 14)
+                            span(1, 9, 1, 19)
                         )
                     ),
-                    span(1, 1, 1, 14)
+                    span(1, 1, 1, 19)
                 )),
-                span(1, 1, 1, 14)
+                span(1, 1, 1, 19)
             )]
         );
     }
@@ -748,14 +748,14 @@ mod tests {
                         Node(
                             ValueSource::Const(Node(
                                 LangValue::min_value(),
-                                span(1, 9, 1, 15)
+                                span(1, 9, 1, 20)
                             )),
-                            span(1, 9, 1, 15)
+                            span(1, 9, 1, 20)
                         )
                     ),
-                    span(1, 1, 1, 15)
+                    span(1, 1, 1, 20)
                 )),
-                span(1, 1, 1, 15)
+                span(1, 1, 1, 20)
             )]
         );
     }

--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -98,8 +98,8 @@ const ProgramIde: React.FC<{
   const wasmProgramSpec = useStaticValue(
     () =>
       new ProgramSpec(
-        Int16Array.from(programSpec.input),
-        Int16Array.from(programSpec.expectedOutput)
+        Int32Array.from(programSpec.input),
+        Int32Array.from(programSpec.expectedOutput)
       )
   );
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "gdlk_wasm"
-version = "0.1.0"
-license = "MIT"
-repository = "https://github.com/LucasPickering/gdlk"
 authors = [
-    "John Reilly Murray <johnreillymurray@gmail.com>",
-    "Lucas Pickering <lucas@lucaspickering.me>",
+  "John Reilly Murray <johnreillymurray@gmail.com>",
+  "Lucas Pickering <lucas@lucaspickering.me>",
 ]
-edition = "2018"
 description = "Webassembly bindings for the GDLK core crate"
+edition = "2018"
+license = "MIT"
+name = "gdlk_wasm"
+repository = "https://github.com/LucasPickering/gdlk"
+version = "0.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "rlib"]
 test = false
 
 [dependencies]
-gdlk = { path = "../core", features = ["wasm"] }
-wasm-bindgen = { version = "0.2.62", features = ["serde-serialize"] }
+gdlk = {path = "../core", features = ["wasm"]}
 serde = "^1.0.59"
 serde_derive = "^1.0.59"
+wasm-bindgen = {version = "0.2.62", features = ["serde-serialize"]}
 
 [dev-dependencies]
 maplit = "^1.0.0"

--- a/wasm/tests/test_wasm.rs
+++ b/wasm/tests/test_wasm.rs
@@ -104,7 +104,7 @@ fn test_compile_success() {
         cycle_count = 0,
         terminated = false,
         successful = false,
-        input = &[1i16],
+        input = &[1],
         output = &[],
         registers = hashmap! {
             "RLI".into() => 1,
@@ -195,7 +195,7 @@ fn test_execute() {
         cycle_count = 0,
         terminated = false,
         successful = false,
-        input = &[1i16, 2i16, 3i16],
+        input = &[1, 2, 3],
         output = &[],
         registers = hashmap! {
             "RLI".into() => 3,
@@ -216,7 +216,7 @@ fn test_execute() {
         cycle_count = 1,
         terminated = false,
         successful = false,
-        input = &[1i16, 2i16, 3i16],
+        input = &[1, 2, 3],
         output = &[],
         registers = hashmap! {
             "RLI".into() => 3,
@@ -237,7 +237,7 @@ fn test_execute() {
         cycle_count = 2,
         terminated = false,
         successful = false,
-        input = &[2i16, 3i16],
+        input = &[2, 3],
         output = &[],
         registers = hashmap! {
             "RLI".into() => 2,
@@ -258,7 +258,7 @@ fn test_execute() {
         cycle_count = 3,
         terminated = false,
         successful = false,
-        input = &[2i16, 3i16],
+        input = &[2, 3],
         output = &[],
         registers = hashmap! {
             "RLI".into() => 2,
@@ -279,7 +279,7 @@ fn test_execute() {
         cycle_count = 4,
         terminated = false,
         successful = false,
-        input = &[2i16, 3i16],
+        input = &[2, 3],
         output = &[],
         registers = hashmap! {
             "RLI".into() => 2,
@@ -300,8 +300,8 @@ fn test_execute() {
         cycle_count = 5,
         terminated = false,
         successful = false,
-        input = &[2i16, 3i16],
-        output = &[1i16],
+        input = &[2, 3],
+        output = &[1],
         registers = hashmap! {
             "RLI".into() => 2,
             "RS0".into() => 0,
@@ -321,8 +321,8 @@ fn test_execute() {
         cycle_count = 6,
         terminated = false,
         successful = false,
-        input = &[2i16, 3i16],
-        output = &[1i16],
+        input = &[2, 3],
+        output = &[1],
         registers = hashmap! {
             "RLI".into() => 2,
             "RS0".into() => 0,
@@ -347,7 +347,7 @@ fn test_execute() {
         terminated = true,
         successful = true,
         input = &[],
-        output = &[1i16, 2i16, 3i16],
+        output = &[1, 2, 3],
         registers = hashmap! {
             "RLI".into() => 0,
             "RS0".into() => 0,


### PR DESCRIPTION
We had `LangValue` set to `i16`. I don't remember why we did that but I think it makes more sense to have it be an i32, just to make it easier to interface w/ GraphQL and postgres.

Also the TOML vscode extension apparently now has formatting support so I just formatted all our Cargo.toml files