### PR TITLE
Add stat_value column to user_program_pbs

### DIFF
--- a/api/migrations/2020-08-20-010208_add_leaderboard_models/up.sql
+++ b/api/migrations/2020-08-20-010208_add_leaderboard_models/up.sql
@@ -19,6 +19,9 @@ CREATE TABLE user_program_pbs (
     stat TEXT NOT NULL CHECK(stat IN (
         'cpu_cycles', 'instructions', 'registers_used', 'stacks_used'
     )),
+    -- This col will duplicate the corresponding column on the record, but it's
+    -- more convenient having it here too
+    stat_value INTEGER NOT NULL CHECK (stat_value >= 0),
     UNIQUE(user_id, program_spec_id, stat)
 );
 

--- a/api/src/models/user_program_pb.rs
+++ b/api/src/models/user_program_pb.rs
@@ -76,6 +76,10 @@ pub struct UserProgramPb {
     /// The name of the statistic that this row is a PB for. Maps to one of
     /// [StatType]. Use [Self::stat_type] to parse this.
     pub stat: String,
+    /// The value of the statistic. This will duplicate the corresponding
+    /// column on the referenced record (e.g. if `stat` is `cpu_cycles`, then
+    /// this will equal `record.cpu_cycles`). Keep it here too for convenience.
+    pub stat_value: i32,
 }
 
 impl UserProgramPb {
@@ -92,6 +96,7 @@ pub struct NewUserProgramPb<'a> {
     pub program_spec_id: Uuid,
     pub record_id: Uuid,
     pub stat: &'a str,
+    pub stat_value: i32,
 }
 
 impl NewUserProgramPb<'_> {

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -53,6 +53,7 @@ table! {
         program_spec_id -> Uuid,
         record_id -> Uuid,
         stat -> Text,
+        stat_value -> Int4,
     }
 }
 

--- a/api/tests/utils/factories.rs
+++ b/api/tests/utils/factories.rs
@@ -106,4 +106,5 @@ pub struct UserProgramPbFactory<'a> {
     pub program_spec: Association<'a, ProgramSpec, ProgramSpecFactory<'a>>,
     pub record: Association<'a, UserProgramRecord, UserProgramRecordFactory>,
     pub stat: String,
+    pub stat_value: i32,
 }


### PR DESCRIPTION
I've been working on the API code for the leaderboards more, and I realized it will be a lot easier to fetch a user's PB for all stats if we just store the PB value on the PB table (so we duplicate one of the 4 values from the record row). Without this, we have to join the record table (which is easy) then do post-processing where we grab the correct value from each of the 4 record rows based on `user_program_pbs.stat`. A comparison:

**Without this col**

```
SELECT user_program_pbs.stat, user_program_records.* 
  FROM user_program_pbs INNER JOIN user_program_records ON user_program_pbs.record_id = user_program_records.id
  WHERE user_program_pbs.user_id = 'blah' AND user_program_pbs.program_spec_id = 'blah';
```

then we need some processing code like this (pseudocode):

```
stats = {}
for stat, record in results:
  stats[stat] = match {
    CPU => record.cpu_cycles,
    INSTRUCTIONS => record.instructions,
    REGISTERS => record.num_registers,
    STACKS => record.num_stacks
  }
```

**With this col**

```
SELECT user_program_pbs.stat, user_program_pbs.stat_value FROM user_program_pbs
  WHERE user_program_pbs.user_id = 'blah' AND user_program_pbs.program_spec_id = 'blah';
```

then

```
stats = {stat: stat_value for stat, stat_value in results}
```

So it definitely makes the code a lot cleaner, it wouldn't add much (if any) complexity to the insertion code, and since it's just an int the space it takes up will be minimal. Also, I haven't deployed new code in a while, so this migration hasn't been run on prod yet. That's why I'm just editing the old migration instead of adding a new one.

My main concern with this that it only works for integer stats. I'm not sure what stats we might have that aren't ints (I can't think of any other stats we may want at all), wbu?