### PR TITLE
Add leaderboard models

### DIFF
--- a/api/migrations/2020-08-20-010208_add_leaderboard_models/down.sql
+++ b/api/migrations/2020-08-20-010208_add_leaderboard_models/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_programs DROP COLUMN record_id;
+DROP TABLE user_program_pbs;
+DROP TABLE user_program_records;

--- a/api/migrations/2020-08-20-010208_add_leaderboard_models/up.sql
+++ b/api/migrations/2020-08-20-010208_add_leaderboard_models/up.sql
@@ -1,0 +1,28 @@
+-- Metrics to measure the performance of a user_program
+CREATE TABLE user_program_records (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    source_code TEXT NOT NULL,
+    cpu_cycles INTEGER NOT NULL CHECK(cpu_cycles >= 0),
+    instructions INTEGER NOT NULL CHECK(instructions >= 0),
+    registers_used INTEGER NOT NULL CHECK(registers_used >= 0),
+    stacks_used INTEGER NOT NULL CHECK(stacks_used >= 0),
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- A user's best solution for a program in a particular stat
+-- pb for "personal best"
+CREATE TABLE user_program_pbs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    program_spec_id UUID NOT NULL REFERENCES program_specs(id),
+    record_id UUID NOT NULL REFERENCES user_program_records(id),
+    stat TEXT NOT NULL CHECK(stat IN (
+        'cpu_cycles', 'instructions', 'registers_used', 'stacks_used'
+    )),
+    UNIQUE(user_id, program_spec_id, stat)
+);
+
+-- Each solution tracks stats for its last run. This column should be populated
+-- after every successful run, and cleared any time the source code changes.
+ALTER TABLE user_programs
+    ADD COLUMN record_id UUID REFERENCES user_program_records(id);

--- a/api/src/models/hardware_spec.rs
+++ b/api/src/models/hardware_spec.rs
@@ -2,6 +2,7 @@ use crate::schema::hardware_specs;
 use diesel::{
     prelude::*, query_builder::InsertStatement, Identifiable, Queryable,
 };
+use std::convert::TryInto;
 use uuid::Uuid;
 use validator::Validate;
 
@@ -26,6 +27,18 @@ pub struct HardwareSpec {
     pub num_stacks: i32,
     /// Maximum size of each stack
     pub max_stack_length: i32,
+}
+
+impl From<HardwareSpec> for gdlk::HardwareSpec {
+    fn from(other: HardwareSpec) -> Self {
+        gdlk::HardwareSpec {
+            // We force these values to be positive in the DB, so the conversion
+            // is safe
+            num_registers: other.num_registers.try_into().unwrap(),
+            num_stacks: other.num_stacks.try_into().unwrap(),
+            max_stack_length: other.max_stack_length.try_into().unwrap(),
+        }
+    }
 }
 
 /// A derivative of [HardwareSpec](gdlk::HardwareSpec), meant for DB inserts.

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -16,6 +16,8 @@ mod role;
 mod role_permission;
 mod user;
 mod user_program;
+mod user_program_pb;
+mod user_program_record;
 mod user_provider;
 mod user_role;
 
@@ -26,5 +28,7 @@ pub use role::*;
 pub use role_permission::*;
 pub use user::*;
 pub use user_program::*;
+pub use user_program_pb::*;
+pub use user_program_record::*;
 pub use user_provider::*;
 pub use user_role::*;

--- a/api/src/models/program_spec.rs
+++ b/api/src/models/program_spec.rs
@@ -48,6 +48,12 @@ impl ProgramSpec {
     }
 }
 
+impl From<ProgramSpec> for gdlk::ProgramSpec {
+    fn from(other: ProgramSpec) -> Self {
+        Self::new(other.input, other.expected_output)
+    }
+}
+
 /// A derivative of [ProgramSpec](gdlk::ProgramSpec), meant for DB inserts.
 /// This can be constructed manually and inserted into the DB. These fields
 /// all correspond to [ProgramSpec](ProgramSpec), so look there for

