### PR TITLE
Fix slow shutdown on API container

### DIFF
--- a/api/Makefile.toml
+++ b/api/Makefile.toml
@@ -47,7 +47,7 @@ done
 [tasks.start]
 dependencies = ["db-setup"]
 command = "cargo"
-args = ["watch", "-x", "run -- server"]
+args = ["watch", "-x", "run"]
 
 [tasks.secrets]
 script = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
   api:
     image: gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
     command: cargo make -p docker start
+    init: true # Workaround for cargo-watch bug that prevents graceful restart
     tty: true # Colorize output
     volumes:
       - ./:/app:rw


### PR DESCRIPTION
Watchexec, which is the lib that cargo-watch uses, has a big where if it's run as PID 1, it doesn't die gracefully from SIGINT/SIGTERM. That's why when you ctrl-c the docker-compose stack, it takes 10 seconds for the API container to shut down. Docker sengs SIGTERM, waits 10s, then SIGKILL to hard kill it. With `init: true` though, cargo-watch isn't PID 1 so it works fine. ez clap