### PR TITLE
Add execution mutation to GQL schema

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -911,7 +911,7 @@ type ProgramRuntimeError {
 Execution output when a program compiles and executes without error, but the
 final state doesn't match the expected state (as defined by the program spec).
 """
-type ProgramFailureOutput {
+type ProgramRejectedOutput {
   # TODO add machine
   """
   TODO
@@ -925,7 +925,7 @@ Execution output when a program executes successfully.
 2. It executed without error
 3. At the end, the input is empty and the output matches the program spec
 """
-type ProgramSuccessOutput {
+type ProgramAcceptedOutput {
   # TODO add machine + stats
   """
   TODO
@@ -940,8 +940,8 @@ info.
 union ExecuteUserProgramStatus =
     ProgramCompileError
   | ProgramRuntimeError
-  | ProgramFailureOutput
-  | ProgramSuccessOutput
+  | ProgramRejectedOutput
+  | ProgramAcceptedOutput
 
 """
 Output for the `executeUserProgram` mutation.
@@ -952,7 +952,7 @@ type ExecuteUserProgramPayload {
   outcome, which could be one of:
   - Compile error
   - Runtime error
-  - Failed execution (incorrect input/output at termination)
+  - Rejected execution (incorrect input/output at termination)
   - Success
   """
   status: ExecuteUserProgramStatus @juniper(infallible: true)

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -583,6 +583,20 @@ type Mutation {
     """
     input: DeleteUserProgramInput!
   ): DeleteUserProgramPayload! @juniper(ownership: "owned")
+
+  """
+  Execute a user program by ID. The source code for the user program will be
+  compiled and executed. If there are any compile OR runtime errors, an error
+  response will be returned. If execution is successful, then the statistics
+  for the program will stored and the user's personal best scores will be
+  updated if appropriate.
+  """
+  executeUserProgram(
+    """
+    All input fields.
+    """
+    input: ExecuteUserProgramInput!
+  ): ExecuteUserProgramPayload! @juniper(ownership: "owned")
 }
 
 """
@@ -849,4 +863,97 @@ type DeleteUserProgramPayload {
   that ID. Will always be populated if the delete occurred.
   """
   deletedId: ID @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Input for the `executeUserProgram` mutation.
+"""
+input ExecuteUserProgramInput {
+  """
+  The ID of the user program to execute.
+  """
+  id: ID!
+}
+
+# type ProgramError {
+#   # TODO add message + span
+#   todo: Int! @juniper(infallible: true, ownership: "owned")
+# }
+
+# type MachineState {
+#   # TODO add fields
+#   todo: Int! @juniper(infallible: true, ownership: "owned")
+# }
+
+"""
+Program execution failed with one or more compilation errors.
+"""
+type ProgramCompileError {
+  # TODO add errors here
+  """
+  TODO
+  """
+  todo: Int! @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Program execution failed with a runtime error.
+"""
+type ProgramRuntimeError {
+  # TODO add error here
+  """
+  TODO
+  """
+  todo: Int! @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Execution output when a program compiles and executes without error, but the
+final state doesn't match the expected state (as defined by the program spec).
+"""
+type ProgramFailureOutput {
+  # TODO add machine
+  """
+  TODO
+  """
+  todo: Int! @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+Execution output when a program executes successfully.
+1. It compiled without error
+2. It executed without error
+3. At the end, the input is empty and the output matches the program spec
+"""
+type ProgramSuccessOutput {
+  # TODO add machine + stats
+  """
+  TODO
+  """
+  todo: Int! @juniper(infallible: true, ownership: "owned")
+}
+
+"""
+The possible output states of a program execution. See individual types for more
+info.
+"""
+union ExecuteUserProgramStatus =
+    ProgramCompileError
+  | ProgramRuntimeError
+  | ProgramFailureOutput
+  | ProgramSuccessOutput
+
+"""
+Output for the `executeUserProgram` mutation.
+"""
+type ExecuteUserProgramPayload {
+  """
+  Output data from the execution. The type of this field indicates the type of
+  outcome, which could be one of:
+  - Compile error
+  - Runtime error
+  - Failed execution (incorrect input/output at termination)
+  - Success
+  """
+  status: ExecuteUserProgramStatus @juniper(infallible: true)
 }

--- a/api/src/models/user_program.rs
+++ b/api/src/models/user_program.rs
@@ -97,4 +97,5 @@ pub struct ModifiedUserProgram<'a> {
     #[validate(length(min = 1))]
     pub file_name: Option<&'a str>,
     pub source_code: Option<&'a str>,
+    pub record_id: Option<Option<Uuid>>,
 }

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     models,
     schema::hardware_specs,
     server::gql::{
-        hardware_spec::*, mutation::*, program_spec::*, user::*,
+        hardware_spec::*, mutation::*, program::*, program_spec::*, user::*,
         user_program::*,
     },
     util::Valid,
@@ -23,6 +23,7 @@ use validator::{Validate, ValidationError, ValidationErrors};
 mod hardware_spec;
 mod internal;
 mod mutation;
+mod program;
 mod program_spec;
 mod user;
 mod user_program;

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -8,8 +8,8 @@ use crate::{
         DeleteUserProgramPayload, ExecuteUserProgramInput,
         ExecuteUserProgramPayload, ExecuteUserProgramStatus,
         InitializeUserInput, InitializeUserPayload, MutationFields,
-        ProgramCompileError, ProgramFailureOutput, ProgramRuntimeError,
-        ProgramSuccessOutput, UpdateHardwareSpecInput,
+        ProgramAcceptedOutput, ProgramCompileError, ProgramRejectedOutput,
+        ProgramRuntimeError, UpdateHardwareSpecInput,
         UpdateHardwareSpecPayload, UpdateProgramSpecInput,
         UpdateProgramSpecPayload, UpdateUserProgramInput,
         UpdateUserProgramPayload,
@@ -199,14 +199,14 @@ impl MutationFields for Mutation {
                     ProgramRuntimeError {},
                 )
             }
-            ExecuteUserProgramOutput::Failure(_) => {
-                ExecuteUserProgramStatus::ProgramFailureOutput(
-                    ProgramFailureOutput {},
+            ExecuteUserProgramOutput::Rejected(_) => {
+                ExecuteUserProgramStatus::ProgramRejectedOutput(
+                    ProgramRejectedOutput {},
                 )
             }
-            ExecuteUserProgramOutput::Success(_) => {
-                ExecuteUserProgramStatus::ProgramSuccessOutput(
-                    ProgramSuccessOutput {},
+            ExecuteUserProgramOutput::Accepted(_) => {
+                ExecuteUserProgramStatus::ProgramAcceptedOutput(
+                    ProgramAcceptedOutput {},
                 )
             }
         });

--- a/api/src/server/gql/program.rs
+++ b/api/src/server/gql/program.rs
@@ -1,0 +1,84 @@
+//! GQL types related to compiling/executing GDLK programs. This types do NOT
+//! correspond to DB models.
+
+use crate::{
+    server::gql::{
+        ProgramCompileErrorFields, ProgramFailureOutputFields,
+        ProgramRuntimeErrorFields, ProgramSuccessOutputFields,
+    },
+    views::RequestContext,
+};
+
+// TODO fill out these fields properly
+
+// #[derive(Clone, Debug)]
+// pub struct ProgramError {}
+
+// impl ProgramErrorFields for ProgramError {
+//     fn field_todo(
+//         &self,
+//         _executor: &juniper::Executor<'_, RequestContext>,
+//     ) -> i32 {
+//         0
+//     }
+// }
+
+// #[derive(Clone, Debug)]
+// pub struct MachineState {}
+
+// impl MachineStateFields for MachineState {
+//     fn field_todo(
+//         &self,
+//         _executor: &juniper::Executor<'_, RequestContext>,
+//     ) -> i32 {
+//         0
+//     }
+// }
+
+#[derive(Clone, Debug)]
+pub struct ProgramCompileError {}
+
+impl ProgramCompileErrorFields for ProgramCompileError {
+    fn field_todo(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProgramRuntimeError {}
+
+impl ProgramRuntimeErrorFields for ProgramRuntimeError {
+    fn field_todo(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProgramFailureOutput {}
+
+impl ProgramFailureOutputFields for ProgramFailureOutput {
+    fn field_todo(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProgramSuccessOutput {}
+
+impl ProgramSuccessOutputFields for ProgramSuccessOutput {
+    fn field_todo(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        0
+    }
+}

--- a/api/src/server/gql/program.rs
+++ b/api/src/server/gql/program.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     server::gql::{
-        ProgramCompileErrorFields, ProgramFailureOutputFields,
-        ProgramRuntimeErrorFields, ProgramSuccessOutputFields,
+        ProgramAcceptedOutputFields, ProgramCompileErrorFields,
+        ProgramRejectedOutputFields, ProgramRuntimeErrorFields,
     },
     views::RequestContext,
 };
@@ -60,9 +60,9 @@ impl ProgramRuntimeErrorFields for ProgramRuntimeError {
 }
 
 #[derive(Clone, Debug)]
-pub struct ProgramFailureOutput {}
+pub struct ProgramRejectedOutput {}
 
-impl ProgramFailureOutputFields for ProgramFailureOutput {
+impl ProgramRejectedOutputFields for ProgramRejectedOutput {
     fn field_todo(
         &self,
         _executor: &juniper::Executor<'_, RequestContext>,
@@ -72,9 +72,9 @@ impl ProgramFailureOutputFields for ProgramFailureOutput {
 }
 
 #[derive(Clone, Debug)]
-pub struct ProgramSuccessOutput {}
+pub struct ProgramAcceptedOutput {}
 
-impl ProgramSuccessOutputFields for ProgramSuccessOutput {
+impl ProgramAcceptedOutputFields for ProgramAcceptedOutput {
     fn field_todo(
         &self,
         _executor: &juniper::Executor<'_, RequestContext>,

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -6,9 +6,10 @@ use crate::{
         internal::{GenericEdge, NodeType},
         ConnectionPageParams, CopyUserProgramPayloadFields,
         CreateUserProgramPayloadFields, Cursor, DeleteUserProgramPayloadFields,
-        PageInfo, ProgramSpecNode, RequestContext,
-        UpdateUserProgramPayloadFields, UserNode, UserProgramConnectionFields,
-        UserProgramEdgeFields, UserProgramNodeFields,
+        ExecuteUserProgramPayloadFields, ExecuteUserProgramStatus, PageInfo,
+        ProgramSpecNode, RequestContext, UpdateUserProgramPayloadFields,
+        UserNode, UserProgramConnectionFields, UserProgramEdgeFields,
+        UserProgramNodeFields,
     },
     util::{self, Valid},
 };
@@ -268,5 +269,19 @@ impl DeleteUserProgramPayloadFields for DeleteUserProgramPayload {
         _executor: &juniper::Executor<'_, RequestContext>,
     ) -> Option<juniper::ID> {
         self.deleted_id.map(util::uuid_to_gql_id)
+    }
+}
+
+pub struct ExecuteUserProgramPayload {
+    pub status: Option<ExecuteUserProgramStatus>,
+}
+
+impl ExecuteUserProgramPayloadFields for ExecuteUserProgramPayload {
+    fn field_status(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+        _trail: &QueryTrail<'_, ExecuteUserProgramStatus, Walked>,
+    ) -> &Option<ExecuteUserProgramStatus> {
+        &self.status
     }
 }

--- a/api/tests/test_execute_user_program.rs
+++ b/api/tests/test_execute_user_program.rs
@@ -68,7 +68,7 @@ fn test_execute_user_program_stats() {
             json!({
                 "executeUserProgram": {
                     "status": {
-                        "__typename": "ProgramSuccessOutput",
+                        "__typename": "ProgramAcceptedOutput",
                         // TODO check stats here once API is fleshed out
                     }
                 }
@@ -138,7 +138,7 @@ fn test_execute_user_program_pb_update() {
             json!({
                 "executeUserProgram": {
                     "status": {
-                        "__typename": "ProgramSuccessOutput",
+                        "__typename": "ProgramAcceptedOutput",
                     }
                 }
             }),
@@ -170,7 +170,7 @@ fn test_execute_user_program_pb_update() {
             json!({
                 "executeUserProgram": {
                     "status": {
-                        "__typename": "ProgramSuccessOutput",
+                        "__typename": "ProgramAcceptedOutput",
                     }
                 }
             }),
@@ -309,7 +309,7 @@ fn test_execute_user_program_incorrect_output() {
             json!({
                 "executeUserProgram": {
                     "status": {
-                        "__typename": "ProgramFailureOutput"
+                        "__typename": "ProgramRejectedOutput"
                     }
                 }
             }),

--- a/api/tests/test_execute_user_program.rs
+++ b/api/tests/test_execute_user_program.rs
@@ -1,0 +1,385 @@
+#![deny(clippy::all)]
+
+use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use diesel_factories::Factory;
+use gdlk_api::models;
+use juniper::InputValue;
+use maplit::hashmap;
+use serde_json::json;
+
+mod utils;
+
+static QUERY: &str = r#"
+    mutation ExecuteUserProgramMutation($id: ID!) {
+        executeUserProgram(input: { id: $id }) {
+            status {
+                __typename
+            }
+        }
+    }
+"#;
+
+/// Test that the correct values are recorded for each stat type.
+#[test]
+fn test_execute_user_program_stats() {
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+    let conn = runner.db_conn();
+
+    let hw_spec = HardwareSpecFactory::default()
+        .name("HW 1")
+        .num_registers(2)
+        .num_stacks(1)
+        .insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .input(vec![1])
+        .expected_output(vec![1])
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .source_code(
+            "
+            READ RX0
+            JMP END
+
+            ; these instructions count even though they never get executed
+            ; the stack/reg references count too
+            PUSH RX0 S0
+            POP S0 RX1
+            END: ; doesn't count as an instruction
+            WRITE RX0
+            ",
+        )
+        .insert(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": {
+                        "__typename": "ProgramSuccessOutput",
+                        // TODO check stats here once API is fleshed out
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+
+    // For now, check the PBs because we have a func for it. Once the API is
+    // done, we can get the stats directly from the response above
+    assert_eq!(
+        models::UserProgramRecord::load_pbs_x(conn, user.id, program_spec.id)
+            .unwrap(),
+        Some(models::UserProgramRecordStats {
+            cpu_cycles: 3,
+            instructions: 5,
+            registers_used: 2,
+            stacks_used: 1,
+        })
+    );
+}
+
+/// Test that PB values get updated properly on subsequent executions. We want
+/// to make sure that ONLY stats that are actually better get updated. Stats
+/// that equal or are worse than the PB shouldn't be written to the PB table.
+#[test]
+fn test_execute_user_program_pb_update() {
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+    let conn = runner.db_conn();
+
+    let hw_spec = HardwareSpecFactory::default()
+        .name("HW 1")
+        .num_stacks(1)
+        .insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .input(vec![1])
+        .expected_output(vec![1])
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .source_code("READ RX0\nWRITE RX0")
+        .insert(conn);
+
+    // this solution is better in one stat (registers) but worse in another
+    // (cpu cycles, instructions)
+    let better_user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("better.gdlk")
+        .source_code("READ RZR\nADD RZR 1\nWRITE 1")
+        .insert(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": {
+                        "__typename": "ProgramSuccessOutput",
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+
+    // Check that PBs are correct
+    assert_eq!(
+        models::UserProgramRecord::load_pbs_x(conn, user.id, program_spec.id)
+            .unwrap(),
+        Some(models::UserProgramRecordStats {
+            cpu_cycles: 2,
+            instructions: 2,
+            registers_used: 1,
+            stacks_used: 0,
+        })
+    );
+
+    // Test that only PBs that are better get updated
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(better_user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": {
+                        "__typename": "ProgramSuccessOutput",
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+
+    // registers_used PB should've improved, but the rest are the same
+    assert_eq!(
+        models::UserProgramRecord::load_pbs_x(conn, user.id, program_spec.id)
+            .unwrap(),
+        Some(models::UserProgramRecordStats {
+            cpu_cycles: 2,
+            instructions: 2,
+            registers_used: 0,
+            stacks_used: 0,
+        })
+    );
+}
+
+/// Test that we get the correct output format when the program fails to compile
+#[test]
+fn test_execute_user_program_compile_error() {
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+    let conn = runner.db_conn();
+
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .source_code("READ RX0\nWRITE RX2")
+        .insert(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": {
+                        "__typename": "ProgramCompileError"
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Test that we get the correct output format when the program has a runtime
+/// error
+#[test]
+fn test_execute_user_program_runtime_error() {
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+    let conn = runner.db_conn();
+
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .input(vec![1])
+        .expected_output(vec![1])
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .source_code("READ RX0\nREAD RX0")
+        .insert(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": {
+                        "__typename": "ProgramRuntimeError"
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Test that we get the correct output format when the program terminates
+/// but has the incorrect output (doesn't match `expected_output` from the
+/// program spec)
+#[test]
+fn test_execute_user_program_incorrect_output() {
+    let mut context_builder = ContextBuilder::new();
+    let user = context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+    let conn = runner.db_conn();
+
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .input(vec![1])
+        .expected_output(vec![1])
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .source_code("READ RX0\nWRITE 2")
+        .insert(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": {
+                        "__typename": "ProgramFailureOutput"
+                    }
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Executing an unknown user_program ID gives a null in the response
+#[test]
+fn test_execute_user_program_unknown_id() {
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar("bogus"),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": serde_json::Value::Null
+                }
+            }),
+            vec![]
+        )
+    );
+}
+
+/// Executing someone else's program should behave like the program doesn't
+/// exist
+#[test]
+fn test_execute_user_program_wrong_owner() {
+    let mut context_builder = ContextBuilder::new();
+    context_builder.log_in(&[]);
+    let runner = QueryRunner::new(context_builder);
+    let conn = runner.db_conn();
+
+    let other_user = UserFactory::default().username("other").insert(conn);
+
+    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
+    let program_spec = ProgramSpecFactory::default()
+        .name("prog1")
+        .hardware_spec(&hw_spec)
+        .insert(conn);
+    let user_program = UserProgramFactory::default()
+        .user(&other_user)
+        .program_spec(&program_spec)
+        .file_name("solution.gdlk")
+        .source_code("READ RX0\nWRITE RX0")
+        .insert(conn);
+
+    assert_eq!(
+        runner.query(
+            QUERY,
+            hashmap! {
+                "id" => InputValue::scalar(user_program.id.to_string()),
+            }
+        ),
+        (
+            json!({
+                "executeUserProgram": {
+                    "status": serde_json::Value::Null
+                }
+            }),
+            vec![]
+        )
+    );
+}


### PR DESCRIPTION
Adds some minimal API shit to allow executing programs server side. This will execute the program and, if successful, store statistical perf data on it. The API isn't fully fleshed out, but all the data we need is being stored. The next step is to add more fields into the API output that we have (hence all the TODOs). After that we can add some more API stuff to actually read leaderboard data, then after that we can do UI.