--- a/api/src/models/user_program.rs
+++ b/api/src/models/user_program.rs
@@ -37,6 +37,7 @@ pub struct UserProgram {
     pub source_code: String,
     pub created: DateTime<Utc>,
     pub last_modified: DateTime<Utc>,
+    pub record_id: Option<Uuid>,
 }
 
 impl UserProgram {
@@ -72,6 +73,7 @@ pub struct NewUserProgram<'a> {
     #[validate(length(min = 1))]
     pub file_name: &'a str,
     pub source_code: &'a str,
+    pub record_id: Option<Uuid>,
 }
 
 impl NewUserProgram<'_> {

--- a/api/src/models/user_program_pb.rs
+++ b/api/src/models/user_program_pb.rs
@@ -1,0 +1,107 @@
+use std::str::FromStr;
+
+use crate::{
+    error::{ResponseError, ResponseResult, ServerError},
+    schema::user_program_pbs,
+};
+use diesel::{
+    prelude::*, query_builder::InsertStatement, Identifiable, Queryable,
+};
+use uuid::Uuid;
+
+/// A mapping of all stat variants to the corresponding name used in the DB
+const STAT_NAME_MAPPING: &[(StatType, &str)] = &[
+    (StatType::CpuCycles, "cpu_cycles"),
+    (StatType::Instructions, "instructions"),
+    (StatType::RegistersUsed, "registers_used"),
+    (StatType::StacksUsed, "stacks_used"),
+];
+
+/// The different program statistics that we track.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum StatType {
+    CpuCycles,
+    Instructions,
+    RegistersUsed,
+    StacksUsed,
+}
+
+impl StatType {
+    pub fn to_str(self) -> &'static str {
+        for (role_type, name) in STAT_NAME_MAPPING {
+            if self == *role_type {
+                return name;
+            }
+        }
+        panic!("Missing name for stat type: {:?}", self);
+    }
+
+    pub fn all_types() -> impl Iterator<Item = Self> {
+        STAT_NAME_MAPPING.iter().map(|(stat_type, _)| *stat_type)
+    }
+}
+
+impl FromStr for StatType {
+    type Err = ResponseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        for (role_type, name) in STAT_NAME_MAPPING {
+            if s == *name {
+                return Ok(*role_type);
+            }
+        }
+
+        // Unknown value
+        Err(ServerError::InvalidDbValue {
+            column: Box::new(user_program_pbs::columns::stat),
+            value: s.into(),
+        }
+        .into())
+    }
+}
+
+/// A user's Personal Best record for a particular program spec.
+#[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
+#[table_name = "user_program_pbs"]
+pub struct UserProgramPb {
+    /// DB primary key
+    pub id: Uuid,
+    /// Foreign key to the user
+    pub user_id: Uuid,
+    /// The program spec for which this solution is written
+    pub program_spec_id: Uuid,
+    /// Statistical record for the user's solution that used the fewest number
+    /// of CPU cycles.
+    pub record_id: Uuid,
+    /// The name of the statistic that this row is a PB for. Maps to one of
+    /// [StatType]. Use [Self::stat_type] to parse this.
+    pub stat: String,
+}
+
+impl UserProgramPb {
+    /// Parse the `stat` value of this model into a [StatType].
+    pub fn stat_type(&self) -> ResponseResult<StatType> {
+        self.stat.parse()
+    }
+}
+
+#[derive(Clone, Debug, Insertable)]
+#[table_name = "user_program_pbs"]
+pub struct NewUserProgramPb<'a> {
+    pub user_id: Uuid,
+    pub program_spec_id: Uuid,
+    pub record_id: Uuid,
+    pub stat: &'a str,
+}
+
+impl NewUserProgramPb<'_> {
+    /// Insert this object into the `user_program_pbs` DB table.
+    pub fn insert(
+        self,
+    ) -> InsertStatement<
+        user_program_pbs::table,
+        <Self as Insertable<user_program_pbs::table>>::Values,
+    > {
+        self.insert_into(user_program_pbs::table)
+    }
+}

