### PR TITLE
Rename ResponseError to ApiError

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cargo run -p gdlk_cli -- run --hardware hw.json --program prog.json -s prog.gdlk
 In the repo root, run:
 
 ```sh
-cd api && cargo make secrets && cd.. # Only needed on first execution
+cd api && cargo make secrets && cd .. # Only needed on first execution
 # Enter your username and the new token as your password
 docker-compose up
 ```

--- a/api/src/models/permission.rs
+++ b/api/src/models/permission.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ResponseError, ServerError},
+    error::{ApiError, ServerError},
     schema::permissions,
 };
 use diesel::{Identifiable, Queryable};
@@ -46,7 +46,7 @@ impl PermissionType {
 }
 
 impl FromStr for PermissionType {
-    type Err = ResponseError;
+    type Err = ApiError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         for (permission_type, name) in NAME_MAPPING {

--- a/api/src/models/role.rs
+++ b/api/src/models/role.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ResponseError, ResponseResult, ServerError},
+    error::{ApiError, ResponseResult, ServerError},
     schema::roles,
 };
 use diesel::{Identifiable, Queryable};
@@ -35,7 +35,7 @@ impl RoleType {
 }
 
 impl FromStr for RoleType {
-    type Err = ResponseError;
+    type Err = ApiError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         for (role_type, name) in NAME_MAPPING {

--- a/api/src/server/auth.rs
+++ b/api/src/server/auth.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{OpenIdConfig, ProviderConfig},
-    error::ResponseError,
+    error::ApiError,
     models::NewUserProvider,
     schema::user_providers,
     util::{self, Pool},
@@ -131,7 +131,7 @@ pub async fn route_login(
     let provider_name: &str = &params.0;
     let oidc_client = client_map.get_client(provider_name)?;
     let conn =
-        &pool.get().map_err(ResponseError::from_server_error)? as &PgConnection;
+        &pool.get().map_err(ApiError::from_server_error)? as &PgConnection;
 
     // Parse the state param and validate the CSRF token in there
     let auth_state = AuthState::deserialize(query.state.as_deref())?;
@@ -156,7 +156,7 @@ pub async fn route_login(
             .filter(user_providers::columns::provider_name.eq(provider_name))
             .get_result(conn)
             .optional()
-            .map_err(ResponseError::from_server_error)?;
+            .map_err(ApiError::from_server_error)?;
 
         match existing_id {
             // user_provider doesn't exist, add a new one
@@ -168,7 +168,7 @@ pub async fn route_login(
             .insert()
             .returning(user_providers::columns::id)
             .get_result(conn)
-            .map_err(ResponseError::from_server_error)?,
+            .map_err(ApiError::from_server_error)?,
             Some(existing_id) => existing_id,
         }
     };

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -4,7 +4,7 @@
 //! their own files.
 
 use crate::{
-    error::{IntDecodeError, ResponseError, ResponseResult},
+    error::{ApiError, IntDecodeError, ResponseResult},
     models,
     schema::hardware_specs,
     server::gql::{
@@ -31,7 +31,7 @@ mod user_program;
 graphql_schema_from_file!(
     "schema.graphql",
     context_type: RequestContext,
-    error_type: ResponseError
+    error_type: ApiError
 );
 
 // To make our context usable by Juniper, we have to implement a marker trait.

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ClientError, ResponseError, ResponseResult},
+    error::{ApiError, ClientError, ResponseResult},
     models,
     schema::users,
     server::gql::{
@@ -97,7 +97,7 @@ impl AuthStatusFields for AuthStatus {
         match executor.context().user() {
             Ok(user) => Ok(Some(user.clone().into_model().into())),
             // User isn't authed or hasn't finished setup
-            Err(ResponseError::Client {
+            Err(ApiError::Client {
                 source: ClientError::Unauthenticated,
                 ..
             }) => Ok(None),

--- a/api/src/server/mod.rs
+++ b/api/src/server/mod.rs
@@ -6,7 +6,7 @@ mod gql;
 pub use crate::server::gql::{create_gql_schema, GqlSchema};
 use crate::{
     config::GdlkConfig,
-    error::ResponseError,
+    error::ApiError,
     server::auth::{logout_route, route_authorize, route_login},
     util::{self, Pool},
     views::RequestContext,
@@ -37,7 +37,7 @@ async fn route_graphql(
     // Auth cookie holds a user provider ID - if populated, parse it
     let user_provider_id = identity.identity().map(|id| util::parse_uuid(&id));
     let context = RequestContext::load_context(
-        pool.get().map_err(ResponseError::from_server_error)?,
+        pool.get().map_err(ApiError::from_server_error)?,
         user_provider_id,
     )?;
     let response = web::block(move || {

--- a/api/src/util/auth.rs
+++ b/api/src/util/auth.rs
@@ -1,5 +1,5 @@
 use crate::error::{
-    ActixClientError, ClientError, ResponseError, ResponseResult, ServerError,
+    ActixClientError, ApiError, ClientError, ResponseResult, ServerError,
 };
 use openidconnect::{
     core::{CoreClient, CoreIdTokenClaims},
@@ -56,7 +56,7 @@ pub async fn oidc_request_token(
         .exchange_code(AuthorizationCode::new(code.into()))
         .request_async(oidc_http_client)
         .await
-        .map_err(ResponseError::from_client_error)?;
+        .map_err(ApiError::from_client_error)?;
 
     // Verify the response token and get the claims out of it
     let token_verifier = oidc_client.id_token_verifier();
@@ -70,7 +70,7 @@ pub async fn oidc_request_token(
             match id_token.claims(&token_verifier, &Nonce::new("4".into())) {
                 // TODO remove clone
                 Ok(claims) => Ok(claims.clone()),
-                Err(source) => Err(ResponseError::from_client_error(source)),
+                Err(source) => Err(ApiError::from_client_error(source)),
             }
         }
     }
@@ -115,7 +115,7 @@ impl AuthState {
             None => Err(ClientError::CsrfError.into()),
             Some(json_str) => {
                 let state: Self = serde_json::from_str(json_str)
-                    .map_err(ResponseError::from_client_error)?;
+                    .map_err(ApiError::from_client_error)?;
                 // TODO make this secure
                 if "3" == state.csrf_token.secret() {
                     Ok(state)

--- a/api/src/views/user.rs
+++ b/api/src/views/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ClientError, DbErrorConverter, ResponseError, ResponseResult},
+    error::{ApiError, ClientError, DbErrorConverter, ResponseResult},
     models,
     schema::{user_providers, users},
     views::{RequestContext, UserContext, View},
@@ -41,7 +41,7 @@ impl<'a> View for InitializeUserView<'a> {
                 // fail.
                 conn.build_transaction()
                     .repeatable_read()
-                    .run::<models::User, ResponseError, _>(|| {
+                    .run::<models::User, ApiError, _>(|| {
                         let create_user_result: Result<models::User, _> =
                             new_user
                                 .insert()


### PR DESCRIPTION
Renamed `ResponseError` to `ApiError` to avoid naming conflict with `actix_web::ResponseError`