### PR TITLE
Update graphql-schema-linter and use inline rule disables

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -1,7 +1,10 @@
+# lint-disable input-object-fields-sorted-alphabetically
+# lint-disable type-fields-sorted-alphabetically
+
 directive @juniper(
   ownership: String = "borrowed"
   infallible: Boolean = false
-  with_time_zone: Boolean = true
+  with_time_zone: Boolean = true # lint-disable-line input-object-values-are-camel-cased
 ) on FIELD_DEFINITION
 
 """
@@ -12,12 +15,8 @@ mutated.
 """
 scalar Cursor
 
-# We can't put a description here because of juniper limitations so we have to
-# disable the types-have-descriptions lint rule. After
-# https://github.com/cjoudrey/graphql-schema-linter/issues/18 we can add a
-# disable just to this type
-scalar DateTimeUtc
-
+# We can't put a description here because of juniper limitations.
+scalar DateTimeUtc # lint-disable-line types-have-descriptions
 schema {
   query: Query
   mutation: Mutation

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8236,9 +8236,9 @@
       "integrity": "sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q=="
     },
     "graphql-schema-linter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/graphql-schema-linter/-/graphql-schema-linter-0.4.0.tgz",
-      "integrity": "sha512-3aTKlMJKA+xjjRROG5d9wqNzWFJNcqfZI4/Oo58wR6kembBPJEARsMu6l0QH/2spZNQSLdqUUaN+/m4FyJ2bOQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-schema-linter/-/graphql-schema-linter-1.0.1.tgz",
+      "integrity": "sha512-wcT0to0fBKLmbe4N9C1pM53T6hn8PJ393k1GkWQPLC5xVAVjh37BU23NB9drekVzYXwWfnvP64B4wwFFHKr56w==",
       "requires": {
         "chalk": "^2.0.1",
         "columnify": "^1.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-react-hooks": "^2.5.1",
     "gdlk_wasm": "file:../wasm/pkg",
     "graphql": "^15.1.0",
-    "graphql-schema-linter": "^0.4.0",
+    "graphql-schema-linter": "^1.0.1",
     "http-proxy-middleware": "^1.0.4",
     "lodash-es": "^4.17.15",
     "nodemon": "^2.0.4",
@@ -85,20 +85,6 @@
   "graphql-schema-linter": {
     "schemaPaths": [
       "../api/schema.graphql"
-    ],
-    "rules": [
-      "arguments-have-descriptions",
-      "defined-types-are-used",
-      "deprecations-have-a-reason",
-      "descriptions-are-capitalized",
-      "enum-values-all-caps",
-      "enum-values-have-descriptions",
-      "fields-are-camel-cased",
-      "fields-have-descriptions",
-      "input-object-values-have-descriptions",
-      "relay-connection-types-spec",
-      "relay-connection-arguments-spec",
-      "types-are-capitalized"
     ]
   }
 }


### PR DESCRIPTION
I was going through some TODOs in the code and found this one, graphql-schema-linter now supports selectively disabling rules so we can turn `types-have-descriptions` off for just one type