--- a/api/src/models/user_program_record.rs
+++ b/api/src/models/user_program_record.rs
@@ -1,0 +1,84 @@
+use crate::{
+    error::{ResponseError, ResponseResult},
+    schema::{user_program_pbs, user_program_records, user_programs},
+};
+use chrono::{DateTime, Utc};
+use diesel::{
+    dsl, query_builder::InsertStatement, ExpressionMethods, Identifiable,
+    Insertable, NullableExpressionMethods, PgConnection, QueryDsl, Queryable,
+    RunQueryDsl,
+};
+use uuid::Uuid;
+
+/// A record of a **successful** program execution. The program must compile,
+/// execute, and have valid output (matching the program spec) for this a row
+/// in this table to be valid. This model does not identify which user executed
+/// the program or which program spec it was written for. This is just meant to
+/// be linked to by `user_programs` or `user_program_pbs` to store stats data
+/// for a program.
+#[derive(Clone, Debug, PartialEq, Identifiable, Queryable)]
+#[table_name = "user_program_records"]
+pub struct UserProgramRecord {
+    /// DB primary key
+    pub id: Uuid,
+    /// GDLK code that was executed
+    pub source_code: String,
+    /// Number of CPU cycles required for the program to terminate
+    pub cpu_cycles: i32,
+    /// Number of compiled instructions in the program (i.e. program size)
+    pub instructions: i32,
+    /// Number of unique user registers referenced by the program
+    pub registers_used: i32,
+    /// Number of unique stacks referenced by the program
+    pub stacks_used: i32,
+    /// When this row was created, which is also when the program was executed.
+    pub created: DateTime<Utc>,
+}
+
+impl UserProgramRecord {
+    /// Delete rows in the `user_program_records` table that are not referenced
+    /// from anywhere. This checks both the `user_programs` and
+    /// `user_program_pbs` tables. This builds and executes the query. Returns
+    /// the number of deleted rows.
+    pub fn delete_dangling_x(conn: &PgConnection) -> ResponseResult<usize> {
+        diesel::delete(
+            user_program_records::table
+                .filter(dsl::not(dsl::exists(
+                    user_programs::table.filter(
+                        user_programs::columns::record_id
+                            .eq(user_program_records::columns::id.nullable()),
+                    ),
+                )))
+                .filter(dsl::not(dsl::exists(
+                    user_program_pbs::table.filter(
+                        user_program_pbs::columns::record_id
+                            .eq(user_program_records::columns::id),
+                    ),
+                ))),
+        )
+        .execute(conn)
+        .map_err(ResponseError::from_server_error)
+    }
+}
+
+#[derive(Clone, Debug, Insertable)]
+#[table_name = "user_program_records"]
+pub struct NewUserProgramRecord<'a> {
+    pub source_code: &'a str,
+    pub cpu_cycles: i32,
+    pub instructions: i32,
+    pub registers_used: i32,
+    pub stacks_used: i32,
+}
+
+impl NewUserProgramRecord<'_> {
+    /// Insert this object into the `user_program_records` DB table.
+    pub fn insert(
+        self,
+    ) -> InsertStatement<
+        user_program_records::table,
+        <Self as Insertable<user_program_records::table>>::Values,
+    > {
+        self.insert_into(user_program_records::table)
+    }
+}

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -47,6 +47,28 @@ table! {
 }
 
 table! {
+    user_program_pbs (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        program_spec_id -> Uuid,
+        record_id -> Uuid,
+        stat -> Text,
+    }
+}
+
+table! {
+    user_program_records (id) {
+        id -> Uuid,
+        source_code -> Text,
+        cpu_cycles -> Int4,
+        instructions -> Int4,
+        registers_used -> Int4,
+        stacks_used -> Int4,
+        created -> Timestamptz,
+    }
+}
+
+table! {
     user_programs (id) {
         id -> Uuid,
         user_id -> Uuid,
@@ -55,6 +77,7 @@ table! {
         source_code -> Text,
         created -> Timestamptz,
         last_modified -> Timestamptz,
+        record_id -> Nullable<Uuid>,
     }
 }
 
@@ -85,7 +108,11 @@ table! {
 joinable!(program_specs -> hardware_specs (hardware_spec_id));
 joinable!(role_permissions -> permissions (permission_id));
 joinable!(role_permissions -> roles (role_id));
+joinable!(user_program_pbs -> program_specs (program_spec_id));
+joinable!(user_program_pbs -> user_program_records (record_id));
+joinable!(user_program_pbs -> users (user_id));
 joinable!(user_programs -> program_specs (program_spec_id));
+joinable!(user_programs -> user_program_records (record_id));
 joinable!(user_programs -> users (user_id));
 joinable!(user_providers -> users (user_id));
 joinable!(user_roles -> roles (role_id));
@@ -97,6 +124,8 @@ allow_tables_to_appear_in_same_query!(
     program_specs,
     role_permissions,
     roles,
+    user_program_pbs,
+    user_program_records,
     user_programs,
     user_providers,
     user_roles,

--- a/api/src/views/user_program.rs
+++ b/api/src/views/user_program.rs
@@ -28,6 +28,7 @@ impl<'a> View for CreateUserProgramView<'a> {
         let new_user_program = models::NewUserProgram {
             user_id: user.id,
             program_spec_id: self.program_spec_id,
+            record_id: None,
             file_name: self.file_name,
             source_code: self.source_code,
         };
@@ -129,6 +130,7 @@ impl<'a> View for CopyUserProgramView<'a> {
                     models::NewUserProgram {
                         user_id: user.id,
                         program_spec_id: user_program.program_spec_id,
+                        record_id: None,
                         // Generate a new file name
                         file_name: &format!("{} copy", &user_program.file_name),
                         source_code: &user_program.source_code,

--- a/api/tests/test_user_program_record.rs
+++ b/api/tests/test_user_program_record.rs
@@ -1,0 +1,63 @@
+#![deny(clippy::all)]
+
+use std::collections::HashSet;
+
+use crate::utils::{factories::*, ContextBuilder};
+use diesel::{dsl, QueryDsl, RunQueryDsl};
+use diesel_factories::Factory;
+use gdlk_api::{models, schema::user_program_records};
+use maplit::hashset;
+use uuid::Uuid;
+
+mod utils;
+
+/// Test the `delete_dangling_x` function, which deletes all
+/// user_program_records that are no longer referenced by any other rows.
+#[test]
+fn test_delete_dangling() {
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in(&[]);
+    let conn = context_builder.db_conn();
+
+    UserProgramRecordFactory::default().insert(conn);
+    let solution_record = UserProgramRecordFactory::default().insert(conn);
+    let pb_record = UserProgramRecordFactory::default().insert(conn);
+
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .input(vec![1])
+        .expected_output(vec![1])
+        .insert(conn);
+
+    UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .record(Some(&solution_record))
+        .insert(conn);
+    UserProgramPbFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .record(&pb_record)
+        .stat(models::StatType::CpuCycles.to_str())
+        .insert(conn);
+
+    assert_eq!(
+        user_program_records::table
+            .select(dsl::count(user_program_records::columns::id))
+            .get_result::<i64>(conn)
+            .unwrap(),
+        3
+    );
+
+    models::UserProgramRecord::delete_dangling_x(conn).unwrap();
+    let remaining_ids: HashSet<Uuid> = user_program_records::table
+        .select(user_program_records::columns::id)
+        .get_results::<Uuid>(conn)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(remaining_ids, hashset! {solution_record.id, pb_record.id});
+}

--- a/api/tests/utils/factories.rs
+++ b/api/tests/utils/factories.rs
@@ -1,7 +1,7 @@
 //! Factory structs for generating test data of our models.
 
 use diesel_factories::{Association, Factory};
-use gdlk_api::models::{HardwareSpec, ProgramSpec, User};
+use gdlk_api::models::{HardwareSpec, ProgramSpec, User, UserProgramRecord};
 use uuid::Uuid;
 
 // TODO change all String to &str after https://github.com/davidpdrsn/diesel-factories/issues/21
@@ -75,6 +75,35 @@ pub struct ProgramSpecFactory<'a> {
 pub struct UserProgramFactory<'a> {
     pub user: Association<'a, User, UserFactory>,
     pub program_spec: Association<'a, ProgramSpec, ProgramSpecFactory<'a>>,
+    pub record:
+        Option<Association<'a, UserProgramRecord, UserProgramRecordFactory>>,
     pub file_name: String,
     pub source_code: String,
+}
+
+#[derive(Clone, Default, Factory)]
+#[factory(
+    model = "gdlk_api::models::UserProgramRecord",
+    table = "gdlk_api::schema::user_program_records",
+    id = "Uuid"
+)]
+pub struct UserProgramRecordFactory {
+    pub source_code: String,
+    pub cpu_cycles: i32,
+    pub instructions: i32,
+    pub registers_used: i32,
+    pub stacks_used: i32,
+}
+
+#[derive(Clone, Default, Factory)]
+#[factory(
+    model = "gdlk_api::models::UserProgramPb",
+    table = "gdlk_api::schema::user_program_pbs",
+    id = "Uuid"
+)]
+pub struct UserProgramPbFactory<'a> {
+    pub user: Association<'a, User, UserFactory>,
+    pub program_spec: Association<'a, ProgramSpec, ProgramSpecFactory<'a>>,
+    pub record: Association<'a, UserProgramRecord, UserProgramRecordFactory>,
+    pub stat: String,
 }

