### PR TITLE
Flesh out leaderboard API more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 pkg/
+.DS_Store
 **/node_modules/
 **/build/
 **/target/

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -407,36 +407,37 @@ type UserProgramNode implements Node {
   UUID for this node.
   """
   id: ID! @juniper(infallible: true, ownership: "owned")
-
   """
   Name for this source file. This is unique among the user-program spec pair.
   """
   fileName: String! @juniper(infallible: true)
-
   """
   The program source code.
   """
   sourceCode: String! @juniper(infallible: true)
-
   """
   The date/time when this object was created.
   """
   created: DateTimeUtc! @juniper(infallible: true)
-
   """
   The date/time when this object was last modified.
   """
   lastModified: DateTimeUtc! @juniper(infallible: true)
-
   """
   The user who owns this program code.
   """
   user: UserNode! @juniper(ownership: "owned")
-
   """
   The program spec for which this code was written.
   """
   programSpec: ProgramSpecNode! @juniper(ownership: "owned")
+  """
+  A statistical record of the last execution of this program. Will be null if
+  the program hasn't been executed since the source was last modified. This is
+  populated whenever the program is executed with a successful termination, and
+  cleared whenever the source code is modified.
+  """
+  record: UserProgramRecordNode @juniper(ownership: "owned")
 }
 
 """
@@ -469,6 +470,48 @@ type UserProgramConnection implements ConnectionInterface {
   The queried user programs.
   """
   edges: [UserProgramEdge!]! @juniper(ownership: "owned")
+}
+
+"""
+A record of a single execution of a program. Holds metadata about the execution,
+include performance stats.
+"""
+type UserProgramRecordNode implements Node {
+  """
+  UUID for this node.
+  """
+  id: ID! @juniper(infallible: true, ownership: "owned")
+  """
+  The number of steps the program took before terminating.
+  """
+  cpuCycles: Int! @juniper(infallible: true, ownership: "owned")
+  """
+  The number of instructions in the compiled program. Unlike with CPU cycles,
+  for this stat, every instruction is counted only once, regardless of how many
+  times it's executed, even if it's never executed at all. This does not include
+  labels, only executable steps.
+  """
+  instructions: Int! @juniper(infallible: true, ownership: "owned")
+  """
+  The number of unique user registers (e.g. RX0, RX1, etc.) REFERENCED by the
+  program. If a register is only referenced by dead code, it will still be
+  counted for this statistic; a register **does not** actually need to be
+  accessed at runtime in order to count. A register that is referenced in
+  multiple places will only count once.
+  """
+  registersUsed: Int! @juniper(infallible: true, ownership: "owned")
+  """
+  The number of unique stacks (e.g. S0, S1, etc.) REFERENCED by the
+  program. If a stack is only referenced by dead code, it will still be
+  counted for this statistic; a stack **does not** actually need to be
+  accessed at runtime in order to count. A stack that is referenced in
+  multiple places will only count once.
+  """
+  stacksUsed: Int! @juniper(infallible: true, ownership: "owned")
+  """
+  The date/time when the program execution completed.
+  """
+  created: DateTimeUtc! @juniper(infallible: true)
 }
 
 # +-----------------------------+
@@ -875,36 +918,51 @@ input ExecuteUserProgramInput {
   id: ID!
 }
 
-# type ProgramError {
-#   # TODO add message + span
-#   todo: Int! @juniper(infallible: true, ownership: "owned")
-# }
+"""
+An error in a program that can be mapped to a particular chunk of source code.
+Could be a compile error or a runtime error.
+"""
+type ProgramError {
+  """
+  The error as a formatted string.
+  """
+  message: String! @juniper(infallible: true)
+  # If we end up processing this data on the UI, we may want to add more fields
+  # here like span
+}
 
-# type MachineState {
-#   # TODO add fields
-#   todo: Int! @juniper(infallible: true, ownership: "owned")
-# }
+"""
+Machines are used to execute GDLK code. Each program executions occurs within
+the context of a single machine. A MachineState gives a snapshot of an
+executing machine at a particular moment.
+"""
+type MachineState {
+  """
+  The number of instructions that have been executed so far. This is non-unique,
+  meaning if an instruction is executed twice, it will take up 2 cycles.
+  """
+  cpuCycles: Int! @juniper(infallible: true, ownership: "owned")
+  # We may want to add more fields here, punting on that for now
+}
 
 """
 Program execution failed with one or more compilation errors.
 """
 type ProgramCompileError {
-  # TODO add errors here
   """
-  TODO
+  The error(s) that caused compilation to fail.
   """
-  todo: Int! @juniper(infallible: true, ownership: "owned")
+  errors: [ProgramError!]! @juniper(infallible: true)
 }
 
 """
 Program execution failed with a runtime error.
 """
 type ProgramRuntimeError {
-  # TODO add error here
   """
-  TODO
+  The error that caused the program to fail.
   """
-  todo: Int! @juniper(infallible: true, ownership: "owned")
+  error: ProgramError! @juniper(infallible: true)
 }
 
 """
@@ -912,11 +970,10 @@ Execution output when a program compiles and executes without error, but the
 final state doesn't match the expected state (as defined by the program spec).
 """
 type ProgramRejectedOutput {
-  # TODO add machine
   """
-  TODO
+  The machine state at the time of program termination.
   """
-  todo: Int! @juniper(infallible: true, ownership: "owned")
+  machine: MachineState! @juniper(infallible: true)
 }
 
 """
@@ -926,11 +983,15 @@ Execution output when a program executes successfully.
 3. At the end, the input is empty and the output matches the program spec
 """
 type ProgramAcceptedOutput {
-  # TODO add machine + stats
   """
-  TODO
+  The machine state at the time of program termination.
   """
-  todo: Int! @juniper(infallible: true, ownership: "owned")
+  machine: MachineState! @juniper(infallible: true)
+  """
+  The statisical record of this program execution. Stores metadata about the
+  execution.
+  """
+  record: UserProgramRecordNode! @juniper(infallible: true)
 }
 
 """

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -3,13 +3,26 @@
 //! API. Utility types/functions live in `internal`. Specific models live in
 //! their own files.
 
+// juniper_from_schema creates enums that violate this, nothing we can do about
+// that
+#![allow(clippy::large_enum_variant)]
+
+mod hardware_spec;
+mod internal;
+mod mutation;
+mod program;
+mod program_spec;
+mod user;
+mod user_program;
+mod user_program_record;
+
 use crate::{
     error::{ApiError, IntDecodeError, ResponseResult},
     models,
     schema::hardware_specs,
     server::gql::{
         hardware_spec::*, mutation::*, program::*, program_spec::*, user::*,
-        user_program::*,
+        user_program::*, user_program_record::*,
     },
     util::Valid,
     views::RequestContext,
@@ -19,14 +32,6 @@ use juniper_from_schema::graphql_schema_from_file;
 use serde::{Serialize, Serializer};
 use std::convert::TryInto;
 use validator::{Validate, ValidationError, ValidationErrors};
-
-mod hardware_spec;
-mod internal;
-mod mutation;
-mod program;
-mod program_spec;
-mod user;
-mod user_program;
 
 graphql_schema_from_file!(
     "schema.graphql",

--- a/api/src/server/gql/program.rs
+++ b/api/src/server/gql/program.rs
@@ -3,82 +3,142 @@
 
 use crate::{
     server::gql::{
-        ProgramAcceptedOutputFields, ProgramCompileErrorFields,
+        MachineStateFields, ProgramAcceptedOutputFields,
+        ProgramCompileErrorFields, ProgramErrorFields,
         ProgramRejectedOutputFields, ProgramRuntimeErrorFields,
+        UserProgramRecordNode,
     },
     views::RequestContext,
 };
+use gdlk::{
+    error::{SourceError, SourceErrorWrapper, WithSource},
+    Machine,
+};
+use juniper_from_schema::{QueryTrail, Walked};
+use std::convert::TryInto;
 
-// TODO fill out these fields properly
-
-// #[derive(Clone, Debug)]
-// pub struct ProgramError {}
-
-// impl ProgramErrorFields for ProgramError {
-//     fn field_todo(
-//         &self,
-//         _executor: &juniper::Executor<'_, RequestContext>,
-//     ) -> i32 {
-//         0
-//     }
-// }
-
-// #[derive(Clone, Debug)]
-// pub struct MachineState {}
-
-// impl MachineStateFields for MachineState {
-//     fn field_todo(
-//         &self,
-//         _executor: &juniper::Executor<'_, RequestContext>,
-//     ) -> i32 {
-//         0
-//     }
-// }
-
+/// See description in schema.graphql
 #[derive(Clone, Debug)]
-pub struct ProgramCompileError {}
+pub struct ProgramError {
+    pub message: String,
+}
+
+impl<E: SourceError> From<&SourceErrorWrapper<E>> for ProgramError {
+    fn from(other: &SourceErrorWrapper<E>) -> Self {
+        Self {
+            message: other.to_string(),
+        }
+    }
+}
+
+impl ProgramError {
+    pub fn from_source_error<E: SourceError>(
+        error: &WithSource<E>,
+    ) -> Vec<Self> {
+        error.errors().iter().map(|err| err.into()).collect()
+    }
+}
+
+impl ProgramErrorFields for ProgramError {
+    fn field_message(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> &String {
+        &self.message
+    }
+}
+
+/// See description in schema.graphql
+#[derive(Clone, Debug)]
+pub struct MachineState {
+    pub machine: Machine,
+}
+
+impl From<Machine> for MachineState {
+    fn from(machine: Machine) -> Self {
+        Self { machine }
+    }
+}
+
+impl MachineStateFields for MachineState {
+    fn field_cpu_cycles(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        // CPU cycles are capped at 1 million so easily in i32 range
+        self.machine.cycle_count().try_into().unwrap()
+    }
+}
+
+/// See description in schema.graphql
+#[derive(Clone, Debug)]
+pub struct ProgramCompileError {
+    pub errors: Vec<ProgramError>,
+}
 
 impl ProgramCompileErrorFields for ProgramCompileError {
-    fn field_todo(
+    fn field_errors(
         &self,
         _executor: &juniper::Executor<'_, RequestContext>,
-    ) -> i32 {
-        0
+        _trail: &QueryTrail<'_, ProgramError, Walked>,
+    ) -> &Vec<ProgramError> {
+        &self.errors
     }
 }
 
+/// See description in schema.graphql
 #[derive(Clone, Debug)]
-pub struct ProgramRuntimeError {}
+pub struct ProgramRuntimeError {
+    pub error: ProgramError,
+}
 
 impl ProgramRuntimeErrorFields for ProgramRuntimeError {
-    fn field_todo(
+    fn field_error(
         &self,
         _executor: &juniper::Executor<'_, RequestContext>,
-    ) -> i32 {
-        0
+        _trail: &QueryTrail<'_, ProgramError, Walked>,
+    ) -> &ProgramError {
+        &self.error
     }
 }
 
+/// See description in schema.graphql
 #[derive(Clone, Debug)]
-pub struct ProgramRejectedOutput {}
+pub struct ProgramRejectedOutput {
+    pub machine_state: MachineState,
+}
 
 impl ProgramRejectedOutputFields for ProgramRejectedOutput {
-    fn field_todo(
+    fn field_machine(
         &self,
         _executor: &juniper::Executor<'_, RequestContext>,
-    ) -> i32 {
-        0
+        _trail: &QueryTrail<'_, MachineState, Walked>,
+    ) -> &MachineState {
+        &self.machine_state
     }
 }
 
+/// See description in schema.graphql
 #[derive(Clone, Debug)]
-pub struct ProgramAcceptedOutput {}
+pub struct ProgramAcceptedOutput {
+    pub machine_state: MachineState,
+    pub user_program_record: UserProgramRecordNode,
+}
 
 impl ProgramAcceptedOutputFields for ProgramAcceptedOutput {
-    fn field_todo(
+    fn field_machine(
         &self,
         _executor: &juniper::Executor<'_, RequestContext>,
-    ) -> i32 {
-        0
+        _trail: &QueryTrail<'_, MachineState, Walked>,
+    ) -> &MachineState {
+        &self.machine_state
+    }
+
+    fn field_record(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+        _trail: &QueryTrail<'_, UserProgramRecordNode, Walked>,
+    ) -> &UserProgramRecordNode {
+        &self.user_program_record
     }
 }

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -4,6 +4,7 @@ use crate::{
     schema::user_programs,
     server::gql::{
         internal::{GenericEdge, NodeType},
+        user_program_record::UserProgramRecordNode,
         ConnectionPageParams, CopyUserProgramPayloadFields,
         CreateUserProgramPayloadFields, Cursor, DeleteUserProgramPayloadFields,
         ExecuteUserProgramPayloadFields, ExecuteUserProgramStatus, PageInfo,
@@ -99,6 +100,24 @@ impl UserProgramNodeFields for UserProgramNode {
             self.user_program.program_spec_id,
         )?
         .into())
+    }
+
+    fn field_record(
+        &self,
+        executor: &juniper::Executor<'_, RequestContext>,
+        _trail: &QueryTrail<'_, UserProgramRecordNode, Walked>,
+    ) -> ResponseResult<Option<UserProgramRecordNode>> {
+        let node_opt = match self.user_program.record_id {
+            None => None,
+            Some(record_id) => Some(
+                UserProgramRecordNode::find(
+                    executor.context().db_conn(),
+                    record_id,
+                )?
+                .into(),
+            ),
+        };
+        Ok(node_opt)
     }
 }
 

--- a/api/src/server/gql/user_program_record.rs
+++ b/api/src/server/gql/user_program_record.rs
@@ -1,0 +1,78 @@
+use crate::{
+    models,
+    schema::user_program_records,
+    server::gql::{
+        internal::NodeType, RequestContext, UserProgramRecordNodeFields,
+    },
+    util,
+};
+use chrono::{offset::Utc, DateTime};
+use diesel::{PgConnection, QueryDsl, QueryResult, RunQueryDsl};
+use juniper::ID;
+use uuid::Uuid;
+
+/// See description in schema.graphql
+#[derive(Clone, Debug)]
+pub struct UserProgramRecordNode {
+    pub user_program_record: models::UserProgramRecord,
+}
+
+impl From<models::UserProgramRecord> for UserProgramRecordNode {
+    fn from(model: models::UserProgramRecord) -> Self {
+        Self {
+            user_program_record: model,
+        }
+    }
+}
+
+impl NodeType for UserProgramRecordNode {
+    type Model = models::UserProgramRecord;
+
+    fn find(conn: &PgConnection, id: Uuid) -> QueryResult<Self::Model> {
+        user_program_records::table.find(id).get_result(conn)
+    }
+}
+
+impl UserProgramRecordNodeFields for UserProgramRecordNode {
+    fn field_id(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> ID {
+        util::uuid_to_gql_id(self.user_program_record.id)
+    }
+
+    fn field_cpu_cycles(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        self.user_program_record.cpu_cycles
+    }
+
+    fn field_instructions(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        self.user_program_record.instructions
+    }
+
+    fn field_registers_used(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        self.user_program_record.registers_used
+    }
+
+    fn field_stacks_used(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> i32 {
+        self.user_program_record.stacks_used
+    }
+
+    fn field_created(
+        &self,
+        _executor: &juniper::Executor<'_, RequestContext>,
+    ) -> &DateTime<Utc> {
+        &self.user_program_record.created
+    }
+}

--- a/api/src/util/auth.rs
+++ b/api/src/util/auth.rs
@@ -15,7 +15,6 @@ pub async fn oidc_http_client(
 ) -> Result<openidconnect::HttpResponse, ActixClientError> {
     // There are some unfortunate clones in here because the types we have don't
     // always allow moving the data.
-    // TODO there's probably still room for improvement here
 
     let client = actix_web::client::Client::default();
 
@@ -68,7 +67,6 @@ pub async fn oidc_request_token(
         Some(id_token) => {
             // TODO better nonce handling here
             match id_token.claims(&token_verifier, &Nonce::new("4".into())) {
-                // TODO remove clone
                 Ok(claims) => Ok(claims.clone()),
                 Err(source) => Err(ApiError::from_client_error(source)),
             }


### PR DESCRIPTION
Adds more output fields to the `executeUserProgram` API. This should be everything we need for that API, after this the next thing we need is fields to read leaderboard stats for a particular program_spec.

You can basically just focus on the API schema and make sure that looks good. All the rust code is pretty straightforward from there. There are a bunch of fields (particularly in `ProgramError` and `MachineState`) that I left out just because we don't need them now. Would be pretty easy to add them later if we need them.