### PR TITLE
Upgrade to async juniper (no async resolvers implemented yet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,9 +384,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -532,6 +532,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11f16001d679cb13d14b2c93c7d0fa13bb484a87c34a6c4c39707ad936499b5"
+dependencies = [
+ "base64 0.12.3",
+ "chrono",
+ "hex",
+ "lazy_static",
+ "linked-hash-map",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 
 [[package]]
 name = "cfg-if"
@@ -763,6 +779,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_utils"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64196eb9f551916167225134f1e8a90f0b5774331d3c900d6328fd94bafe3544"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "diesel"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +951,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1006,17 @@ name = "futures-core"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+
+[[package]]
+name = "futures-enum"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f3979efb3aea70991b7fd261a40decddae71f8bdfd8b2982cc8442e8f6813a"
+dependencies = [
+ "derive_utils",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
 
 [[package]]
 name = "futures-executor"
@@ -1137,12 +1185,12 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "graphql-parser"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
+checksum = "d1abd4ce5247dfc04a03ccde70f87a048458c9356c7e41d21ad8c407b3dde6f2"
 dependencies = [
  "combine",
- "failure",
+ "thiserror",
 ]
 
 [[package]]
@@ -1188,6 +1236,12 @@ checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hostname"
@@ -1317,15 +1371,19 @@ dependencies = [
 [[package]]
 name = "juniper"
 version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f662ba51e2fbc3d6dd1ca66be70b44963606a34473156abddcb0351fc6caa668"
+source = "git+https://github.com/graphql-rust/juniper?branch=master#a4871887bb6b30029bd4671af716c0649a0cc60c"
 dependencies = [
+ "async-trait",
+ "bson",
  "chrono",
  "fnv",
+ "futures",
+ "futures-enum",
+ "graphql-parser",
  "indexmap",
  "juniper_codegen",
  "serde",
- "serde_derive",
+ "static_assertions",
  "url",
  "uuid",
 ]
@@ -1333,16 +1391,17 @@ dependencies = [
 [[package]]
 name = "juniper-from-schema"
 version = "0.5.2"
-source = "git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround#2e9941d425972d03d8aab9080be67199dfbc062a"
+source = "git+https://github.com/davidpdrsn/juniper-from-schema?branch=master#0b30c69996d4bb0e81b461f4d05a924c502564e3"
 dependencies = [
+ "futures",
  "juniper",
- "juniper-from-schema-code-gen",
+ "juniper-from-schema-proc-macro",
 ]
 
 [[package]]
 name = "juniper-from-schema-code-gen"
 version = "0.5.2"
-source = "git+https://github.com/LucasPickering/juniper-from-schema?branch=fragment-bug-workaround#2e9941d425972d03d8aab9080be67199dfbc062a"
+source = "git+https://github.com/davidpdrsn/juniper-from-schema?branch=master#0b30c69996d4bb0e81b461f4d05a924c502564e3"
 dependencies = [
  "colored",
  "graphql-parser",
@@ -1353,11 +1412,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "juniper-from-schema-proc-macro"
+version = "0.5.2"
+source = "git+https://github.com/davidpdrsn/juniper-from-schema?branch=master#0b30c69996d4bb0e81b461f4d05a924c502564e3"
+dependencies = [
+ "juniper-from-schema-code-gen",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "juniper_codegen"
 version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40af234d8e971a9d7dda93ffbcc8a44a93f17e69e3067f72ce7a6894c41d51b"
+source = "git+https://github.com/graphql-rust/juniper?branch=master#a4871887bb6b30029bd4671af716c0649a0cc60c"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.48",
@@ -2067,6 +2135,7 @@ version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2092,12 +2161,12 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest",
  "opaque-debug",
@@ -2238,18 +2307,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2485,10 +2554,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -2497,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "serde",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -23,17 +23,18 @@ diesel = {version = "^1.4.3", default-features = false, features = ["chrono", "p
 env_logger = "0.7"
 futures = "0.3"
 gdlk = {path = "../core"}
-juniper = {version = "0.14.2", default-features = false, features = ["chrono"]}
-# We can switch back to stable once https://github.com/graphql-rust/juniper/issues/500 is fixed
+# Go back to stable once they release async support
+# juniper = {version = "0.14.2", default-features = false, features = ["chrono"]}
+juniper = {git = "https://github.com/graphql-rust/juniper", branch = "master", default-features = false, features = ["chrono"]}
 # juniper-from-schema = "0.5.2"
-juniper-from-schema = {git = "https://github.com/LucasPickering/juniper-from-schema", branch = "fragment-bug-workaround"}
+juniper-from-schema = {git = "https://github.com/davidpdrsn/juniper-from-schema", branch = "master"}
 log = "^0.4.8"
 openidconnect = {version = "2.0.0-alpha.1", default-features = false}
 r2d2 = "0.8"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0"
-uuid = {version = "^0.7.0", default-features = false, features = ["serde"]}
+uuid = {version = "^0.8.0", default-features = false, features = ["serde"]}
 validator = "0.10.1"
 validator_derive = "0.10.1"
 

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -2,10 +2,13 @@
 # lint-disable type-fields-sorted-alphabetically
 
 directive @juniper(
-  ownership: String = "borrowed"
+  async: Boolean = false
   infallible: Boolean = false
+  ownership: String = "borrowed"
+  stream_item_infallible: Boolean = true # lint-disable-line input-object-values-are-camel-cased
+  stream_type: String = null # lint-disable-line input-object-values-are-camel-cased
   with_time_zone: Boolean = true # lint-disable-line input-object-values-are-camel-cased
-) on FIELD_DEFINITION
+) on FIELD_DEFINITION | SCALAR
 
 """
 An opaque identifier that uniquely identifies an object within a connection.

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -112,7 +112,7 @@ pub enum ServerError {
         /// Should be a boxed reference to the column that the value was in.
         /// `Debug` is the best type constraint we can put on this, but this
         /// should always be something like `roles::columns::name`.
-        column: Box<dyn Debug>,
+        column: Box<dyn Debug + Send>,
         /// The invalid value.
         value: String,
     },

--- a/api/src/server/gql/hardware_spec.rs
+++ b/api/src/server/gql/hardware_spec.rs
@@ -45,49 +45,49 @@ impl NodeType for HardwareSpecNode {
 impl HardwareSpecNodeFields for HardwareSpecNode {
     fn field_id(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> ID {
         util::uuid_to_gql_id(self.hardware_spec.id)
     }
 
     fn field_slug(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &String {
         &self.hardware_spec.slug
     }
 
     fn field_name(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &String {
         &self.hardware_spec.name
     }
 
     fn field_num_registers(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.hardware_spec.num_registers
     }
 
     fn field_num_stacks(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.hardware_spec.num_stacks
     }
 
     fn field_max_stack_length(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.hardware_spec.max_stack_length
     }
 
     fn field_program_spec(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramSpecNode, Walked>,
         slug: String,
     ) -> ApiResult<Option<ProgramSpecNode>> {
@@ -95,7 +95,9 @@ impl HardwareSpecNodeFields for HardwareSpecNode {
         Ok(
             models::ProgramSpec::filter_by_hardware_spec(self.hardware_spec.id)
                 .filter(program_specs::dsl::slug.eq(&slug))
-                .get_result::<models::ProgramSpec>(executor.context().db_conn())
+                .get_result::<models::ProgramSpec>(
+                    &executor.context().db_conn()?,
+                )
                 .optional()?
                 .map(ProgramSpecNode::from),
         )
@@ -103,7 +105,7 @@ impl HardwareSpecNodeFields for HardwareSpecNode {
 
     fn field_program_specs(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramSpecConnection, Walked>,
         first: Option<i32>,
         after: Option<Cursor>,
@@ -117,7 +119,7 @@ pub type HardwareSpecEdge = GenericEdge<HardwareSpecNode>;
 impl HardwareSpecEdgeFields for HardwareSpecEdge {
     fn field_node(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecNode, Walked>,
     ) -> &HardwareSpecNode {
         self.node()
@@ -125,7 +127,7 @@ impl HardwareSpecEdgeFields for HardwareSpecEdge {
 
     fn field_cursor(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &Cursor {
         self.cursor()
     }
@@ -146,7 +148,7 @@ impl HardwareSpecConnection {
     fn get_total_count(&self, context: &RequestContext) -> ApiResult<i32> {
         match hardware_specs::table
             .select(dsl::count_star())
-            .get_result::<i64>(context.db_conn())
+            .get_result::<i64>(&context.db_conn()?)
         {
             // Convert i64 to i32 - if this fails, we're in a rough spot
             Ok(count) => Ok(count.try_into().unwrap()),
@@ -169,7 +171,7 @@ impl HardwareSpecConnection {
         }
 
         let rows: Vec<models::HardwareSpec> =
-            query.get_results(context.db_conn())?;
+            query.get_results(&context.db_conn()?)?;
 
         Ok(HardwareSpecEdge::from_db_rows(rows, offset))
     }
@@ -178,14 +180,14 @@ impl HardwareSpecConnection {
 impl HardwareSpecConnectionFields for HardwareSpecConnection {
     fn field_total_count(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> ApiResult<i32> {
         self.get_total_count(executor.context())
     }
 
     fn field_page_info(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, PageInfo, Walked>,
     ) -> ApiResult<PageInfo> {
         Ok(PageInfo::from_page_params(
@@ -196,7 +198,7 @@ impl HardwareSpecConnectionFields for HardwareSpecConnection {
 
     fn field_edges(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
     ) -> ApiResult<Vec<HardwareSpecEdge>> {
         self.get_edges(executor.context())
@@ -210,7 +212,7 @@ pub struct CreateHardwareSpecPayload {
 impl CreateHardwareSpecPayloadFields for CreateHardwareSpecPayload {
     fn field_hardware_spec_edge(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
     ) -> HardwareSpecEdge {
         GenericEdge::from_db_row(self.hardware_spec.clone(), 0)
@@ -224,7 +226,7 @@ pub struct UpdateHardwareSpecPayload {
 impl UpdateHardwareSpecPayloadFields for UpdateHardwareSpecPayload {
     fn field_hardware_spec_edge(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, HardwareSpecEdge, Walked>,
     ) -> Option<HardwareSpecEdge> {
         self.hardware_spec

--- a/api/src/server/gql/internal.rs
+++ b/api/src/server/gql/internal.rs
@@ -89,13 +89,13 @@ pub fn get_by_id_from_all_types(
     context: &RequestContext,
     id: &juniper::ID,
 ) -> ApiResult<Option<Node>> {
-    let conn = context.db_conn();
+    let conn = context.db_conn()?;
     let uuid_id = util::gql_id_to_uuid(id);
 
     // Do one query per node type to fine the node with this ID
     // This isn't the most efficient solution but ¯\_(ツ)_/¯
     for f in ALL_NODES_GET_BY_ID {
-        if let Some(node) = f(conn, uuid_id)? {
+        if let Some(node) = f(&conn, uuid_id)? {
             return Ok(Some(node));
         }
     }

--- a/api/src/server/gql/mutation.rs
+++ b/api/src/server/gql/mutation.rs
@@ -25,7 +25,7 @@ pub struct Mutation;
 impl MutationFields for Mutation {
     fn field_initialize_user(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, InitializeUserPayload, Walked>,
         input: InitializeUserInput,
     ) -> ApiResult<InitializeUserPayload> {
@@ -39,7 +39,7 @@ impl MutationFields for Mutation {
 
     fn field_create_hardware_spec(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, CreateHardwareSpecPayload, Walked>,
         input: CreateHardwareSpecInput,
     ) -> ApiResult<CreateHardwareSpecPayload> {
@@ -57,7 +57,7 @@ impl MutationFields for Mutation {
 
     fn field_update_hardware_spec(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UpdateHardwareSpecPayload, Walked>,
         input: UpdateHardwareSpecInput,
     ) -> ApiResult<UpdateHardwareSpecPayload> {
@@ -76,7 +76,7 @@ impl MutationFields for Mutation {
 
     fn field_create_program_spec(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, CreateProgramSpecPayload, Walked>,
         input: CreateProgramSpecInput,
     ) -> ApiResult<CreateProgramSpecPayload> {
@@ -95,7 +95,7 @@ impl MutationFields for Mutation {
 
     fn field_update_program_spec(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UpdateProgramSpecPayload, Walked>,
         input: UpdateProgramSpecInput,
     ) -> ApiResult<UpdateProgramSpecPayload> {
@@ -114,7 +114,7 @@ impl MutationFields for Mutation {
 
     fn field_create_user_program(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, CreateUserProgramPayload, Walked>,
         input: CreateUserProgramInput,
     ) -> ApiResult<CreateUserProgramPayload> {
@@ -132,7 +132,7 @@ impl MutationFields for Mutation {
 
     fn field_update_user_program(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UpdateUserProgramPayload, Walked>,
         input: UpdateUserProgramInput,
     ) -> ApiResult<UpdateUserProgramPayload> {
@@ -149,7 +149,7 @@ impl MutationFields for Mutation {
 
     fn field_copy_user_program(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, CopyUserProgramPayload, Walked>,
         input: CopyUserProgramInput,
     ) -> ApiResult<CopyUserProgramPayload> {
@@ -164,7 +164,7 @@ impl MutationFields for Mutation {
 
     fn field_delete_user_program(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, DeleteUserProgramPayload, Walked>,
         input: DeleteUserProgramInput,
     ) -> ApiResult<DeleteUserProgramPayload> {
@@ -179,7 +179,7 @@ impl MutationFields for Mutation {
 
     fn field_execute_user_program(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, ExecuteUserProgramPayload, Walked>,
         input: ExecuteUserProgramInput,
     ) -> ApiResult<ExecuteUserProgramPayload> {

--- a/api/src/server/gql/program.rs
+++ b/api/src/server/gql/program.rs
@@ -42,7 +42,7 @@ impl ProgramError {
 impl ProgramErrorFields for ProgramError {
     fn field_message(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &String {
         &self.message
     }
@@ -63,7 +63,7 @@ impl From<Machine> for MachineState {
 impl MachineStateFields for MachineState {
     fn field_cpu_cycles(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         // CPU cycles are capped at 1 million so easily in i32 range
         self.machine.cycle_count().try_into().unwrap()
@@ -79,7 +79,7 @@ pub struct ProgramCompileError {
 impl ProgramCompileErrorFields for ProgramCompileError {
     fn field_errors(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramError, Walked>,
     ) -> &Vec<ProgramError> {
         &self.errors
@@ -95,7 +95,7 @@ pub struct ProgramRuntimeError {
 impl ProgramRuntimeErrorFields for ProgramRuntimeError {
     fn field_error(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, ProgramError, Walked>,
     ) -> &ProgramError {
         &self.error
@@ -111,7 +111,7 @@ pub struct ProgramRejectedOutput {
 impl ProgramRejectedOutputFields for ProgramRejectedOutput {
     fn field_machine(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, MachineState, Walked>,
     ) -> &MachineState {
         &self.machine_state
@@ -128,7 +128,7 @@ pub struct ProgramAcceptedOutput {
 impl ProgramAcceptedOutputFields for ProgramAcceptedOutput {
     fn field_machine(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, MachineState, Walked>,
     ) -> &MachineState {
         &self.machine_state
@@ -136,7 +136,7 @@ impl ProgramAcceptedOutputFields for ProgramAcceptedOutput {
 
     fn field_record(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UserProgramRecordNode, Walked>,
     ) -> &UserProgramRecordNode {
         &self.user_program_record

--- a/api/src/server/gql/user.rs
+++ b/api/src/server/gql/user.rs
@@ -36,14 +36,14 @@ impl NodeType for UserNode {
 impl UserNodeFields for UserNode {
     fn field_id(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> ID {
         util::uuid_to_gql_id(self.user.id)
     }
 
     fn field_username(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &String {
         &self.user.username
     }
@@ -54,7 +54,7 @@ pub type UserEdge = GenericEdge<UserNode>;
 impl UserEdgeFields for UserEdge {
     fn field_node(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UserNode, Walked>,
     ) -> &UserNode {
         self.node()
@@ -62,7 +62,7 @@ impl UserEdgeFields for UserEdge {
 
     fn field_cursor(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &Cursor {
         self.cursor()
     }
@@ -75,21 +75,21 @@ pub struct AuthStatus();
 impl AuthStatusFields for AuthStatus {
     fn field_authenticated(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> bool {
         executor.context().user_context.is_some()
     }
 
     fn field_user_created(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> bool {
         executor.context().user().is_ok()
     }
 
     fn field_user(
         &self,
-        executor: &juniper::Executor<'_, RequestContext>,
+        executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UserNode, Walked>,
     ) -> ApiResult<Option<UserNode>> {
         // We have all the user data we need in the request context, no need
@@ -114,7 +114,7 @@ pub struct InitializeUserPayload {
 impl InitializeUserPayloadFields for InitializeUserPayload {
     fn field_user_edge(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
         _trail: &QueryTrail<'_, UserEdge, Walked>,
     ) -> UserEdge {
         GenericEdge::from_db_row(self.user.clone(), 0)

--- a/api/src/server/gql/user_program_record.rs
+++ b/api/src/server/gql/user_program_record.rs
@@ -36,42 +36,42 @@ impl NodeType for UserProgramRecordNode {
 impl UserProgramRecordNodeFields for UserProgramRecordNode {
     fn field_id(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> ID {
         util::uuid_to_gql_id(self.user_program_record.id)
     }
 
     fn field_cpu_cycles(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.user_program_record.cpu_cycles
     }
 
     fn field_instructions(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.user_program_record.instructions
     }
 
     fn field_registers_used(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.user_program_record.registers_used
     }
 
     fn field_stacks_used(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> i32 {
         self.user_program_record.stacks_used
     }
 
     fn field_created(
         &self,
-        _executor: &juniper::Executor<'_, RequestContext>,
+        _executor: &juniper::Executor<'_, '_, RequestContext>,
     ) -> &DateTime<Utc> {
         &self.user_program_record.created
     }

--- a/api/src/views/hardware_spec.rs
+++ b/api/src/views/hardware_spec.rs
@@ -43,7 +43,7 @@ impl<'a> View for CreateHardwareSpecView<'a> {
         let result: Result<models::HardwareSpec, _> = new_hardware_spec
             .insert()
             .returning(hardware_specs::table::all_columns())
-            .get_result(self.context.db_conn());
+            .get_result(&self.context.db_conn()?);
 
         DbErrorConverter {
             // HardwareSpec already exists with this name or slug
@@ -93,7 +93,7 @@ impl<'a> View for UpdateHardwareSpecView<'a> {
             diesel::update(hardware_specs::table.find(self.id))
                 .set(modified_hardware_spec)
                 .returning(hardware_specs::table::all_columns())
-                .get_result(self.context.db_conn())
+                .get_result(&self.context.db_conn()?)
                 .optional();
 
         DbErrorConverter {

--- a/api/src/views/program_spec.rs
+++ b/api/src/views/program_spec.rs
@@ -45,7 +45,7 @@ impl<'a> View for CreateProgramSpecView<'a> {
         let result: Result<models::ProgramSpec, _> = new_program_spec
             .insert()
             .returning(program_specs::table::all_columns())
-            .get_result(self.context.db_conn());
+            .get_result(&self.context.db_conn()?);
 
         DbErrorConverter {
             // Given hardware spec ID was invalid
@@ -97,7 +97,7 @@ impl<'a> View for UpdateProgramSpecView<'a> {
             diesel::update(program_specs::table.find(modified_program_spec.id))
                 .set(modified_program_spec)
                 .returning(program_specs::table::all_columns())
-                .get_result(self.context.db_conn())
+                .get_result(&self.context.db_conn()?)
                 .optional();
 
         DbErrorConverter {

--- a/api/src/views/user.rs
+++ b/api/src/views/user.rs
@@ -28,7 +28,7 @@ impl<'a> View for InitializeUserView<'a> {
             Some(UserContext {
                 user_provider_id, ..
             }) => {
-                let conn = self.context.db_conn();
+                let conn = self.context.db_conn()?;
                 let new_user = models::NewUser {
                     username: &self.username,
                 };
@@ -46,7 +46,7 @@ impl<'a> View for InitializeUserView<'a> {
                             new_user
                                 .insert()
                                 .returning(users::all_columns)
-                                .get_result(conn);
+                                .get_result(&conn);
 
                         // Check if the username already exists
                         let created_user = DbErrorConverter {
@@ -70,7 +70,7 @@ impl<'a> View for InitializeUserView<'a> {
                             user_providers::columns::user_id
                                 .eq(Some(created_user.id)),
                         )
-                        .execute(conn)?;
+                        .execute(&conn)?;
 
                         if updated_rows == 0 {
                             Err(ClientError::NotFound { source: None }.into())

--- a/api/tests/test_execute_user_program.rs
+++ b/api/tests/test_execute_user_program.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use crate::utils::{factories::*, QueryRunner};
 use diesel_factories::Factory;
 use gdlk_api::models;
 use juniper::InputValue;
@@ -43,50 +43,52 @@ static QUERY: &str = r#"
 "#;
 
 /// Test that the correct values are recorded for each stat type.
-#[test]
-fn test_execute_user_program_stats() {
-    let mut context_builder = ContextBuilder::new();
-    let user = context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
-    let conn = runner.db_conn();
+#[actix_rt::test]
+async fn test_execute_user_program_stats() {
+    let mut runner = QueryRunner::new();
+    let user = runner.log_in(&[]);
 
-    let hw_spec = HardwareSpecFactory::default()
-        .name("HW 1")
-        .num_registers(2)
-        .num_stacks(1)
-        .insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hw_spec)
-        .input(vec![1])
-        .expected_output(vec![1])
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("solution.gdlk")
-        .source_code(
-            "
-            READ RX0
-            JMP END
+    let user_program = runner.run_with_conn(|conn| {
+        let hw_spec = HardwareSpecFactory::default()
+            .name("HW 1")
+            .num_registers(2)
+            .num_stacks(1)
+            .insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hw_spec)
+            .input(vec![1])
+            .expected_output(vec![1])
+            .insert(&conn);
+        UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("solution.gdlk")
+            .source_code(
+                "
+                READ RX0
+                JMP END
 
-            ; these instructions count even though they never get executed
-            ; the stack/reg references count too
-            PUSH RX0 S0
-            POP S0 RX1
-            END: ; doesn't count as an instruction
-            WRITE RX0
-            ",
-        )
-        .insert(conn);
+                ; these instructions count even though they never get executed
+                ; the stack/reg references count too
+                PUSH RX0 S0
+                POP S0 RX1
+                END: ; doesn't count as an instruction
+                WRITE RX0
+                ",
+            )
+            .insert(&conn)
+    });
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar(user_program.id.to_string()),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar(user_program.id.to_string()),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {
@@ -109,46 +111,54 @@ fn test_execute_user_program_stats() {
 /// Test that PB values get updated properly on subsequent executions. We want
 /// to make sure that ONLY stats that are actually better get updated. Stats
 /// that equal or are worse than the PB shouldn't be written to the PB table.
-#[test]
-fn test_execute_user_program_pb_update() {
-    let mut context_builder = ContextBuilder::new();
-    let user = context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
-    let conn = runner.db_conn();
+#[actix_rt::test]
+async fn test_execute_user_program_pb_update() {
+    let mut runner = QueryRunner::new();
+    let user = runner.log_in(&[]);
 
-    let hw_spec = HardwareSpecFactory::default()
-        .name("HW 1")
-        .num_stacks(1)
-        .insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hw_spec)
-        .input(vec![1])
-        .expected_output(vec![1])
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("solution.gdlk")
-        .source_code("READ RX0\nWRITE RX0")
-        .insert(conn);
+    let (program_spec, user_program, better_user_program): (
+        models::ProgramSpec,
+        models::UserProgram,
+        models::UserProgram,
+    ) = runner.run_with_conn(|conn| {
+        let hw_spec = HardwareSpecFactory::default()
+            .name("HW 1")
+            .num_stacks(1)
+            .insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hw_spec)
+            .input(vec![1])
+            .expected_output(vec![1])
+            .insert(&conn);
+        let user_program = UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("solution.gdlk")
+            .source_code("READ RX0\nWRITE RX0")
+            .insert(&conn);
 
-    // this solution is better in one stat (registers) but worse in another
-    // (cpu cycles, instructions)
-    let better_user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("better.gdlk")
-        .source_code("READ RZR\nADD RZR 1\nWRITE 1")
-        .insert(conn);
+        // this solution is better in one stat (registers) but worse in
+        // another (cpu cycles, instructions)
+        let better_user_program = UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("better.gdlk")
+            .source_code("READ RZR\nADD RZR 1\nWRITE 1")
+            .insert(&conn);
+
+        (program_spec, user_program, better_user_program)
+    });
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar(user_program.id.to_string()),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar(user_program.id.to_string()),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {
@@ -168,17 +178,22 @@ fn test_execute_user_program_pb_update() {
     );
 
     // Check initial PBs
-    assert_eq!(
-        models::UserProgramRecord::load_pbs_x(conn, user.id, program_spec.id)
+    runner.run_with_conn(|conn| {
+        assert_eq!(
+            models::UserProgramRecord::load_pbs_x(
+                &conn,
+                user.id,
+                program_spec.id
+            )
             .unwrap(),
-        Some(models::UserProgramRecordStats {
-            cpu_cycles: 2,
-            instructions: 2,
-            registers_used: 1,
-            stacks_used: 0,
-        })
-    );
-
+            Some(models::UserProgramRecordStats {
+                cpu_cycles: 2,
+                instructions: 2,
+                registers_used: 1,
+                stacks_used: 0,
+            })
+        );
+    });
     // Test that only PBs that are better get updated
     assert_eq!(
         runner.query(
@@ -186,7 +201,7 @@ fn test_execute_user_program_pb_update() {
             hashmap! {
                 "id" => InputValue::scalar(better_user_program.id.to_string()),
             }
-        ),
+        ).await,
         (
             json!({
                 "executeUserProgram": {
@@ -207,45 +222,53 @@ fn test_execute_user_program_pb_update() {
     );
 
     // registers_used PB should've improved, but the rest are the same
-    assert_eq!(
-        models::UserProgramRecord::load_pbs_x(conn, user.id, program_spec.id)
+    runner.run_with_conn(|conn| {
+        assert_eq!(
+            models::UserProgramRecord::load_pbs_x(
+                &conn,
+                user.id,
+                program_spec.id
+            )
             .unwrap(),
-        Some(models::UserProgramRecordStats {
-            cpu_cycles: 2,
-            instructions: 2,
-            registers_used: 0,
-            stacks_used: 0,
-        })
-    );
+            Some(models::UserProgramRecordStats {
+                cpu_cycles: 2,
+                instructions: 2,
+                registers_used: 0,
+                stacks_used: 0,
+            })
+        );
+    });
 }
 
 /// Test that we get the correct output format when the program fails to compile
-#[test]
-fn test_execute_user_program_compile_error() {
-    let mut context_builder = ContextBuilder::new();
-    let user = context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
-    let conn = runner.db_conn();
+#[actix_rt::test]
+async fn test_execute_user_program_compile_error() {
+    let mut runner = QueryRunner::new();
+    let user = runner.log_in(&[]);
 
-    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hw_spec)
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("solution.gdlk")
-        .source_code("READ RX2\nWRITE RX2")
-        .insert(conn);
+    let user_program = runner.run_with_conn(|conn| {
+        let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hw_spec)
+            .insert(&conn);
+        UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("solution.gdlk")
+            .source_code("READ RX2\nWRITE RX2")
+            .insert(&conn)
+    });
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar(user_program.id.to_string()),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar(user_program.id.to_string()),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {
@@ -265,34 +288,36 @@ fn test_execute_user_program_compile_error() {
 
 /// Test that we get the correct output format when the program has a runtime
 /// error
-#[test]
-fn test_execute_user_program_runtime_error() {
-    let mut context_builder = ContextBuilder::new();
-    let user = context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
-    let conn = runner.db_conn();
+#[actix_rt::test]
+async fn test_execute_user_program_runtime_error() {
+    let mut runner = QueryRunner::new();
+    let user = runner.log_in(&[]);
 
-    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hw_spec)
-        .input(vec![1])
-        .expected_output(vec![1])
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("solution.gdlk")
-        .source_code("READ RX0\nREAD RX0")
-        .insert(conn);
+    let user_program = runner.run_with_conn(|conn| {
+        let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hw_spec)
+            .input(vec![1])
+            .expected_output(vec![1])
+            .insert(&conn);
+        UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("solution.gdlk")
+            .source_code("READ RX0\nREAD RX0")
+            .insert(&conn)
+    });
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar(user_program.id.to_string()),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar(user_program.id.to_string()),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {
@@ -312,34 +337,36 @@ fn test_execute_user_program_runtime_error() {
 /// Test that we get the correct output format when the program terminates
 /// but has the incorrect output (doesn't match `expected_output` from the
 /// program spec)
-#[test]
-fn test_execute_user_program_incorrect_output() {
-    let mut context_builder = ContextBuilder::new();
-    let user = context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
-    let conn = runner.db_conn();
+#[actix_rt::test]
+async fn test_execute_user_program_incorrect_output() {
+    let mut runner = QueryRunner::new();
+    let user = runner.log_in(&[]);
 
-    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hw_spec)
-        .input(vec![1])
-        .expected_output(vec![1])
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("solution.gdlk")
-        .source_code("READ RX0\nWRITE 2")
-        .insert(conn);
+    let user_program = runner.run_with_conn(|conn| {
+        let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hw_spec)
+            .input(vec![1])
+            .expected_output(vec![1])
+            .insert(&conn);
+        UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("solution.gdlk")
+            .source_code("READ RX0\nWRITE 2")
+            .insert(&conn)
+    });
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar(user_program.id.to_string()),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar(user_program.id.to_string()),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {
@@ -357,19 +384,20 @@ fn test_execute_user_program_incorrect_output() {
 }
 
 /// Executing an unknown user_program ID gives a null in the response
-#[test]
-fn test_execute_user_program_unknown_id() {
-    let mut context_builder = ContextBuilder::new();
-    context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
+#[actix_rt::test]
+async fn test_execute_user_program_unknown_id() {
+    let mut runner = QueryRunner::new();
+    runner.log_in(&[]);
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar("bogus"),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar("bogus"),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {
@@ -383,34 +411,36 @@ fn test_execute_user_program_unknown_id() {
 
 /// Executing someone else's program should behave like the program doesn't
 /// exist
-#[test]
-fn test_execute_user_program_wrong_owner() {
-    let mut context_builder = ContextBuilder::new();
-    context_builder.log_in(&[]);
-    let runner = QueryRunner::new(context_builder);
-    let conn = runner.db_conn();
+#[actix_rt::test]
+async fn test_execute_user_program_wrong_owner() {
+    let mut runner = QueryRunner::new();
+    runner.log_in(&[]);
 
-    let other_user = UserFactory::default().username("other").insert(conn);
+    let user_program = runner.run_with_conn(|conn| {
+        let other_user = UserFactory::default().username("other").insert(&conn);
 
-    let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hw_spec)
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&other_user)
-        .program_spec(&program_spec)
-        .file_name("solution.gdlk")
-        .source_code("READ RX0\nWRITE RX0")
-        .insert(conn);
+        let hw_spec = HardwareSpecFactory::default().name("HW 1").insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hw_spec)
+            .insert(&conn);
+        UserProgramFactory::default()
+            .user(&other_user)
+            .program_spec(&program_spec)
+            .file_name("solution.gdlk")
+            .source_code("READ RX0\nWRITE RX0")
+            .insert(&conn)
+    });
 
     assert_eq!(
-        runner.query(
-            QUERY,
-            hashmap! {
-                "id" => InputValue::scalar(user_program.id.to_string()),
-            }
-        ),
+        runner
+            .query(
+                QUERY,
+                hashmap! {
+                    "id" => InputValue::scalar(user_program.id.to_string()),
+                }
+            )
+            .await,
         (
             json!({
                 "executeUserProgram": {

--- a/api/tests/test_query_node.rs
+++ b/api/tests/test_query_node.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use crate::utils::{factories::*, ContextBuilder, QueryRunner};
+use crate::utils::{factories::*, QueryRunner};
 use diesel_factories::Factory;
 use juniper::InputValue;
 use maplit::hashmap;
@@ -8,23 +8,25 @@ use serde_json::json;
 
 mod utils;
 
-#[test]
-fn test_field_node() {
-    let context_builder = ContextBuilder::new();
-    let conn = context_builder.db_conn();
+#[actix_rt::test]
+async fn test_field_node() {
+    let runner = QueryRunner::new();
 
-    let user = UserFactory::default().username("user1").insert(conn);
-    let hardware_spec =
-        HardwareSpecFactory::default().name("HW 1").insert(conn);
-    let program_spec = ProgramSpecFactory::default()
-        .name("prog1")
-        .hardware_spec(&hardware_spec)
-        .insert(conn);
-    let user_program = UserProgramFactory::default()
-        .user(&user)
-        .program_spec(&program_spec)
-        .file_name("new.gdlk")
-        .insert(conn);
+    let node_ids = runner.run_with_conn(|conn| {
+        let user = UserFactory::default().username("user1").insert(&conn);
+        let hardware_spec =
+            HardwareSpecFactory::default().name("HW 1").insert(&conn);
+        let program_spec = ProgramSpecFactory::default()
+            .name("prog1")
+            .hardware_spec(&hardware_spec)
+            .insert(&conn);
+        let user_program = UserProgramFactory::default()
+            .user(&user)
+            .program_spec(&program_spec)
+            .file_name("new.gdlk")
+            .insert(&conn);
+        [user.id, hardware_spec.id, program_spec.id, user_program.id]
+    });
 
     let query = r#"
     query NodeQuery($nodeId: ID!) {
@@ -35,15 +37,16 @@ fn test_field_node() {
     "#;
 
     // Check a known UUID for each model type
-    let runner = QueryRunner::new(context_builder);
-    for id in &[user.id, hardware_spec.id, program_spec.id, user_program.id] {
+    for id in &node_ids {
         assert_eq!(
-            runner.query(
-                query,
-                hashmap! {
-                    "nodeId" => InputValue::scalar(id.to_string()),
-                }
-            ),
+            runner
+                .query(
+                    query,
+                    hashmap! {
+                        "nodeId" => InputValue::scalar(id.to_string()),
+                    }
+                )
+                .await,
             (
                 json!({
                     "node": {
@@ -58,12 +61,14 @@ fn test_field_node() {
     // Check an invalid UUID, and a valid UUID that isn't in the DB
     for id in &["invalid-uuid", "1bb9a3a1-0149-4264-a0a7-ff17ac7b8a61"] {
         assert_eq!(
-            runner.query(
-                query,
-                hashmap! {
-                    "nodeId" => InputValue::scalar(*id),
-                }
-            ),
+            runner
+                .query(
+                    query,
+                    hashmap! {
+                        "nodeId" => InputValue::scalar(*id),
+                    }
+                )
+                .await,
             (
                 json!({
                     "node": serde_json::Value::Null,

--- a/api/tests/test_user_program_record.rs
+++ b/api/tests/test_user_program_record.rs
@@ -1,30 +1,30 @@
 #![deny(clippy::all)]
 
-use crate::utils::{factories::*, ContextBuilder};
+use crate::utils::factories::*;
 use diesel_factories::Factory;
-use gdlk_api::models;
+use gdlk_api::{models, util};
 use uuid::Uuid;
 
 mod utils;
 
 /// Test the `load_pbs_x` function, loads all stat PBs for a user+program_spec
-#[test]
-fn test_load_pbs_x() {
-    let mut context_builder = ContextBuilder::new();
-    let user = context_builder.log_in(&[]);
-    let conn = context_builder.db_conn();
+#[actix_rt::test]
+async fn test_load_pbs_x() {
+    let conn = util::init_test_db_conn_pool().unwrap().get().unwrap();
 
-    let hw_spec = HardwareSpecFactory::default().name("HW1").insert(conn);
+    let user = UserFactory::default().username("user1").insert(&conn);
+    let hw_spec = HardwareSpecFactory::default().name("HW1").insert(&conn);
     let prog_spec = ProgramSpecFactory::default()
         .hardware_spec(&hw_spec)
         .name("Prog1")
-        .insert(conn);
+        .insert(&conn);
     // Create some extra rows to make sure we don't pull in extra rows
-    let other_user = UserFactory::default().username("other user").insert(conn);
+    let other_user =
+        UserFactory::default().username("other user").insert(&conn);
     let other_prog_spec = ProgramSpecFactory::default()
         .hardware_spec(&hw_spec)
         .name("Prog2")
-        .insert(conn);
+        .insert(&conn);
 
     // user+prog_spec
     UserProgramRecordFactory::default()
@@ -36,7 +36,7 @@ fn test_load_pbs_x() {
         // These 2 are NOT PBs
         .registers_used(10)
         .stacks_used(10)
-        .insert(conn);
+        .insert(&conn);
     UserProgramRecordFactory::default()
         .user(&user)
         .program_spec(&prog_spec)
@@ -46,20 +46,20 @@ fn test_load_pbs_x() {
         // These 2 are PBs
         .registers_used(3)
         .stacks_used(4)
-        .insert(conn);
+        .insert(&conn);
 
     // These 2 are decoys to make sure the query is filtering properly
     UserProgramRecordFactory::default()
         .user(&other_user)
         .program_spec(&prog_spec)
-        .insert(conn);
+        .insert(&conn);
     UserProgramRecordFactory::default()
         .user(&user)
         .program_spec(&other_prog_spec)
-        .insert(conn);
+        .insert(&conn);
 
     assert_eq!(
-        models::UserProgramRecord::load_pbs_x(conn, user.id, prog_spec.id)
+        models::UserProgramRecord::load_pbs_x(&conn, user.id, prog_spec.id)
             .unwrap(),
         Some(models::UserProgramRecordStats {
             cpu_cycles: 1,
@@ -71,7 +71,7 @@ fn test_load_pbs_x() {
 
     // Make an empty query, make sure it gives no results
     assert_eq!(
-        models::UserProgramRecord::load_pbs_x(conn, user.id, Uuid::nil())
+        models::UserProgramRecord::load_pbs_x(&conn, user.id, Uuid::nil())
             .unwrap(),
         None
     )

--- a/db/dev/Dockerfile
+++ b/db/dev/Dockerfile
@@ -26,8 +26,11 @@ RUN POSTGRES_DB=${db_name} \
 # make sure the sensitive data never touches this image, otherwise it will get
 # captured in one of the layers.
 FROM postgres:12-alpine
+
+ARG db_name=gdlk
 ENV POSTGRES_DB=${db_name}
 ENV POSTGRES_USER=root
 ENV POSTGRES_PASSWORD=root
+
 # The pg image will automatically load the file from this dir on first startup
 COPY --from=builder /app/sanitized.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Upgraded to juniper `master`, which has async support. I didn't actually update any of the resolvers to be async yet, since there's no point. Diesel is all sync and that's the only IO we do from the API.

This required rewriting a ton of test code. I had to update the GQL context type to hold a full connection pool instead of just a single connection. For tests, everything has to run on a single connection because we do it all in a transaction. So I had to rejigger a bunch of code to make that work. Basically the same change like 1000 times.