### PR TITLE
Fix up some transactions

### DIFF
--- a/api/tests/test_initialize_user.rs
+++ b/api/tests/test_initialize_user.rs
@@ -30,6 +30,7 @@ static QUERY: &str = r#"
 #[test]
 fn test_initialize_user_success() {
     let mut context_builder = ContextBuilder::new();
+    context_builder.disable_transaction();
     let conn = context_builder.db_conn();
 
     let user_provider = UserProviderFactory::default().insert(conn);
@@ -86,6 +87,7 @@ fn test_initialize_user_not_logged_in() {
 #[test]
 fn test_initialize_user_duplicate_username() {
     let mut context_builder = ContextBuilder::new();
+    context_builder.disable_transaction();
     let conn = context_builder.db_conn();
 
     UserFactory::default().username("user1").insert(conn);
@@ -115,6 +117,7 @@ fn test_initialize_user_duplicate_username() {
 #[test]
 fn test_initialize_user_invalid_username() {
     let mut context_builder = ContextBuilder::new();
+    context_builder.disable_transaction();
     let conn = context_builder.db_conn();
 
     let user_provider = UserProviderFactory::default().insert(conn);
@@ -171,6 +174,7 @@ fn test_initialize_user_invalid_username() {
 #[test]
 fn test_initialize_user_already_initialized() {
     let mut context_builder = ContextBuilder::new();
+    context_builder.disable_transaction();
     let conn = context_builder.db_conn();
 
     let user = UserFactory::default().username("user1").insert(conn);


### PR DESCRIPTION
We have two places in the code that use transactions. Turns out neither were doing what we wanted. On one, I ditched the transaction and just made it fail if the data gets invalid. On the either, I changed the isolation level so that now the transaction does what we really want. In order to do that though, I had to change the tests on that view to not use a transaction (by default all tests are run within a transaction). Do now when we disable transactions, the test code will wipe the DB tables at the end of the test instead (test transaction will be more reliable but the DB wiping is a good fallback). For now though I just had it wipe the two auth tables (`users` and `user_providers`), mostly cause I'm lazy.