### PR TITLE
Run OIDC provider init concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "diesel",
  "diesel-factories",
  "env_logger",
+ "futures",
  "gdlk",
  "juniper",
  "juniper-from-schema",

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ DEBUG=1 cargo make test
 We use nightly Rust. Here's a list of reasons why. If this list every gets empty, we should switch to stable.
 
 - Rust features
+  - [async_closure](https://github.com/rust-lang/rust/issues/62290)
   - [backtrace](https://github.com/rust-lang/rust/issues/53487)
   - [or_patterns](https://github.com/rust-lang/rust/issues/54883)
 - Rustfmt

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,6 +21,7 @@ chrono = "0.4"
 config = {version = "0.10", default-features = false, features = ["json"]}
 diesel = {version = "^1.4.3", default-features = false, features = ["chrono", "postgres", "r2d2", "uuidv07"]}
 env_logger = "0.7"
+futures = "0.3"
 gdlk = {path = "../core"}
 juniper = {version = "0.14.2", default-features = false, features = ["chrono"]}
 # juniper-from-schema = "0.5.2"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![feature(async_closure)]
 #![feature(backtrace)]
 
 // Diesel hasn't fully moved to Rust 2018 yet so we need this


### PR DESCRIPTION
Made provider init concurrent. These will still run on one thread, but since the bottleneck is network I/O, that should still improve perf a ton once we start adding more providers. I ran a test just to make sure this works (I just duplicated the google provider):

```
api_1       | making client: google
api_1       | making client: google2
api_1       | done with: google2
api_1       | done with: google
api_1       | [2020-11-03T01:46:56Z INFO  actix_server::builder] Starting 8 workers
api_1       | [2020-11-03T01:46:56Z INFO  actix_server::builder] Starting "actix-web-service-0.0.0.0:8000" service on 0.0.0.0:8000
```

so it's definitely launching all the HTTP requests before waiting for any to resolve.