### PR TITLE
Switch from google container reg to github container reg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Push API image
         if: github.ref == 'refs/heads/master'
         run: |-
-          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker login -u '${{ github.actor }}' -p '${{ secrets.GHCR_SECRET }}' ghcr.io
           docker-compose push api
 
   test-frontend:
@@ -120,7 +120,7 @@ jobs:
       - name: Push Frontend image
         if: github.ref == 'refs/heads/master'
         run: |-
-          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker login -u '${{ github.actor }}' -p '${{ secrets.GHCR_SECRET }}' ghcr.io
           docker-compose push frontend
 
   build-db-prd:
@@ -135,7 +135,7 @@ jobs:
       - name: Push image
         if: github.ref == 'refs/heads/master'
         run: |-
-          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker login -u '${{ github.actor }}' -p '${{ secrets.GHCR_SECRET }}' ghcr.io
           docker-compose push db-prd
 
   build-api-prd:
@@ -154,7 +154,7 @@ jobs:
       - name: Push image
         if: github.ref == 'refs/heads/master'
         run: |-
-          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker login -u '${{ github.actor }}' -p '${{ secrets.GHCR_SECRET }}' ghcr.io
           docker-compose push api-prd
 
   build-nginx-prd:
@@ -174,5 +174,5 @@ jobs:
       - name: Push image
         if: github.ref == 'refs/heads/master'
         run: |-
-          docker login -u _json_key -p '${{ secrets.GCR_SECRET_KEY }}' gcr.io
+          docker login -u '${{ github.actor }}' -p '${{ secrets.GHCR_SECRET }}' ghcr.io
           docker-compose push nginx-prd

--- a/crates/api/prd.Dockerfile
+++ b/crates/api/prd.Dockerfile
@@ -1,5 +1,5 @@
 # Build the server distributable
-FROM gcr.io/gdlkit/gdlk-api:latest as rust-builder
+FROM ghcr.io/lucaspickering/gdlk-api:latest as rust-builder
 # We need core/, api/, and a bunch of other files, so just copy everything in
 COPY . /app
 RUN cargo build -p gdlk_api --release

--- a/deploy/docker-stack.yml
+++ b/deploy/docker-stack.yml
@@ -27,7 +27,7 @@ secrets:
 
 services:
   nginx:
-    image: gcr.io/gdlkit/gdlk-nginx-prd:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-nginx-prd:${DOCKER_TAG}
     # Need mode:host so the client IP gets logged properly
     ports:
       - target: 80
@@ -48,7 +48,7 @@ services:
         delay: 10s
 
   db:
-    image: gcr.io/gdlkit/gdlk-db-prd:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-db-prd:${DOCKER_TAG}
     environment:
       POSTGRES_DB: gdlk
       POSTGRES_USER: root
@@ -87,7 +87,7 @@ services:
         delay: 10m
 
   api:
-    image: gcr.io/gdlkit/gdlk-api-prd:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-api-prd:${DOCKER_TAG}
     depends_on:
       - db
     environment:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,15 +5,15 @@ services:
   # See README for instructions.
   db:
     build: ./db/dev
-    image: gcr.io/gdlkit/gdlk-db:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-db:${DOCKER_TAG}
 
   api:
     build:
       context: .
       dockerfile: ./crates/api/Dockerfile
       cache_from:
-        - gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
-    image: gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
+        - ghcr.io/lucaspickering/gdlk-api:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-api:${DOCKER_TAG}
     volumes:
       - ./:/app:rw
     depends_on:
@@ -27,25 +27,25 @@ services:
       context: .
       dockerfile: ./frontend/Dockerfile
       cache_from:
-        - gcr.io/gdlkit/gdlk-frontend:${DOCKER_TAG}
-    image: gcr.io/gdlkit/gdlk-frontend:${DOCKER_TAG}
+        - ghcr.io/lucaspickering/gdlk-frontend:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-frontend:${DOCKER_TAG}
     volumes:
       - ./:/app:rw
 
   db-prd:
     build: ./db/prd
-    image: gcr.io/gdlkit/gdlk-db-prd:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-db-prd:${DOCKER_TAG}
 
   api-prd:
     build:
       context: .
       dockerfile: ./crates/api/prd.Dockerfile
       cache_from:
-        - gcr.io/gdlkit/gdlk-api-prd:${DOCKER_TAG}
-    image: gcr.io/gdlkit/gdlk-api-prd:${DOCKER_TAG}
+        - ghcr.io/lucaspickering/gdlk-api-prd:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-api-prd:${DOCKER_TAG}
 
   nginx-prd:
     build:
       context: .
       dockerfile: ./nginx/Dockerfile
-    image: gcr.io/gdlkit/gdlk-nginx-prd:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-nginx-prd:${DOCKER_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ volumes:
 services:
   db:
     # DB: gdlk; creds: root/root
-    image: gcr.io/gdlkit/gdlk-db:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-db:${DOCKER_TAG}
     command: postgres -c log_statement=all
     ports:
       - "5432:5432"
 
   api:
-    image: gcr.io/gdlkit/gdlk-api:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-api:${DOCKER_TAG}
     command: cargo make -p docker start
     init: true # Workaround for cargo-watch bug that prevents graceful restart
     tty: true # Colorize output
@@ -33,7 +33,7 @@ services:
       - "8000:8000"
 
   frontend:
-    image: gcr.io/gdlkit/gdlk-frontend:${DOCKER_TAG}
+    image: ghcr.io/lucaspickering/gdlk-frontend:${DOCKER_TAG}
     command: ./docker/run_frontend.sh
     init: true # Needed to kill the relay compiler background process
     tty: true # Colorize output

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # Build the frontend static assets
-FROM gcr.io/gdlkit/gdlk-frontend:latest as frontend-builder
+FROM ghcr.io/lucaspickering/gdlk-frontend:latest as frontend-builder
 ENV NODE_ENV production
 
 WORKDIR /app/


### PR DESCRIPTION
I'm planning on shutting down all the google cloud stuff cause it's gonna start charging me soon. github has a free non-shitty container registry now so I'm moving the images over to that. I just copied this stuff from another repo I have where this is already set up, and I generated a new access token for this repo and add it to the repo secrets, so the CI _should_ all work. I haven't actually tested this tho so we won't know if the build+push works until it hits master. 🙏 