### PR TITLE
Rename ResponseResult to ApiResult

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -15,7 +15,7 @@ use std::{
 use thiserror::Error;
 use validator::{ValidationError, ValidationErrors, ValidationErrorsKind};
 
-pub type ResponseResult<T> = Result<T, ApiError>;
+pub type ApiResult<T> = Result<T, ApiError>;
 
 /// A response error that originated because of an error on the client's part.
 /// This could be invalid input, an invalid request URL, permission denied, etc.

--- a/api/src/models/role.rs
+++ b/api/src/models/role.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ApiError, ResponseResult, ServerError},
+    error::{ApiError, ApiResult, ServerError},
     schema::roles,
 };
 use diesel::{Identifiable, Queryable};
@@ -63,7 +63,7 @@ pub struct Role {
 }
 
 impl Role {
-    pub fn role_type(&self) -> ResponseResult<RoleType> {
+    pub fn role_type(&self) -> ApiResult<RoleType> {
         self.name.parse()
     }
 }

--- a/api/src/models/user_program_record.rs
+++ b/api/src/models/user_program_record.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use crate::{error::ResponseResult, schema::user_program_records};
+use crate::{error::ApiResult, schema::user_program_records};
 use chrono::{DateTime, Utc};
 use diesel::{
     dsl, expression::bound::Bound, query_builder::InsertStatement, sql_types,
@@ -89,7 +89,7 @@ impl UserProgramRecord {
         conn: &PgConnection,
         user_id: Uuid,
         program_spec_id: Uuid,
-    ) -> ResponseResult<Option<UserProgramRecordStats>> {
+    ) -> ApiResult<Option<UserProgramRecordStats>> {
         // TODO switch to a GROUP BY after https://github.com/diesel-rs/diesel/issues/210
 
         // Load all records for this user+program_spec

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::ResponseResult,
+    error::ApiResult,
     models,
     schema::{hardware_specs, program_specs},
     server::gql::{
@@ -90,7 +90,7 @@ impl HardwareSpecNodeFields for HardwareSpecNode {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramSpecNode, Walked>,
         slug: String,
-    ) -> ResponseResult<Option<ProgramSpecNode>> {
+    ) -> ApiResult<Option<ProgramSpecNode>> {
         // Get program spec by hardware spec + slug
         Ok(
             models::ProgramSpec::filter_by_hardware_spec(self.hardware_spec.id)
@@ -107,7 +107,7 @@ impl HardwareSpecNodeFields for HardwareSpecNode {
         _trail: &QueryTrail<'_, ProgramSpecConnection, Walked>,
         first: Option<i32>,
         after: Option<Cursor>,
-    ) -> ResponseResult<ProgramSpecConnection> {
+    ) -> ApiResult<ProgramSpecConnection> {
         ProgramSpecConnection::new(self.hardware_spec.id, first, after)
     }
 }
@@ -137,16 +137,13 @@ pub struct HardwareSpecConnection {
 }
 
 impl HardwareSpecConnection {
-    pub fn new(
-        first: Option<i32>,
-        after: Option<Cursor>,
-    ) -> ResponseResult<Self> {
+    pub fn new(first: Option<i32>, after: Option<Cursor>) -> ApiResult<Self> {
         Ok(Self {
             page_params: ConnectionPageParams::new(first, after)?,
         })
     }
 
-    fn get_total_count(&self, context: &RequestContext) -> ResponseResult<i32> {
+    fn get_total_count(&self, context: &RequestContext) -> ApiResult<i32> {
         match hardware_specs::table
             .select(dsl::count_star())
             .get_result::<i64>(context.db_conn())
@@ -160,7 +157,7 @@ impl HardwareSpecConnection {
     fn get_edges(
         &self,
         context: &RequestContext,
-    ) -> ResponseResult<Vec<HardwareSpecEdge>> {
+    ) -> ApiResult<Vec<HardwareSpecEdge>> {
         let offset = self.page_params.offset();
 
         // Load data from the query
@@ -182,7 +179,7 @@ impl HardwareSpecConnectionFields for HardwareSpecConnection {
     fn field_total_count(
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
-    ) -> ResponseResult<i32> {
+    ) -> ApiResult<i32> {
         self.get_total_count(executor.context())
     }
 
@@ -190,7 +187,7 @@ impl HardwareSpecConnectionFields for HardwareSpecConnection {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, PageInfo, Walked>,
-    ) -> ResponseResult<PageInfo> {
+    ) -> ApiResult<PageInfo> {
         Ok(PageInfo::from_page_params(
             &self.page_params,
             self.get_total_count(executor.context())?,
@@ -201,7 +198,7 @@ impl HardwareSpecConnectionFields for HardwareSpecConnection {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
-    ) -> ResponseResult<Vec<HardwareSpecEdge>> {
+    ) -> ApiResult<Vec<HardwareSpecEdge>> {
         self.get_edges(executor.context())
     }
 }

--- a/api/src/server/gql/internal.rs
+++ b/api/src/server/gql/internal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::ResponseResult,
+    error::ApiResult,
     server::gql::{
         hardware_spec::HardwareSpecNode, program_spec::ProgramSpecNode,
         user::UserNode, user_program::UserProgramNode, Cursor, Node,
@@ -15,7 +15,7 @@ use uuid::Uuid;
 const ALL_NODES_GET_BY_ID: &[&dyn Fn(
     &PgConnection,
     Uuid,
-) -> ResponseResult<Option<Node>>] = &[
+) -> ApiResult<Option<Node>>] = &[
     &HardwareSpecNode::get_by_id,
     &ProgramSpecNode::get_by_id,
     &UserNode::get_by_id,
@@ -34,10 +34,7 @@ pub trait NodeType: Sized + Into<Node> {
     /// A wrapper around [Self::find] that converts the result into an
     /// `Option<Node>`, so that it has a uniform output type with all other
     /// node types.
-    fn get_by_id(
-        conn: &PgConnection,
-        id: Uuid,
-    ) -> ResponseResult<Option<Node>> {
+    fn get_by_id(conn: &PgConnection, id: Uuid) -> ApiResult<Option<Node>> {
         Ok(Self::find(conn, id)
             .optional()?
             // Self::Model -> Self -> Node
@@ -91,7 +88,7 @@ impl<N: NodeType> GenericEdge<N> {
 pub fn get_by_id_from_all_types(
     context: &RequestContext,
     id: &juniper::ID,
-) -> ResponseResult<Option<Node>> {
+) -> ApiResult<Option<Node>> {
     let conn = context.db_conn();
     let uuid_id = util::gql_id_to_uuid(id);
 

--- a/api/src/server/gql/mod.rs
+++ b/api/src/server/gql/mod.rs
@@ -17,7 +17,7 @@ mod user_program;
 mod user_program_record;
 
 use crate::{
-    error::{ApiError, IntDecodeError, ResponseResult},
+    error::{ApiError, ApiResult, IntDecodeError},
     models,
     schema::hardware_specs,
     server::gql::{
@@ -58,7 +58,7 @@ impl QueryFields for Query {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, Node, Walked>,
         id: juniper::ID,
-    ) -> ResponseResult<Option<Node>> {
+    ) -> ApiResult<Option<Node>> {
         internal::get_by_id_from_all_types(&executor.context(), &id)
     }
 
@@ -67,7 +67,7 @@ impl QueryFields for Query {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserNode, Walked>,
         username: String,
-    ) -> ResponseResult<Option<UserNode>> {
+    ) -> ApiResult<Option<UserNode>> {
         Ok(models::User::filter_by_username(&username)
             .get_result::<models::User>(executor.context().db_conn())
             .optional()?
@@ -87,7 +87,7 @@ impl QueryFields for Query {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecNode, Walked>,
         slug: String,
-    ) -> ResponseResult<Option<HardwareSpecNode>> {
+    ) -> ApiResult<Option<HardwareSpecNode>> {
         Ok(hardware_specs::table
             .filter(hardware_specs::dsl::slug.eq(&slug))
             .get_result::<models::HardwareSpec>(executor.context().db_conn())
@@ -101,7 +101,7 @@ impl QueryFields for Query {
         _trail: &QueryTrail<'_, HardwareSpecConnection, Walked>,
         first: Option<i32>,
         after: Option<Cursor>,
-    ) -> ResponseResult<HardwareSpecConnection> {
+    ) -> ApiResult<HardwareSpecConnection> {
         HardwareSpecConnection::new(first, after)
     }
 }

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::ResponseResult,
+    error::ApiResult,
     server::gql::{
         program::ProgramError, CopyUserProgramInput, CopyUserProgramPayload,
         CreateHardwareSpecInput, CreateHardwareSpecPayload,
@@ -28,7 +28,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, InitializeUserPayload, Walked>,
         input: InitializeUserInput,
-    ) -> ResponseResult<InitializeUserPayload> {
+    ) -> ApiResult<InitializeUserPayload> {
         let view = views::InitializeUserView {
             context: executor.context(),
             username: &input.username,
@@ -42,7 +42,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, CreateHardwareSpecPayload, Walked>,
         input: CreateHardwareSpecInput,
-    ) -> ResponseResult<CreateHardwareSpecPayload> {
+    ) -> ApiResult<CreateHardwareSpecPayload> {
         let view = views::CreateHardwareSpecView {
             context: executor.context(),
             name: &input.name,
@@ -60,7 +60,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UpdateHardwareSpecPayload, Walked>,
         input: UpdateHardwareSpecInput,
-    ) -> ResponseResult<UpdateHardwareSpecPayload> {
+    ) -> ApiResult<UpdateHardwareSpecPayload> {
         let view = views::UpdateHardwareSpecView {
             context: executor.context(),
             id: util::gql_id_to_uuid(&input.id),
@@ -79,7 +79,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, CreateProgramSpecPayload, Walked>,
         input: CreateProgramSpecInput,
-    ) -> ResponseResult<CreateProgramSpecPayload> {
+    ) -> ApiResult<CreateProgramSpecPayload> {
         let view = views::CreateProgramSpecView {
             context: executor.context(),
             hardware_spec_id: util::gql_id_to_uuid(&input.hardware_spec_id),
@@ -98,7 +98,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UpdateProgramSpecPayload, Walked>,
         input: UpdateProgramSpecInput,
-    ) -> ResponseResult<UpdateProgramSpecPayload> {
+    ) -> ApiResult<UpdateProgramSpecPayload> {
         let view = views::UpdateProgramSpecView {
             context: executor.context(),
             id: util::gql_id_to_uuid(&input.id),
@@ -117,7 +117,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, CreateUserProgramPayload, Walked>,
         input: CreateUserProgramInput,
-    ) -> ResponseResult<CreateUserProgramPayload> {
+    ) -> ApiResult<CreateUserProgramPayload> {
         let view = views::CreateUserProgramView {
             context: executor.context(),
             program_spec_id: util::gql_id_to_uuid(&input.program_spec_id),
@@ -135,7 +135,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UpdateUserProgramPayload, Walked>,
         input: UpdateUserProgramInput,
-    ) -> ResponseResult<UpdateUserProgramPayload> {
+    ) -> ApiResult<UpdateUserProgramPayload> {
         let view = views::UpdateUserProgramView {
             context: executor.context(),
             id: util::gql_id_to_uuid(&input.id),
@@ -152,7 +152,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, CopyUserProgramPayload, Walked>,
         input: CopyUserProgramInput,
-    ) -> ResponseResult<CopyUserProgramPayload> {
+    ) -> ApiResult<CopyUserProgramPayload> {
         let view = views::CopyUserProgramView {
             context: executor.context(),
             id: util::gql_id_to_uuid(&input.id),
@@ -167,7 +167,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, DeleteUserProgramPayload, Walked>,
         input: DeleteUserProgramInput,
-    ) -> ResponseResult<DeleteUserProgramPayload> {
+    ) -> ApiResult<DeleteUserProgramPayload> {
         let view = views::DeleteUserProgramView {
             context: executor.context(),
             id: util::gql_id_to_uuid(&input.id),
@@ -182,7 +182,7 @@ impl MutationFields for Mutation {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, ExecuteUserProgramPayload, Walked>,
         input: ExecuteUserProgramInput,
-    ) -> ResponseResult<ExecuteUserProgramPayload> {
+    ) -> ApiResult<ExecuteUserProgramPayload> {
         let view = views::ExecuteUserProgramView {
             context: executor.context(),
             id: util::gql_id_to_uuid(&input.id),

--- a/api/src/server/gql/program_spec.rs
+++ b/api/src/server/gql/program_spec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::ResponseResult,
+    error::ApiResult,
     models,
     schema::{program_specs, user_programs},
     server::gql::{
@@ -100,7 +100,7 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecNode, Walked>,
-    ) -> ResponseResult<HardwareSpecNode> {
+    ) -> ApiResult<HardwareSpecNode> {
         Ok(HardwareSpecNode::find(
             &executor.context().db_conn(),
             self.program_spec.hardware_spec_id,
@@ -113,7 +113,7 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramNode, Walked>,
         file_name: String,
-    ) -> ResponseResult<Option<UserProgramNode>> {
+    ) -> ApiResult<Option<UserProgramNode>> {
         let context = executor.context();
         let user_id = context.user()?.id;
 
@@ -134,7 +134,7 @@ impl ProgramSpecNodeFields for ProgramSpecNode {
         _trail: &QueryTrail<'_, UserProgramConnection, Walked>,
         first: Option<i32>,
         after: Option<Cursor>,
-    ) -> ResponseResult<UserProgramConnection> {
+    ) -> ApiResult<UserProgramConnection> {
         let user_id = executor.context().user()?.id;
         UserProgramConnection::new(user_id, self.program_spec.id, first, after)
     }
@@ -170,14 +170,14 @@ impl ProgramSpecConnection {
         hardware_spec_id: Uuid,
         first: Option<i32>,
         after: Option<Cursor>,
-    ) -> ResponseResult<Self> {
+    ) -> ApiResult<Self> {
         Ok(Self {
             hardware_spec_id,
             page_params: ConnectionPageParams::new(first, after)?,
         })
     }
 
-    fn get_total_count(&self, context: &RequestContext) -> ResponseResult<i32> {
+    fn get_total_count(&self, context: &RequestContext) -> ApiResult<i32> {
         match program_specs::table
             .filter(models::ProgramSpec::with_hardware_spec(
                 self.hardware_spec_id,
@@ -194,7 +194,7 @@ impl ProgramSpecConnection {
     fn get_edges(
         &self,
         context: &RequestContext,
-    ) -> ResponseResult<Vec<ProgramSpecEdge>> {
+    ) -> ApiResult<Vec<ProgramSpecEdge>> {
         let offset = self.page_params.offset();
 
         // Load data from the query
@@ -221,7 +221,7 @@ impl ProgramSpecConnectionFields for ProgramSpecConnection {
     fn field_total_count(
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
-    ) -> ResponseResult<i32> {
+    ) -> ApiResult<i32> {
         self.get_total_count(executor.context())
     }
 
@@ -229,7 +229,7 @@ impl ProgramSpecConnectionFields for ProgramSpecConnection {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, PageInfo, Walked>,
-    ) -> ResponseResult<PageInfo> {
+    ) -> ApiResult<PageInfo> {
         Ok(PageInfo::from_page_params(
             &self.page_params,
             self.get_total_count(executor.context())?,
@@ -240,7 +240,7 @@ impl ProgramSpecConnectionFields for ProgramSpecConnection {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramSpecEdge, Walked>,
-    ) -> ResponseResult<Vec<ProgramSpecEdge>> {
+    ) -> ApiResult<Vec<ProgramSpecEdge>> {
         self.get_edges(executor.context())
     }
 }

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ApiError, ClientError, ResponseResult},
+    error::{ApiError, ApiResult, ClientError},
     models,
     schema::users,
     server::gql::{
@@ -91,7 +91,7 @@ impl AuthStatusFields for AuthStatus {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserNode, Walked>,
-    ) -> ResponseResult<Option<UserNode>> {
+    ) -> ApiResult<Option<UserNode>> {
         // We have all the user data we need in the request context, no need
         // to do another query
         match executor.context().user() {

--- a/api/src/server/gql/user_program.rs
+++ b/api/src/server/gql/user_program.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::ResponseResult,
+    error::ApiResult,
     models,
     schema::user_programs,
     server::gql::{
@@ -82,7 +82,7 @@ impl UserProgramNodeFields for UserProgramNode {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserNode, Walked>,
-    ) -> ResponseResult<UserNode> {
+    ) -> ApiResult<UserNode> {
         Ok(UserNode::find(
             executor.context().db_conn(),
             self.user_program.user_id,
@@ -94,7 +94,7 @@ impl UserProgramNodeFields for UserProgramNode {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramSpecNode, Walked>,
-    ) -> ResponseResult<ProgramSpecNode> {
+    ) -> ApiResult<ProgramSpecNode> {
         Ok(ProgramSpecNode::find(
             executor.context().db_conn(),
             self.user_program.program_spec_id,
@@ -106,7 +106,7 @@ impl UserProgramNodeFields for UserProgramNode {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramRecordNode, Walked>,
-    ) -> ResponseResult<Option<UserProgramRecordNode>> {
+    ) -> ApiResult<Option<UserProgramRecordNode>> {
         let node_opt = match self.user_program.record_id {
             None => None,
             Some(record_id) => Some(
@@ -153,7 +153,7 @@ impl UserProgramConnection {
         program_spec_id: Uuid,
         first: Option<i32>,
         after: Option<Cursor>,
-    ) -> ResponseResult<Self> {
+    ) -> ApiResult<Self> {
         Ok(Self {
             user_id,
             program_spec_id,
@@ -161,7 +161,7 @@ impl UserProgramConnection {
         })
     }
 
-    fn get_total_count(&self, context: &RequestContext) -> ResponseResult<i32> {
+    fn get_total_count(&self, context: &RequestContext) -> ApiResult<i32> {
         match models::UserProgram::filter_by_user_and_program_spec(
             self.user_id,
             self.program_spec_id,
@@ -178,7 +178,7 @@ impl UserProgramConnection {
     fn get_edges(
         &self,
         context: &RequestContext,
-    ) -> ResponseResult<Vec<UserProgramEdge>> {
+    ) -> ApiResult<Vec<UserProgramEdge>> {
         let offset = self.page_params.offset();
 
         // Load data from the query
@@ -206,7 +206,7 @@ impl UserProgramConnectionFields for UserProgramConnection {
     fn field_total_count(
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
-    ) -> ResponseResult<i32> {
+    ) -> ApiResult<i32> {
         self.get_total_count(executor.context())
     }
 
@@ -214,7 +214,7 @@ impl UserProgramConnectionFields for UserProgramConnection {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, PageInfo, Walked>,
-    ) -> ResponseResult<PageInfo> {
+    ) -> ApiResult<PageInfo> {
         Ok(PageInfo::from_page_params(
             &self.page_params,
             self.get_total_count(executor.context())?,
@@ -225,7 +225,7 @@ impl UserProgramConnectionFields for UserProgramConnection {
         &self,
         executor: &juniper::Executor<'_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramEdge, Walked>,
-    ) -> ResponseResult<Vec<UserProgramEdge>> {
+    ) -> ApiResult<Vec<UserProgramEdge>> {
         self.get_edges(executor.context())
     }
 }

--- a/api/src/util/auth.rs
+++ b/api/src/util/auth.rs
@@ -1,5 +1,5 @@
 use crate::error::{
-    ActixClientError, ApiError, ClientError, ResponseResult, ServerError,
+    ActixClientError, ApiError, ApiResult, ClientError, ServerError,
 };
 use openidconnect::{
     core::{CoreClient, CoreIdTokenClaims},
@@ -49,7 +49,7 @@ pub async fn oidc_http_client(
 pub async fn oidc_request_token(
     oidc_client: &CoreClient,
     code: &str,
-) -> ResponseResult<CoreIdTokenClaims> {
+) -> ApiResult<CoreIdTokenClaims> {
     // Exchange the temp code for a token
     let token_response = oidc_client
         .exchange_code(AuthorizationCode::new(code.into()))
@@ -108,7 +108,7 @@ impl AuthState {
 
     /// Deserialize input from the user into auth state. This will also
     /// validate the CSRF token in the param.
-    pub fn deserialize(input: Option<&str>) -> ResponseResult<Self> {
+    pub fn deserialize(input: Option<&str>) -> ApiResult<Self> {
         match input {
             None => Err(ClientError::CsrfError.into()),
             Some(json_str) => {

--- a/api/src/views/hardware_spec.rs
+++ b/api/src/views/hardware_spec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ClientError, DbErrorConverter, ResponseResult},
+    error::{ApiResult, ClientError, DbErrorConverter},
     models,
     schema::hardware_specs,
     views::{RequestContext, View},
@@ -20,7 +20,7 @@ pub struct CreateHardwareSpecView<'a> {
 impl<'a> View for CreateHardwareSpecView<'a> {
     type Output = models::HardwareSpec;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         let user = self.context.user()?;
         if user.has_permission(models::PermissionType::CreateSpecs) {
             Ok(())
@@ -29,7 +29,7 @@ impl<'a> View for CreateHardwareSpecView<'a> {
         }
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         // User a helper type to do the insert
         let new_hardware_spec = models::NewHardwareSpec {
             name: self.name,
@@ -67,7 +67,7 @@ pub struct UpdateHardwareSpecView<'a> {
 impl<'a> View for UpdateHardwareSpecView<'a> {
     type Output = Option<models::HardwareSpec>;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         let user = self.context.user()?;
         if user.has_permission(models::PermissionType::ModifyAllSpecs) {
             Ok(())
@@ -76,7 +76,7 @@ impl<'a> View for UpdateHardwareSpecView<'a> {
         }
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         // User a helper type to do the insert
         let modified_hardware_spec = models::ModifiedHardwareSpec {
             id: self.id,

--- a/api/src/views/mod.rs
+++ b/api/src/views/mod.rs
@@ -8,7 +8,7 @@ mod program_spec;
 mod user;
 mod user_program;
 
-use crate::error::ResponseResult;
+use crate::error::ApiResult;
 pub use context::*;
 pub use hardware_spec::*;
 pub use program_spec::*;
@@ -22,11 +22,11 @@ pub use user_program::*;
 pub trait View {
     type Output;
 
-    fn check_permissions(&self) -> ResponseResult<()>;
+    fn check_permissions(&self) -> ApiResult<()>;
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output>;
+    fn execute_internal(&self) -> ApiResult<Self::Output>;
 
-    fn execute(&self) -> ResponseResult<Self::Output> {
+    fn execute(&self) -> ApiResult<Self::Output> {
         self.check_permissions()?;
         self.execute_internal()
     }

--- a/api/src/views/program_spec.rs
+++ b/api/src/views/program_spec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ClientError, DbErrorConverter, ResponseResult},
+    error::{ApiResult, ClientError, DbErrorConverter},
     models,
     schema::program_specs,
     views::{RequestContext, View},
@@ -21,7 +21,7 @@ pub struct CreateProgramSpecView<'a> {
 impl<'a> View for CreateProgramSpecView<'a> {
     type Output = models::ProgramSpec;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         let user = self.context.user()?;
         if user.has_permission(models::PermissionType::CreateSpecs) {
             Ok(())
@@ -30,7 +30,7 @@ impl<'a> View for CreateProgramSpecView<'a> {
         }
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         // User a helper type to do the insert
         let new_program_spec = models::NewProgramSpec {
             hardware_spec_id: self.hardware_spec_id,
@@ -71,7 +71,7 @@ pub struct UpdateProgramSpecView<'a> {
 impl<'a> View for UpdateProgramSpecView<'a> {
     type Output = Option<models::ProgramSpec>;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         let user = self.context.user()?;
         if user.has_permission(models::PermissionType::ModifyAllSpecs) {
             Ok(())
@@ -80,7 +80,7 @@ impl<'a> View for UpdateProgramSpecView<'a> {
         }
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         // Use a helper type to do the insert
         let modified_program_spec = models::ModifiedProgramSpec {
             id: self.id,

--- a/api/src/views/user.rs
+++ b/api/src/views/user.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ApiError, ClientError, DbErrorConverter, ResponseResult},
+    error::{ApiError, ApiResult, ClientError, DbErrorConverter},
     models,
     schema::{user_providers, users},
     views::{RequestContext, UserContext, View},
@@ -16,13 +16,13 @@ pub struct InitializeUserView<'a> {
 impl<'a> View for InitializeUserView<'a> {
     type Output = models::User;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         // Since we're directly handling the user context in this view, we
         // handle all the not-logged-in logic directly during execution.
         Ok(())
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         // The user should be logged in, but not had a User object created yet
         match self.context.user_context {
             Some(UserContext {

--- a/api/src/views/user_program.rs
+++ b/api/src/views/user_program.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 
 use crate::{
-    error::{DbErrorConverter, ResponseResult},
+    error::{ApiResult, DbErrorConverter},
     models,
     schema::{
         hardware_specs, program_specs, user_program_records, user_programs,
@@ -29,11 +29,11 @@ pub struct CreateUserProgramView<'a> {
 impl<'a> View for CreateUserProgramView<'a> {
     type Output = models::UserProgram;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         Ok(())
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         let user = self.context.user()?;
         let new_user_program = models::NewUserProgram {
             user_id: user.id,
@@ -73,11 +73,11 @@ pub struct UpdateUserProgramView<'a> {
 impl<'a> View for UpdateUserProgramView<'a> {
     type Output = Option<models::UserProgram>;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         Ok(())
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         let user = self.context.user()?;
         let modified_user_program = models::ModifiedUserProgram {
             id: self.id,
@@ -122,11 +122,11 @@ pub struct CopyUserProgramView<'a> {
 impl<'a> View for CopyUserProgramView<'a> {
     type Output = Option<models::UserProgram>;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         Ok(())
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         let conn = self.context.db_conn();
         let user = self.context.user()?;
 
@@ -167,11 +167,11 @@ pub struct DeleteUserProgramView<'a> {
 impl<'a> View for DeleteUserProgramView<'a> {
     type Output = Option<Uuid>;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         Ok(())
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         let user = self.context.user()?;
 
         // User has to own the program to delete it
@@ -221,7 +221,7 @@ impl<'a> ExecuteUserProgramView<'a> {
         &self,
         program_spec_id: Uuid,
         machine: &Machine,
-    ) -> ResponseResult<models::UserProgramRecord> {
+    ) -> ApiResult<models::UserProgramRecord> {
         let conn = self.context.db_conn();
         let user = self.context.user()?;
         let program = machine.program();
@@ -258,11 +258,11 @@ impl<'a> ExecuteUserProgramView<'a> {
 impl<'a> View for ExecuteUserProgramView<'a> {
     type Output = Option<ExecuteUserProgramOutput>;
 
-    fn check_permissions(&self) -> ResponseResult<()> {
+    fn check_permissions(&self) -> ApiResult<()> {
         Ok(())
     }
 
-    fn execute_internal(&self) -> ResponseResult<Self::Output> {
+    fn execute_internal(&self) -> ApiResult<Self::Output> {
         let user = self.context.user()?;
         let conn = self.context.db_conn();
 


### PR DESCRIPTION
Rename `ResponseResult` -> `ApiResult`, to make the `ResponseError` -> `ApiError` change that Stefan made.