### PR TITLE
Auto-save programs and some cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ volumes:
   api_build:
   frontend_core_build:
   frontend_wasm_build:
-  frontend_wasm_pkg:
   frontend_node_modules:
 
 services:
@@ -46,7 +45,6 @@ services:
       - ./:/app:rw
       - frontend_core_build:/app/target
       - frontend_wasm_build:/app/wasm/target
-      - frontend_wasm_pkg:/app/wasm/pkg
       - frontend_node_modules:/app/frontend/node_modules
     ports:
       - "3000:3000"

--- a/frontend/src/components/ide/AutoSaveHandler.tsx
+++ b/frontend/src/components/ide/AutoSaveHandler.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useContext, useEffect } from 'react';
+import graphql from 'babel-plugin-relay/macro';
+import { Snackbar } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import { IdeContext } from 'state/ide';
+import { useMutation } from 'relay-hooks';
+import { AutoSaveHandler_Mutation } from './__generated__/AutoSaveHandler_Mutation.graphql';
+import { createFragmentContainer, RelayProp } from 'react-relay';
+import { AutoSaveHandler_userProgram } from './__generated__/AutoSaveHandler_userProgram.graphql';
+import useDebouncedValue from 'hooks/useDebouncedValue';
+
+const saveUserProgramMutation = graphql`
+  mutation AutoSaveHandler_Mutation($id: ID!, $sourceCode: String!) {
+    updateUserProgram(input: { id: $id, sourceCode: $sourceCode }) {
+      userProgramEdge {
+        node {
+          sourceCode
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Component to automatically save edits to source code. Includes a snack bar
+ * status indicator.
+ */
+const AutoSaveHandler: React.FC<{
+  userProgram: AutoSaveHandler_userProgram;
+  relay: RelayProp;
+}> = ({ userProgram }) => {
+  const { sourceCode } = useContext(IdeContext);
+  // Debounce changes so we're not sending constant requests
+  const debouncedSourceCode = useDebouncedValue(sourceCode, 1000);
+  const [mutate, { loading }] = useMutation<AutoSaveHandler_Mutation>(
+    saveUserProgramMutation
+  );
+  const [saveState, setSaveState] = useState<'success' | 'error' | undefined>();
+
+  useEffect(() => {
+    // If the user has changed the source code, save the new value
+    if (debouncedSourceCode !== userProgram.sourceCode) {
+      mutate({
+        variables: {
+          id: userProgram.id,
+          sourceCode: debouncedSourceCode,
+        },
+        onCompleted: () => setSaveState('success'),
+        onError: () => setSaveState('error'),
+      });
+    }
+  }, [debouncedSourceCode, userProgram.sourceCode, userProgram.id, mutate]);
+
+  return (
+    <>
+      <Snackbar
+        open={!loading && saveState === 'success'}
+        onClose={() => setSaveState(undefined)}
+      >
+        <Alert severity="success">Solution saved</Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={!loading && saveState === 'error'}
+        onClose={() => setSaveState(undefined)}
+      >
+        <Alert severity="error">Error saving program</Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default createFragmentContainer(AutoSaveHandler, {
+  userProgram: graphql`
+    fragment AutoSaveHandler_userProgram on UserProgramNode {
+      id
+      sourceCode
+    }
+  `,
+});

--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -1,23 +1,22 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { RelayProp, createFragmentContainer } from 'react-relay';
 import graphql from 'babel-plugin-relay/macro';
 import { ProgramIde_hardwareSpec } from './__generated__/ProgramIde_hardwareSpec.graphql';
 import { makeStyles } from '@material-ui/core';
 import CodeEditor from './CodeEditor';
 import RegistersInfo from './RegistersInfo';
-import { IdeContextType, IdeContext, CompiledState } from 'state/ide';
+import { IdeContextType, IdeContext } from 'state/ide';
 import IoInfo from './IoInfo';
 import StackInfo from './StackInfo';
 import IdeControls from './IdeControls';
 import ProgramStatus from './ProgramStatus';
-import { CompileResult, CompilerWrapper } from 'util/compile';
-import { HardwareSpec, ProgramSpec } from 'gdlk_wasm';
 import useDebouncedValue from 'hooks/useDebouncedValue';
 import { assertIsDefined } from 'util/guards';
 import NotFoundPage from 'components/NotFoundPage';
 import { StorageHandler } from 'util/storage';
 import useStaticValue from 'hooks/useStaticValue';
 import PromptOnExit from 'components/common/PromptOnExit';
+import useCompiler from './useCompiler';
 
 const useLocalStyles = makeStyles(({ palette, spacing }) => {
   const border = `2px solid ${palette.divider}`;
@@ -83,105 +82,6 @@ const ProgramIde: React.FC<{
   const userProgram = programSpec.userProgram;
   assertIsDefined(userProgram);
 
-  // These values come from wasm. They're read only, so they're safe to share
-  // with the whole component tree. They are pointers and therefore updates
-  // won't trigger re-renders, but these values shouldn't be changing while
-  // this component tree is mounted anyway.
-  const wasmHardwareSpec = useStaticValue(
-    () =>
-      new HardwareSpec(
-        hardwareSpec.numRegisters,
-        hardwareSpec.numStacks,
-        hardwareSpec.maxStackLength
-      )
-  );
-  const wasmProgramSpec = useStaticValue(
-    () =>
-      new ProgramSpec(
-        Int32Array.from(programSpec.input),
-        Int32Array.from(programSpec.expectedOutput)
-      )
-  );
-
-  // This wasm value is NOT safe to share outside this component. It's stored
-  // in a ref because it contains pointers, which often don't reflect changed
-  // values to React. As such, making it a state field would be useless. This
-  // value has to be manually transformed into compiledState after changes.
-  const compileResult = useRef<CompileResult | undefined>();
-
-  // This is the safe version of the wasm values, which CAN be shared
-  const [compiledState, setCompiledState] = useState<
-    CompiledState | undefined
-  >();
-
-  /**
-   * A manual function called to refresh the shared state that's derived from
-   * the wasm compiled state. This needs to be called explicitly because there
-   * are values in wasm hidden behind pointers. When the values change, the
-   * pointers stay the same, so React doesn't recognize that a change has
-   * occurred. By copying this state into our own JS objects, we allow React to
-   * do its normal updates whenever there's changes.
-   *
-   * @param newCompileResult The new value of compilation output. If not given
-   */
-  const updateCompiledState = useCallback(
-    (newCompileResult: CompileResult | undefined): void => {
-      // Update refs
-      compileResult.current = newCompileResult;
-
-      switch (newCompileResult?.type) {
-        case 'compiled':
-          setCompiledState({
-            type: 'compiled',
-            instructions: newCompileResult.instructions,
-            machineState: newCompileResult.machine.state,
-          });
-          break;
-        case 'error':
-          setCompiledState({
-            type: 'error',
-            errors: newCompileResult.errors,
-          });
-          break;
-        case undefined:
-          setCompiledState(undefined);
-          break;
-      }
-    },
-    [compileResult]
-  );
-
-  /**
-   * Compile the given source code, and update the compiled state with the
-   * new compiled program.
-   *
-   * @param source The source code to compile
-   */
-  const compile = useCallback(
-    (source: string): void => {
-      updateCompiledState(
-        CompilerWrapper.compile(wasmHardwareSpec, wasmProgramSpec, source)
-      );
-    },
-    [wasmHardwareSpec, wasmProgramSpec, updateCompiledState]
-  );
-
-  const execute = useCallback(
-    (executeAll: boolean = false): void => {
-      if (compileResult.current?.type === 'compiled') {
-        compileResult.current.machine.execute(executeAll);
-        // We need to manually refresh since the wasm pointers won't change
-        updateCompiledState(compileResult.current);
-      } else {
-        // This indicates an FE bug, where we tried to step when not allowed
-        throw new Error(
-          'Program is not compiled, cannot execute next instruction.'
-        );
-      }
-    },
-    [compileResult, updateCompiledState]
-  );
-
   // This will be used to read and write source from/to browser local storage
   const sourceStorageHandler = useStaticValue<StorageHandler<string>>(
     () =>
@@ -202,6 +102,14 @@ const ProgramIde: React.FC<{
     return userProgram.sourceCode;
   });
 
+  const {
+    wasmHardwareSpec,
+    wasmProgramSpec,
+    compiledState,
+    compile,
+    execute,
+  } = useCompiler({ hardwareSpec, sourceCode });
+
   // When the source changes, save it to local storage and recompile
   // Use a debounce to prevent constant recompilation
   const debouncedSourceCode = useDebouncedValue(sourceCode, 250);
@@ -209,13 +117,6 @@ const ProgramIde: React.FC<{
     sourceStorageHandler.set(debouncedSourceCode);
     compile(debouncedSourceCode);
   }, [sourceStorageHandler, debouncedSourceCode, compile]);
-
-  // When either spec or the source changes, invalidate the compiled program
-  useEffect(() => {
-    // Do this as a post-effect so that it doesn't run on first render. That
-    // prevents us wiping out state right after we compile
-    return () => updateCompiledState(undefined);
-  }, [wasmHardwareSpec, wasmProgramSpec, sourceCode, updateCompiledState]);
 
   const contextValue: IdeContextType = {
     wasmHardwareSpec,

--- a/frontend/src/components/ide/ProgramIde.tsx
+++ b/frontend/src/components/ide/ProgramIde.tsx
@@ -9,6 +9,7 @@ import { IdeContextType, IdeContext } from 'state/ide';
 import IoInfo from './IoInfo';
 import StackInfo from './StackInfo';
 import IdeControls from './IdeControls';
+import AutoSaveHandler from './AutoSaveHandler';
 import ProgramStatus from './ProgramStatus';
 import useDebouncedValue from 'hooks/useDebouncedValue';
 import { assertIsDefined } from 'util/guards';
@@ -134,13 +135,11 @@ const ProgramIde: React.FC<{
         <RegistersInfo className={localClasses.registersInfo} />
         <IoInfo className={localClasses.ioInfo} />
         <ProgramStatus className={localClasses.programStatus} />
-        <IdeControls
-          className={localClasses.controls}
-          userProgram={userProgram}
-        />
+        <IdeControls className={localClasses.controls} />
         <StackInfo className={localClasses.stackInfo} />
         <CodeEditor className={localClasses.editor} />
 
+        <AutoSaveHandler userProgram={userProgram} />
         {/* Prompt on exit for unsaved changes */}
         <PromptOnExit
           when={sourceCode !== userProgram.sourceCode}
@@ -186,7 +185,7 @@ export default createFragmentContainer(ProgramIdeWrapper, {
           id
           sourceCode
           lastModified
-          ...IdeControls_userProgram
+          ...AutoSaveHandler_userProgram
         }
       }
     }

--- a/frontend/src/components/ide/useCompiler.ts
+++ b/frontend/src/components/ide/useCompiler.ts
@@ -1,0 +1,147 @@
+import { HardwareSpec, ProgramSpec } from 'gdlk_wasm';
+import useStaticValue from 'hooks/useStaticValue';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { CompiledState } from 'state/ide';
+import { CompileResult, CompilerWrapper } from 'util/compile';
+import { assertIsDefined } from 'util/guards';
+import { ProgramIde_hardwareSpec } from './__generated__/ProgramIde_hardwareSpec.graphql';
+
+interface Input {
+  hardwareSpec: ProgramIde_hardwareSpec;
+  sourceCode: string;
+}
+
+interface Output {
+  wasmHardwareSpec: HardwareSpec;
+  wasmProgramSpec: ProgramSpec;
+  compiledState: CompiledState | undefined;
+  compile: (source: string) => void;
+  execute: (executeAll?: boolean) => void;
+}
+
+/**
+ * A helper hook that handles a lot of state management for the compiler.
+ * Because a lot of the state is stored in Wasm, we need some extra logic
+ * surrounding it to make sure it interacts properly with React. This hook
+ * encapsulates all that state, to make it easier to work with externally.
+ * @param hardwareSpec Hardware being compiled on
+ * @param sourceCode Current source code, as shown in the editor (NOT necessarily
+ *  what is saved server-side)
+ */
+const useCompiler = ({ hardwareSpec, sourceCode }: Input): Output => {
+  // If the program spec or the user program doesn't exist, freak out!!
+  const programSpec = hardwareSpec.programSpec;
+  assertIsDefined(programSpec);
+  const userProgram = programSpec.userProgram;
+  assertIsDefined(userProgram);
+
+  // These values come from wasm. They're read only, so they're safe to share
+  // with the whole component tree. They are pointers and therefore updates
+  // won't trigger re-renders, but these values shouldn't be changing while
+  // this component tree is mounted anyway.
+  const wasmHardwareSpec = useStaticValue(
+    () =>
+      new HardwareSpec(
+        hardwareSpec.numRegisters,
+        hardwareSpec.numStacks,
+        hardwareSpec.maxStackLength
+      )
+  );
+  const wasmProgramSpec = useStaticValue(
+    () =>
+      new ProgramSpec(
+        Int32Array.from(programSpec.input),
+        Int32Array.from(programSpec.expectedOutput)
+      )
+  );
+
+  // This wasm value is NOT safe to share outside this component. It's stored
+  // in a ref because it contains pointers, which often don't reflect changed
+  // values to React. As such, making it a state field would be useless. This
+  // value has to be manually transformed into compiledState after changes.
+  const compileResult = useRef<CompileResult | undefined>();
+
+  // This is the safe version of the wasm values, which CAN be shared
+  const [compiledState, setCompiledState] = useState<
+    CompiledState | undefined
+  >();
+
+  /**
+   * A manual function called to refresh the shared state that's derived from
+   * the wasm compiled state. This needs to be called explicitly because there
+   * are values in wasm hidden behind pointers. When the values change, the
+   * pointers stay the same, so React doesn't recognize that a change has
+   * occurred. By copying this state into our own JS objects, we allow React to
+   * do its normal updates whenever there's changes.
+   *
+   * @param newCompileResult The new value of compilation output. If not given
+   */
+  const updateCompiledState = useCallback(
+    (newCompileResult: CompileResult | undefined): void => {
+      // Update refs
+      compileResult.current = newCompileResult;
+
+      switch (newCompileResult?.type) {
+        case 'compiled':
+          setCompiledState({
+            type: 'compiled',
+            instructions: newCompileResult.instructions,
+            machineState: newCompileResult.machine.state,
+          });
+          break;
+        case 'error':
+          setCompiledState({
+            type: 'error',
+            errors: newCompileResult.errors,
+          });
+          break;
+        case undefined:
+          setCompiledState(undefined);
+          break;
+      }
+    },
+    [compileResult]
+  );
+
+  /**
+   * Compile the given source code, and update the compiled state with the
+   * new compiled program.
+   *
+   * @param source The source code to compile
+   */
+  const compile = useCallback(
+    (source: string): void => {
+      updateCompiledState(
+        CompilerWrapper.compile(wasmHardwareSpec, wasmProgramSpec, source)
+      );
+    },
+    [wasmHardwareSpec, wasmProgramSpec, updateCompiledState]
+  );
+
+  const execute = useCallback(
+    (executeAll: boolean = false): void => {
+      if (compileResult.current?.type === 'compiled') {
+        compileResult.current.machine.execute(executeAll);
+        // We need to manually refresh since the wasm pointers won't change
+        updateCompiledState(compileResult.current);
+      } else {
+        // This indicates an FE bug, where we tried to step when not allowed
+        throw new Error(
+          'Program is not compiled, cannot execute next instruction.'
+        );
+      }
+    },
+    [compileResult, updateCompiledState]
+  );
+
+  // When either spec or the source changes, invalidate the compiled program
+  useEffect(() => {
+    // Do this as a post-effect so that it doesn't run on first render. That
+    // prevents us wiping out state right after we compile
+    return () => updateCompiledState(undefined);
+  }, [wasmHardwareSpec, wasmProgramSpec, sourceCode, updateCompiledState]);
+
+  return { wasmHardwareSpec, wasmProgramSpec, compiledState, compile, execute };
+};
+
+export default useCompiler;


### PR DESCRIPTION
- Replaced the Save button on the IDE with an auto-save feature
  - If the user stops editing for 1 second, it saves their changes
- Moved a bunch of logic from `ProgramIde` into a separate hook called `useCompiler`
  - I didn't change the logic at all, but this should make it easier to work on the compiler mgt logic without that component getting huge