--- a/api/tests/utils/mod.rs
+++ b/api/tests/utils/mod.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 
 /// Convert a serializable value into a JSON value.
+#[allow(dead_code)] // Not all test crates use this
 pub fn to_json<T: Serialize>(input: T) -> serde_json::Value {
     let serialized: String = serde_json::to_string(&input).unwrap();
     serde_json::from_str(&serialized).unwrap()
@@ -67,6 +68,7 @@ impl ContextBuilder {
         user
     }
 
+    #[allow(dead_code)] // Not all test crates use this
     pub fn build(self) -> RequestContext {
         RequestContext::load_context(
             self.db_conn,
@@ -77,12 +79,14 @@ impl ContextBuilder {
 }
 
 /// Helper type for setting up and executing test GraphQL queries
+#[allow(dead_code)] // Not all test crates use this
 pub struct QueryRunner {
     schema: GqlSchema,
     context: RequestContext,
 }
 
 impl QueryRunner {
+    #[allow(dead_code)] // Not all test crates use this
     pub fn new(context_builder: ContextBuilder) -> Self {
         Self {
             schema: create_gql_schema(),
@@ -95,6 +99,7 @@ impl QueryRunner {
         &self.context.db_conn
     }
 
+    #[allow(dead_code)] // Not all test crates use this
     pub fn query<'a>(
         &'a self,
         query: &'a str,


### PR DESCRIPTION
Added two new tables for tracking leaderboards: `user_program_records` and `user_program_pbs`.

`user_program_records` just holds stats for a particular program execution, and doesn't point out to any other tables.

`user_program_pbs` tracks a user's best solution for a particular (user, program_spec, stat) combo, where stat is one of (cpu cycles, instructions, registers referenced, stacks referenced). This users `user_program_records` for holding the actual stats.

I also added a column to `user_programs` that points to `user_program_records`, which is meant to track the statistics for the current version of the program. It's populated whenever the program is run and is successful, and gets wiped out any time the source changes.

I have most of the code written to for an `executeUserProgram` mutation so we can start populating these models through the API, but that's still in progress.

Here's what a query might look like to get a user's PB for a particular program_spec/stat:

```
SELECT user_program_records.cpu_cycles FROM user_program_pbs
  INNER JOIN user_program_records ON user_program_pbs.record_id = user_program_records.id
  WHERE user_id = ... AND program_spec_id = ... AND user_program_pbs.stat = 'cpu';
```
